### PR TITLE
(lex) Alias '?' operator to 'print' statement

### DIFF
--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -77,6 +77,7 @@ function scanToken(): void {
         case "^": addToken(Lexeme.Caret); break;
         case "\\": addToken(Lexeme.Backslash); break;
         case ":": addToken(Lexeme.Colon); break;
+        case "?": addToken(Lexeme.Print); break;
         case "<":
             switch (peek()) {
                 case "=":

--- a/test/Lexer.test.js
+++ b/test/Lexer.test.js
@@ -24,6 +24,15 @@ describe("lexer", () => {
         ]);
     });
 
+    it("aliases '?' to 'print'", () => {
+        let tokens = Lexer.scan("?2");
+        expect(tokens.map(t => t.kind)).toEqual([
+            Lexeme.Print,
+            Lexeme.Integer,
+            Lexeme.Eof
+        ]);
+    });
+
     describe("comments", () => {
         it("ignores everything after `'`", () => {
             let tokens = Lexer.scan("= ' (");


### PR DESCRIPTION
BrightScript allows the `?` operator to act as a shortcut to the full `print` statement, so our interpreter should do the same.  That means lexing it first.