### PR TITLE
(arch) Replace node-int64 with long

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   ],
   "dependencies": {
     "commander": "^2.12.2",
-    "node-int64": "^0.4.0"
+    "long": "^3.2.0"
   },
   "devDependencies": {
     "@types/jest": "^22.0.0",
+    "@types/long": "^3.0.32",
     "@types/node": "^8.5.2",
-    "@types/node-int64": "^0.4.29",
     "jest": "^22.0.4",
     "rimraf": "^2.6.2",
     "typescript": "^2.6.2"

--- a/src/Token.ts
+++ b/src/Token.ts
@@ -1,8 +1,8 @@
 import { Lexeme } from "./Lexeme";
-import Int64 = require("node-int64");
+import Long = require("long");
 
 export type Invalid = undefined;
-export type Literal = string | number | Int64 | boolean | Invalid;
+export type Literal = string | number | Long | boolean | Invalid;
 
 export interface Token {
     kind: Lexeme;

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -1,4 +1,4 @@
-import Int64 = require("node-int64");
+import Long = require("long");
 
 import { Lexeme } from "../Lexeme";
 import { Token, Literal } from "../Token";
@@ -327,7 +327,7 @@ function number() {
         // numeric literals ending with "&" are forced to LongIntegers
         advance();
         asString = source.slice(start, current);
-        addToken(Lexeme.LongInteger, new Int64(asString));
+        addToken(Lexeme.LongInteger, Long.fromString(asString));
         return;
     } else {
         // otherwise, it's a regular integer

--- a/test/Lexer.test.js
+++ b/test/Lexer.test.js
@@ -1,4 +1,4 @@
-const Int64 = require("node-int64");
+const Long = require("long");
 
 const Lexer = require("../lib/lexer");
 const { Lexeme } = require("../lib/Lexeme");
@@ -169,7 +169,7 @@ describe("lexer", () => {
         it("respects '&' suffix", () => {
             let li = Lexer.scan("123&")[0];
             expect(li.kind).toBe(Lexeme.LongInteger);
-            expect(li.literal).toEqual(new Int64("123"));
+            expect(li.literal).toEqual(Long.fromInt(123));
         });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,11 +14,9 @@
   version "22.0.0"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.0.0.tgz#23009941178aad7979a9591e026f7a96054d7bc0"
 
-"@types/node-int64@^0.4.29":
-  version "0.4.29"
-  resolved "https://registry.yarnpkg.com/@types/node-int64/-/node-int64-0.4.29.tgz#8c7c16a7c1195ae4f8beaa903b0018ac66291d16"
-  dependencies:
-    "@types/node" "*"
+"@types/long@^3.0.32":
+  version "3.0.32"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-3.0.32.tgz#f4e5af31e9e9b196d8e5fca8a5e2e20aa3d60b69"
 
 "@types/node@*", "@types/node@^8.5.2":
   version "8.5.2"
@@ -1649,6 +1647,10 @@ lodash.sortby@^4.7.0:
 lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+long@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
 
 longest@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The `long` package includes 64-bit integer arithmetic, but `node-int64` didn't.  Now that we're going to start executing ASTs, we'll need that!