### PR TITLE
Add global scope assignments

### DIFF
--- a/src/Error.ts
+++ b/src/Error.ts
@@ -1,12 +1,17 @@
 let foundError = false;
 
 export function make(message: string, line: number, file?: string) {
-    let location = file ? `${file}: ${line}` : `line ${line}`;
-    if (process.env.NODE_ENV !== "test") {
-        console.error(`[${location}] ${message}`);
-    }
-
     foundError = true;
+    return runtime(message, line, file);
+}
+
+export function runtime(message: string, line: number, file?: string) {
+    let location = file ? `${file}: ${line}` : `line ${line}`;
+    let error = new Error(`[${location}] ${message}`);
+    if (process.env.NODE_ENV !== "test") {
+        console.error(error);
+    }
+    return error;
 }
 
 export function found() {

--- a/src/grammar/BrightscriptGrammar.ebnf
+++ b/src/grammar/BrightscriptGrammar.ebnf
@@ -17,7 +17,29 @@
 
 (* Start from the top, a brightscript script will have a number of "statements" before reaching the end of the file *)
 program
-    : statementList? EOF
+    : declarationList? EOF
+    ;
+
+declarationList
+    : multiDeclaration+
+    ;
+
+(* brightscript supports multiple declarations on a line if they're separated bu ':' literals*)
+multiDeclaration
+    : singleAssignment (":" singleDeclaration)* NEWLINE
+    ;
+
+singleAssignment
+    : assignment
+    | statementList
+    ;
+
+assignment
+    : IDENTIFIER assignmentOperator expression
+    ;
+
+assignmentOperator
+    : ("=" | "*=" | "/=" | "\=" | "+=" | "-=" | "<<=" | ">>=")
     ;
 
 statementList
@@ -50,20 +72,7 @@ expressionStatement
     ;
 
 expression
-    : assignmentExpression
-    ;
-
-assignmentExpression
     : conditionalExpression
-    | assignment
-    ;
-
-assignment
-    : IDENTIFIER assignmentOperator expression
-    ;
-
-assignmentOperator
-    : ("=" | "*=" | "/=" | "\=" | "+=" | "-=" | "<<=" | ">>=")
     ;
 
 (*

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import { Executioner, isLong } from "./visitor/Executioner";
 import { stringify } from "./Stringify";
 import * as BrsError from "./Error";
 
+const executioner = new Executioner();
+
 export function execute(filename: string) {
     fs.readFile(filename, "utf-8", (err, contents) => {
         run(contents);
@@ -47,7 +49,6 @@ function run(contents: string) {
         return;
     }
 
-    const executioner = new Executioner();
     if (!statements) { return; }
 
     return executioner.exec(statements);

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -2,12 +2,21 @@ import * as Expr from "./Expression";
 import { Token } from "../Token";
 
 export interface Visitor<T> {
+    visitAssignment(statement: Assignment): T;
     visitExpression(statement: Expression): T;
     visitPrint(statement: Print): T;
 }
 
 export interface Statement {
     accept <R> (visitor: Visitor<R>): R;
+}
+
+export class Assignment implements Statement {
+    constructor(readonly name: Token, readonly value: Expr.Expression) {}
+
+    accept<R>(visitor: Visitor<R>): R {
+        return visitor.visitAssignment(this);
+    }
 }
 
 export class Block implements Statement {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -40,6 +40,7 @@ function declaration(): Statement | undefined {
 
         return statement();
     } catch (error) {
+        synchronize();
         return;
     }
 }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -31,6 +31,9 @@ export function parse(toParse: ReadonlyArray<Token>) {
 
 function declaration(): Statement | undefined {
     try {
+        // BrightScript is like python, in that variables can be declared without a `var`,
+        // `let`, (...) keyword. As such, we must check the token *after* an identifier to figure
+        // out what to do with it.
         if (check(Lexeme.Identifier) && checkNext(Lexeme.Equal)) {
             return assignment();
         }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -50,6 +50,7 @@ function assignment(): Statement {
     // TODO: support +=, -=, >>=, etc.
 
     let value = expression();
+    consume("Expected newline or ':' after assignment", Lexeme.Newline, Lexeme.Colon, Lexeme.Eof);
     return new Stmt.Assignment(name, value);
 }
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -31,7 +31,7 @@ export function parse(toParse: ReadonlyArray<Token>) {
 
 function declaration(): Statement | undefined {
     try {
-        if (match(Lexeme.Identifier)) {
+        if (check(Lexeme.Identifier) && checkNext(Lexeme.Equal)) {
             return assignment();
         }
 
@@ -42,7 +42,7 @@ function declaration(): Statement | undefined {
 }
 
 function assignment(): Statement {
-    let name = previous();
+    let name = advance();
     consume("Expected '=' after idenfifier", Lexeme.Equal);
     // TODO: support +=, -=, >>=, etc.
 
@@ -212,8 +212,17 @@ function check(lexeme: Lexeme) {
     return peek().kind === lexeme;
 }
 
+function checkNext(lexeme: Lexeme) {
+    return peekNext().kind === lexeme;
+}
+
 function isAtEnd() {
     return peek().kind === Lexeme.Eof;
+}
+
+function peekNext() {
+    if (isAtEnd()) { return peek(); }
+    return tokens[current + 1];
 }
 
 function peek() {

--- a/src/visitor/Environment.ts
+++ b/src/visitor/Environment.ts
@@ -1,0 +1,19 @@
+import { Token, Literal as TokenLiteral } from "../Token";
+import { Lexeme } from "../Lexeme";
+import * as BrsError from "../Error";
+
+export default class Environment {
+    private values = new Map<string, TokenLiteral>();
+
+    public define(name: string, value: TokenLiteral): void {
+        this.values.set(name, value);
+    }
+
+    public get(name: Token): TokenLiteral {
+        if (this.values.has(name.text!)) {
+            return this.values.get(name.text!);
+        }
+
+        throw BrsError.runtime(`Undefined variable ${name.text}`, name.line);
+    }
+}

--- a/src/visitor/Executioner.ts
+++ b/src/visitor/Executioner.ts
@@ -24,6 +24,10 @@ export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<Tok
         return statements.map((statement) => this.execute(statement));
     }
 
+    visitAssignment(statement: Stmt.Assignment): TokenLiteral {
+        return undefined;
+    }
+
     visitExpression(statement: Stmt.Expression): TokenLiteral {
         return this.evaluate(statement.expression);
     }

--- a/src/visitor/Executioner.ts
+++ b/src/visitor/Executioner.ts
@@ -7,6 +7,8 @@ import { Lexeme } from "../Lexeme";
 import { stringify } from "../Stringify";
 import * as BrsError from "../Error";
 
+import Environment from "./Environment";
+
 export function isLong(arg: TokenLiteral): arg is Long {
     return Long.isLong(arg);
 }
@@ -20,11 +22,13 @@ function isString(arg: TokenLiteral): arg is string {
 }
 
 export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<TokenLiteral> {
+    private environment = new Environment();
+
     exec(statements: Stmt.Statement[]) {
         return statements.map((statement) => this.execute(statement));
     }
 
-    visitAssignment(statement: Stmt.Assignment): TokenLiteral {
+    visitAssign(statement: Expr.Assign): TokenLiteral {
         return undefined;
     }
 
@@ -38,8 +42,10 @@ export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<Tok
         return;
     }
 
-    visitAssign(expression: Expr.Assign) {
-        return undefined;
+    visitAssignment(statement: Stmt.Assignment): undefined {
+        let value = this.evaluate(statement.value);
+        this.environment.define(statement.name.text!, value);
+        return;
     }
 
     visitBinary(expression: Expr.Binary) {
@@ -389,7 +395,7 @@ export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<Tok
     }
 
     visitVariable(expression: Expr.Variable) {
-        return undefined;
+        return this.environment.get(expression.name);
     }
 
     evaluate(expression: Expr.Expression): TokenLiteral {

--- a/test/executioner/Variables.test.js
+++ b/test/executioner/Variables.test.js
@@ -1,0 +1,52 @@
+const BrsError = require("../../lib/Error");
+const Expr = require("../../lib/parser/Expression");
+const Stmt = require("../../lib/parser/Statement");
+const { identifier, token } = require("../parser/ParserTests");
+const { Lexeme } = require("../../lib/Lexeme");
+const { Executioner } = require("../../lib/visitor/Executioner");
+
+let executioner;
+
+describe("executioner", () => {
+    beforeEach(() => {
+        BrsError.reset();
+        executioner = new Executioner();
+    });
+
+    it("returns 'invalid' for assignments", () => {
+        let ast = new Stmt.Assignment(
+            identifier("foo"),
+            new Expr.Literal(5)
+        );
+
+        let result = executioner.exec([ast]);
+        expect(result).toEqual([undefined]);
+    });
+
+    it("stores assigned values in global scope", () => {
+        let ast = new Stmt.Assignment(
+            identifier("bar"),
+            new Expr.Literal(6)
+        );
+        executioner.exec([ast]);
+        expect(
+            executioner.environment.get(
+                identifier("bar")
+            )
+        ).toBe(6);
+    });
+
+    it("retrieves variables from global scope", () => {
+        let assign = new Stmt.Assignment(
+            identifier("baz"),
+            new Expr.Literal(7)
+        );
+        let retrieve = new Stmt.Expression(
+            new Expr.Variable(
+                identifier("baz")
+            )
+        );
+        let results = executioner.exec([ assign, retrieve ]);
+        expect(results).toEqual([undefined, 7]);
+    });
+});

--- a/test/parser/ParserTests.js
+++ b/test/parser/ParserTests.js
@@ -16,5 +16,18 @@ exports.token = function(kind, literal) {
     };
 }
 
+/**
+ * Creates an Identifier token with the given `text`.
+ * @param {string} text
+ * @returns {object} a token with the provided `text`.
+ */
+exports.identifier = function(text) {
+    return {
+        kind: Lexeme.Identifier,
+        text: text,
+        line: 1
+    };
+}
+
 /** An end-of-file token. */
 exports.EOF = exports.token(Lexeme.Eof);

--- a/test/parser/statement/Declaration.test.js
+++ b/test/parser/statement/Declaration.test.js
@@ -1,0 +1,53 @@
+const Parser = require("../../../lib/parser");
+const { Lexeme } = require("../../../lib/Lexeme");
+const BrsError = require("../../../lib/Error");
+
+const { token, identifier, EOF } = require("../ParserTests");
+
+
+describe("parser", () => {
+    afterEach(() => BrsError.reset());
+
+    describe("variable declarations", () => {
+        it("parses literal value assignments", () => {
+            let parsed = Parser.parse([
+                identifier("foo"),
+                token(Lexeme.Equal),
+                token(Lexeme.Integer, 5),
+                EOF
+            ]);
+
+            expect(parsed).toBeDefined();
+            expect(parsed).not.toBeNull();
+            expect(parsed).toMatchSnapshot();
+        });
+
+        it("parses evaluated value assignments", () => {
+            let parsed = Parser.parse([
+                identifier("bar"),
+                token(Lexeme.Equal),
+                token(Lexeme.Integer, 5),
+                token(Lexeme.Caret),
+                token(Lexeme.Integer, 3),
+                EOF
+            ]);
+
+            expect(parsed).toBeDefined();
+            expect(parsed).not.toBeNull();
+            expect(parsed).toMatchSnapshot();
+        });
+
+        it("parses variable aliasing", () => {
+            let parsed = Parser.parse([
+                identifier("baz"),
+                token(Lexeme.Equal),
+                identifier("foo"),
+                EOF
+            ]);
+
+            expect(parsed).toBeDefined();
+            expect(parsed).not.toBeNull();
+            expect(parsed).toMatchSnapshot();
+        });
+    });
+});

--- a/test/parser/statement/Declaration.test.js
+++ b/test/parser/statement/Declaration.test.js
@@ -9,6 +9,19 @@ describe("parser", () => {
     afterEach(() => BrsError.reset());
 
     describe("variable declarations", () => {
+        it("allows newlines after assignments", () => {
+            let parsed = Parser.parse([
+                identifier("hasNewlines"),
+                token(Lexeme.Equal),
+                token(Lexeme.True),
+                token(Lexeme.Newline),
+                EOF
+            ]);
+
+            expect(parsed).toBeDefined();
+            expect(parsed).not.toBeNull();
+        });
+
         it("parses literal value assignments", () => {
             let parsed = Parser.parse([
                 identifier("foo"),

--- a/test/parser/statement/__snapshots__/Declaration.test.js.snap
+++ b/test/parser/statement/__snapshots__/Declaration.test.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parser variable declarations parses evaluated value assignments 1`] = `
+Array [
+  Assignment {
+    "name": Object {
+      "kind": 21,
+      "line": 1,
+      "text": "bar",
+    },
+    "value": Binary {
+      "left": Literal {
+        "value": 5,
+      },
+      "right": Literal {
+        "value": 3,
+      },
+      "token": Object {
+        "kind": 6,
+        "line": 1,
+        "literal": undefined,
+      },
+    },
+  },
+]
+`;
+
+exports[`parser variable declarations parses literal value assignments 1`] = `
+Array [
+  Assignment {
+    "name": Object {
+      "kind": 21,
+      "line": 1,
+      "text": "foo",
+    },
+    "value": Literal {
+      "value": 5,
+    },
+  },
+]
+`;
+
+exports[`parser variable declarations parses variable aliasing 1`] = `
+Array [
+  Assignment {
+    "name": Object {
+      "kind": 21,
+      "line": 1,
+      "text": "baz",
+    },
+    "value": Variable {
+      "name": Object {
+        "kind": 21,
+        "line": 1,
+        "text": "foo",
+      },
+    },
+  },
+]
+`;


### PR DESCRIPTION
This PR allows users of BRS to create globally-scoped variables, assign values to them, and reference their stored values in other expressions and statements.  It makes `brs` significantly more useful, because it can remember things!

Global variables currently take a copy-value approach, e.g.:

```brightscript
a = 10
b = a
a = 1000

print a     ' 1000
print b     ' 10
print a = b ' false
```

This will likely need to change once we implement associative arrays in BRS, but IIRC "copy-value" is correct for primitive values.