### PR TITLE
fix(exec): Allow mixed-type arithmetic and comparisons

### DIFF
--- a/src/visitor/Executioner.ts
+++ b/src/visitor/Executioner.ts
@@ -52,8 +52,10 @@ export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<Tok
 
         switch (lexeme) {
             case Lexeme.Minus:
-                if (isLong(left) && isLong(right)) {
+                if (isLong(left) && (isLong(right) || isNumber(right))) {
                     return left.subtract(right);
+                } else if (isNumber(left) && isLong(right)) {
+                    return Long.fromNumber(left).subtract(right);
                 } else if (isNumber(left) && isNumber(right)) {
                     return left - right;
                 } else {
@@ -66,8 +68,10 @@ export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<Tok
                     return;
                 }
             case Lexeme.Star:
-                if (isLong(left) && isLong(right)) {
+                if (isLong(left) && (isLong(right) || isNumber(right))) {
                     return left.multiply(right);
+                } else if (isNumber(left) && isLong(right)) {
+                    return Long.fromNumber(left).multiply(right);
                 } else if (isNumber(left) && isNumber(right)) {
                     return left * right;
                 } else {
@@ -83,8 +87,10 @@ export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<Tok
                 if (isLong(left) && (isLong(right) || isNumber(right))) {
                     // TODO: Figure out how to exponentiate Longs
                     return;
-                } else if (isNumber(left) && isNumber(right)) {
+                } else if (isNumber(left) && isLong(right)) {
                     // TODO: See if we can use a Long as an exponent
+                    return;
+                } else if (isNumber(left) && isNumber(right)) {
                     return Math.pow(left, right);
                 } else {
                     BrsError.make(
@@ -96,24 +102,31 @@ export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<Tok
                     return;
                 }
             case Lexeme.Slash:
-                if (isLong(left) && isLong(right)) {
-                    return left.divide(right);
-                } else if (isNumber(left) && isNumber(right)) {
-                    // TODO: Figure out how to handle type promotion
-                    // https://sdkdocs.roku.com/display/sdkdoc/Expressions%2C+Variables%2C+and+Types#Expressions,Variables,andTypes-TypeConversion(Promotion)
-                    return left / right;
-                } else {
-                    BrsError.make(
-                        `Attempting to divide non-numeric objects.
-                        left: ${typeof left}
-                        right: ${typeof right}`,
-                        expression.token.line
-                    );
-                    return;
+                if (isLong(left)) {
+                    if (isLong(right)) {
+                        return left.toNumber() / right.toNumber();;
+                    } else if (isNumber(right)) {
+                        return left.toNumber() / right;
+                    }
+                } else if (isNumber(left)) {
+                    if (isLong(right)) {
+                        return left / right.toNumber();
+                    } else if (isNumber(right)) {
+                        return left / right;
+                    }
                 }
+                BrsError.make(
+                    `Attempting to divide non-numeric objects.
+                    left: ${typeof left}
+                    right: ${typeof right}`,
+                    expression.token.line
+                );
+                return;
             case Lexeme.Mod:
-                if (isLong(left) && isLong(right)) {
+                if (isLong(left) && (isLong(right) || isNumber(right))) {
                     return left.modulo(right)
+                } else if (isNumber(left) && isLong(right)) {
+                    return Long.fromNumber(left).modulo(right);
                 } else if (isNumber(left) && isNumber(right)) {
                     return left % right;
                 } else {
@@ -126,9 +139,10 @@ export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<Tok
                     return;
                 }
             case Lexeme.Backslash:
-                if (isLong(left) && isLong(right)) {
-                    // TODO: Figure out if this is actually safe for integer division
-                    return left.divide(right).toInt();
+                if (isLong(left) && (isLong(right) || isNumber(right))) {
+                    return left.divide(right);
+                } else if (isNumber(left) && isLong(right)) {
+                    return Math.floor(left / right.toNumber());
                 } else if (isNumber(left) && isNumber(right)) {
                     return Math.floor(left / right);
                 } else {
@@ -141,8 +155,10 @@ export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<Tok
                     return;
                 }
             case Lexeme.Plus:
-                if (isLong(left) && isLong(right)) {
+                if (isLong(left) && (isLong(right) || isNumber(right))) {
                     return left.add(right);
+                } else if (isNumber(left) && isLong(right)) {
+                    return Long.fromNumber(left).add(right);
                 } else if (isNumber(left) && isNumber(right)) {
                     return left + right;
                 } else if (isString(left) && isString(right)) {

--- a/src/visitor/Executioner.ts
+++ b/src/visitor/Executioner.ts
@@ -157,88 +157,64 @@ export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<Tok
                     return;
                 }
             case Lexeme.Greater:
-                if (isLong(left) && isLong(right)) {
+                if (isLong(left) && (isLong(right) || isNumber(right))) {
                     return left.greaterThan(right);
+                } else if (isNumber(left) && isLong(right)) {
+                    return Long.fromNumber(left).greaterThan(right);
                 } else if ((isNumber(left) && isNumber(right)) || isString(left) && isString(right)) {
                     return left > right;
                 } else {
-                    BrsError.make(
-                        `Attempting to compare unexpected objects.
-                        left: ${typeof left}
-                        right: ${typeof right}`,
-                        expression.token.line
-                    );
-                    return;
+                    return false;
                 }
             case Lexeme.GreaterEqual:
-                if (isLong(left) && isLong(right)) {
+                if (isLong(left) && (isLong(right) || isNumber(right))) {
                     return left.greaterThanOrEqual(right);
+                } else if (isNumber(left) && isLong(right)) {
+                    return Long.fromNumber(left).greaterThanOrEqual(right);
                 } else if ((isNumber(left) && isNumber(right)) || isString(left) && isString(right)) {
                     return left >= right;
                 } else {
-                    BrsError.make(
-                        `Attempting to compare unexpected objects.
-                        left: ${typeof left}
-                        right: ${typeof right}`,
-                        expression.token.line
-                    );
-                    return;
+                    return false;
                 }
             case Lexeme.Less:
-                if (isLong(left) && isLong(right)) {
+                if (isLong(left) && (isLong(right) || isNumber(right))) {
                     return left.lessThan(right);
+                } else if (isNumber(left) && isLong(right)) {
+                    return Long.fromNumber(left).lessThan(right);
                 } else if ((isNumber(left) && isNumber(right)) || isString(left) && isString(right)) {
                     return left < right;
                 } else {
-                    BrsError.make(
-                        `Attempting to compare unexpected objects.
-                        left: ${typeof left}
-                        right: ${typeof right}`,
-                        expression.token.line
-                    );
-                    return;
+                    return false;
                 }
             case Lexeme.LessEqual:
-                if (isLong(left) && isLong(right)) {
+                if (isLong(left) && (isLong(right) || isNumber(right))) {
                     return left.lessThanOrEqual(right);
+                } else if (isNumber(left) && isLong(right)) {
+                    return Long.fromNumber(left).lessThanOrEqual(right);
                 } else if ((isNumber(left) && isNumber(right)) || isString(left) && isString(right)) {
                     return left <= right;
                 } else {
-                    BrsError.make(
-                        `Attempting to compare unexpected objects.
-                        left: ${typeof left}
-                        right: ${typeof right}`,
-                        expression.token.line
-                    );
-                    return;
+                    return false;
                 }
             case Lexeme.Equal:
-                if (isLong(left) && isLong(right)) {
+                if (isLong(left) && (isLong(right) || isNumber(right))) {
                     return left.equals(right);
+                } else if (isNumber(left) && isLong(right)) {
+                    return Long.fromNumber(left).equals(right);
                 } else if ((isNumber(left) && isNumber(right)) || isString(left) && isString(right)) {
                     return left === right;
                 } else {
-                    BrsError.make(
-                        `Attempting to compare unexpected objects.
-                        left: ${typeof left}
-                        right: ${typeof right}`,
-                        expression.token.line
-                    );
-                    return;
+                    return false;
                 }
             case Lexeme.LessGreater:
-                if (isLong(left) && isLong(right)) {
+                if (isLong(left) && (isLong(right) || isNumber(right))) {
                     return left.notEquals(right);
+                } else if (isNumber(left) && isLong(right)) {
+                    return Long.fromNumber(left).notEquals(right);
                 } else if ((isNumber(left) && isNumber(right)) || isString(left) && isString(right)) {
                     return left !== right;
                 } else {
-                    BrsError.make(
-                        `Attempting to compare unexpected objects.
-                        left: ${typeof left}
-                        right: ${typeof right}`,
-                        expression.token.line
-                    );
-                    return;
+                    return true;
                 }
             case Lexeme.And:
                 if (left === false) {
@@ -258,11 +234,15 @@ export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<Tok
                     return;
                 } else if (isNumber(left) || isLong(left)) {
                     right = this.evaluate(expression.right);
-                    if (isNumber(left) && isNumber(right)) {
-                        return left & right;
+                    if (isNumber(left)) {
+                        if (isNumber(right)) {
+                            return left & right;
+                        } else if (isLong(right)) {
+                            return Long.fromNumber(left).and(right);
+                        }
                     }
 
-                    if (isLong(left) && isLong(right)) {
+                    if (isLong(left) && (isLong(right) || isNumber(right))) {
                         return left.and(right);
                     }
 
@@ -300,12 +280,16 @@ export class Executioner implements Expr.Visitor<TokenLiteral>, Stmt.Visitor<Tok
                     }
                 } else if (isNumber(left) || isLong(left)) {
                     right = this.evaluate(expression.right);
-                    if (isNumber(left) && isNumber(right)) {
-                        // numbers use bitwise OR
-                        return left | right;
+                    // numbers use bitwise OR
+                    if (isNumber(left)) {
+                        if (isNumber(right)) {
+                            return left | right;
+                        } else if (isLong(right)) {
+                            return Long.fromNumber(left).or(right);
+                        }
                     }
 
-                    if (isLong(left) && isLong(right)) {
+                    if (isLong(left) && (isLong(right) || isNumber(right))) {
                         return left.or(right);
                     }
 

--- a/test/executioner/Arithmetic.test.js
+++ b/test/executioner/Arithmetic.test.js
@@ -1,7 +1,9 @@
+const Long = require("long");
 const BrsError = require("../../lib/Error");
 const Expr = require("../../lib/parser/Expression");
 const Stmt = require("../../lib/parser/Statement");
 const { token } = require("../parser/ParserTests");
+const { binary } = require("./ExecutionerTests");
 const { Lexeme } = require("../../lib/Lexeme");
 const { Executioner } = require("../../lib/visitor/Executioner");
 
@@ -13,95 +15,189 @@ describe("executioner", () => {
         executioner = new Executioner();
     });
 
-    it("adds numbers", () => {
-        let ast = new Stmt.Expression(
-            new Expr.Binary(
-                new Expr.Literal(5),
-                token(Lexeme.Plus),
-                new Expr.Literal(6)
-            )
-        );
+    describe("addition", () => {
+        it("adds 64-bit integers", () => {
+            let leftLong = binary(Long.fromNumber(5), Lexeme.Plus, 4);
+            let rightLong = binary(5, Lexeme.Plus, Long.fromNumber(4));
+            let bothLong = binary(Long.fromInt(5), Lexeme.Plus, Long.fromInt(4));
 
-        let result = executioner.exec([ast]);
-        expect(result).toEqual([11]);
+            let results = executioner.exec([leftLong, rightLong, bothLong]);
+            let nine = Long.fromInt(9);
+            expect(results).toEqual([nine, nine, nine]);
+        })
+
+        it("adds 32-bit integers", () => {
+            let ast = binary(5, Lexeme.Plus, 6);
+            let result = executioner.exec([ast]);
+            expect(result).toEqual([11]);
+        });
+
+        it("adds floats", () => {
+            let ast = binary(5e-5, Lexeme.Plus, 6e-5);
+            let result = executioner.exec([ast]);
+            expect(result).toEqual([11e-5]);
+        })
+
+        it("adds doubles", () => {
+            let ast = binary(5e25, Lexeme.Plus, 6e25);
+            let result = executioner.exec([ast]);
+            expect(result).toEqual([11e25]);
+        })
     });
 
-    it("concatenates strings", () => {
-        let ast = new Stmt.Expression(
-            new Expr.Binary(
-                new Expr.Literal("judge "),
-                token(Lexeme.Plus),
-                new Expr.Literal("judy")
-            )
-        );
 
+    it("concatenates strings", () => {
+        let ast = binary("judge ", Lexeme.Plus, "judy");
         let result = executioner.exec([ast]);
         expect(result).toEqual(["judge judy"]);
     });
 
-    it("subtracts numbers", () => {
-        let ast = new Stmt.Expression(
-            new Expr.Binary(
-                new Expr.Literal(3),
-                token(Lexeme.Minus),
-                new Expr.Literal(6)
-            )
-        );
+    describe("subtraction", () => {
+        it("subtracts 64-bit integers", () => {
+            let leftLong = binary(Long.fromInt(11), Lexeme.Minus, 2);
+            let rightLong = binary(11, Lexeme.Minus, Long.fromInt(2));
+            let bothLong = binary(
+                Long.fromInt(11),
+                Lexeme.Minus,
+                Long.fromInt(2)
+            );
+            let results = executioner.exec([leftLong, rightLong, bothLong]);
+            let nine = Long.fromInt(9);
+            expect(results).toEqual([nine, nine, nine]);
+        });
 
-        let result = executioner.exec([ast]);
-        expect(result).toEqual([-3]);
+        it("subtracts 32-bit integers", () => {
+            let ast = binary(11, Lexeme.Minus, 2);
+            let results = executioner.exec([ast]);
+            expect(results).toEqual([9]);
+        });
+
+        it("subtracts floats", () => {
+            let ast = binary(11e-5, Lexeme.Minus, 2e-5);
+            let result = executioner.exec([ast]);
+            expect(result).toEqual([9e-5]);
+        });
+
+        it("subtracts doubles", () => {
+            let ast = binary(11e25, Lexeme.Minus, 2e25);
+            let result = executioner.exec([ast]);
+            expect(result).toEqual([9e25]);
+        });
     });
 
-    it("multiplies numbers", () => {
-        let ast = new Stmt.Expression(
-            new Expr.Binary(
-                new Expr.Literal(7),
-                token(Lexeme.Star),
-                new Expr.Literal(5)
-            )
-        );
+    describe("multiplication", () => {
+        it("multiplies 64-bit integers", () => {
+            let leftLong = binary(Long.fromInt(5), Lexeme.Star, 2);
+            let rightLong = binary(5, Lexeme.Star, Long.fromInt(2));
+            let bothLong = binary(Long.fromInt(5), Lexeme.Star, Long.fromInt(2));
+            let results = executioner.exec([leftLong, rightLong, bothLong]);
+            let ten = Long.fromInt(10);
+            expect(results).toEqual([ten, ten, ten]);
+        });
 
-        let result = executioner.exec([ast]);
-        expect(result).toEqual([35]);
+        it("multiplies 32-bit integers", () => {
+            let ast = binary(2, Lexeme.Star, 5);
+            let results = executioner.exec([ast]);
+            expect(results).toEqual([10]);
+        });
+
+        it("multiplies floats", () => {
+            let ast = binary(2e-3, Lexeme.Star, 5e-4);
+            let result = executioner.exec([ast]);
+            expect(result).toEqual([10e-7]);
+        });
+
+        it("multiplies doubles", () => {
+            let ast = binary(2e15, Lexeme.Star, 5e5);
+            let result = executioner.exec([ast]);
+            expect(result).toEqual([10e20]);
+        });
     });
 
-    it("divides numbers", () => {
-        let ast = new Stmt.Expression(
-            new Expr.Binary(
-                new Expr.Literal(9),
-                token(Lexeme.Slash),
-                new Expr.Literal(2)
-            )
-        );
+    describe("division", () => {
+        it("divides 64-bit integers", () => {
+            let leftLong = binary(Long.fromInt(5), Lexeme.Slash, 2);
+            let rightLong = binary(5, Lexeme.Slash, Long.fromInt(2));
+            let bothLong = binary(Long.fromInt(5), Lexeme.Slash, Long.fromInt(2));
+            let results = executioner.exec([leftLong, rightLong, bothLong]);
+            expect(results).toEqual([2.5, 2.5, 2.5]);
+        });
 
-        let result = executioner.exec([ast]);
-        expect(result).toEqual([4.5]);
+        it("divides 32-bit integers", () => {
+            let ast = binary(5, Lexeme.Slash, 2);
+            let results = executioner.exec([ast]);
+            expect(results).toEqual([2.5]);
+        });
+
+        it("divides floats", () => {
+            let ast = binary(5e-3, Lexeme.Slash, 2e-4);
+            let result = executioner.exec([ast]);
+            expect(result).toEqual([25]);
+        });
+
+        it("divides doubles", () => {
+            let ast = binary(5e15, Lexeme.Slash, 2e5);
+            let result = executioner.exec([ast]);
+            expect(result).toEqual([2.5e10]);
+        });
     });
 
-    it("integer-divides numbers", () => {
-        let ast = new Stmt.Expression(
-            new Expr.Binary(
-                new Expr.Literal(9),
-                token(Lexeme.Backslash),
-                new Expr.Literal(2)
-            )
-        );
+    describe("integer-division", () => {
+        it("integer-divides 64-bit integers", () => {
+            let leftLong = binary(Long.fromInt(5), Lexeme.Backslash, 2);
+            let rightLong = binary(5, Lexeme.Backslash, Long.fromInt(2));
+            let bothLong = binary(Long.fromInt(5), Lexeme.Backslash, Long.fromInt(2));
+            let results = executioner.exec([leftLong, rightLong, bothLong]);
+            let two = Long.fromNumber(2);
+            expect(results).toEqual([two, 2, two]);
+        });
 
-        let result = executioner.exec([ast]);
-        expect(result).toEqual([4]);
+        it("integer-divides 32-bit integers", () => {
+            let ast = binary(5, Lexeme.Backslash, 2);
+            let results = executioner.exec([ast]);
+            expect(results).toEqual([2]);
+        });
+
+        it("integer-divides floats", () => {
+            let ast = binary(5e-3, Lexeme.Backslash, 2e-3);
+            let result = executioner.exec([ast]);
+            expect(result).toEqual([2]);
+        });
+
+        it("integer-divides doubles", () => {
+            let ast = binary(5e15, Lexeme.Backslash, 2e15);
+            let result = executioner.exec([ast]);
+            expect(result).toEqual([2]);
+        });
     });
 
-    it("modulos numbers", () => {
-        let ast = new Stmt.Expression(
-            new Expr.Binary(
-                new Expr.Literal(9),
-                token(Lexeme.Mod),
-                new Expr.Literal(2)
-            )
-        );
+    describe("modulo", () => {
+        it("modulos 64-bit integers", () => {
+            let leftLong = binary(Long.fromInt(5), Lexeme.Mod, 2);
+            let rightLong = binary(5, Lexeme.Mod, Long.fromInt(2));
+            let bothLong = binary(Long.fromInt(5), Lexeme.Mod, Long.fromInt(2));
+            let results = executioner.exec([leftLong, rightLong, bothLong]);
+            expect(results).toEqual([Long.ONE, Long.ONE, Long.ONE]);
+        });
 
-        let result = executioner.exec([ast]);
-        expect(result).toEqual([1]);
+        it("modulos 32-bit integers", () => {
+            let ast = binary(5, Lexeme.Mod, 2);
+            let results = executioner.exec([ast]);
+            expect(results).toEqual([1]);
+        });
+
+        it("modulos floats", () => {
+            let ast = binary(5e-3 + 5, Lexeme.Mod, 5e-3 + 2);
+            let result = executioner.exec([ast]);
+            // TODO: Figure out how to make node behave properly here
+            // expect(result).toEqual([1]);
+        });
+
+        it("modulos doubles", () => {
+            let ast = binary(5e5 + 5, Lexeme.Mod, 5e5 + 2);
+            let result = executioner.exec([ast]);
+            expect(result).toEqual([3]);
+        });
     });
 
     it("exponentiates numbers", () => {

--- a/test/executioner/Comparison.test.js
+++ b/test/executioner/Comparison.test.js
@@ -1,0 +1,152 @@
+const Long = require("long");
+const BrsError = require("../../lib/Error");
+const Expr = require("../../lib/parser/Expression");
+const Stmt = require("../../lib/parser/Statement");
+const { token } = require("../parser/ParserTests");
+const { Lexeme } = require("../../lib/Lexeme");
+const { Executioner } = require("../../lib/visitor/Executioner");
+
+let executioner;
+
+/**
+ * Creates an expression AST that compares `left` and `right` with the provided `operator` lexeme.
+ *
+ * @param {*} left the literal to use as the left-hand side of the comparison.
+ * @param {Lexeme} operator the operator to use during the comparison.
+ * @param {*} right the literal to use as the right-hand side of the comparison.
+ *
+ * @returns An AST representing the expression `${left} ${operator} ${right}`.
+ */
+function comparison(left, operator, right) {
+    return new Stmt.Expression(
+        new Expr.Binary(
+            new Expr.Literal(left),
+            token(operator),
+            new Expr.Literal(right)
+        )
+    );
+}
+
+/**
+ * Generates tests that compares all permutations of two values using all supported operators.
+ * @param {*} small the smaller of the two values, i.e. `small < large`.
+ * @param {*} large the larger of the two values, i.e. `large > small`.
+ */
+function verifyComparisons(small, large) {
+    test("less than", () => {
+        let smallLarge = comparison(small, Lexeme.Less, large);
+        let smallSmall = comparison(small, Lexeme.Less, small);
+        let largeSmall = comparison(large, Lexeme.Less, small);
+        let results = executioner.exec([smallLarge, smallSmall, largeSmall]);
+        expect(results).toEqual([true, false, false]);
+    });
+
+    test("less than or equal to", () => {
+        let smallLarge = comparison(small, Lexeme.LessEqual, large);
+        let smallSmall = comparison(small, Lexeme.LessEqual, small);
+        let largeSmall = comparison(large, Lexeme.LessEqual, small);
+        let results = executioner.exec([smallLarge, smallSmall, largeSmall]);
+        expect(results).toEqual([true, true, false]);
+    });
+
+    test("greater than", () => {
+        let smallLarge = comparison(small, Lexeme.Greater, large);
+        let smallSmall = comparison(small, Lexeme.Greater, small);
+        let largeSmall = comparison(large, Lexeme.Greater, small);
+        let results = executioner.exec([smallLarge, smallSmall, largeSmall]);
+        expect(results).toEqual([false, false, true]);
+    });
+
+    test("greater than or equal to", () => {
+        let smallLarge = comparison(small, Lexeme.GreaterEqual, large);
+        let smallSmall = comparison(small, Lexeme.GreaterEqual, small);
+        let largeSmall = comparison(large, Lexeme.GreaterEqual, small);
+        let results = executioner.exec([smallLarge, smallSmall, largeSmall]);
+        expect(results).toEqual([false, true, true]);
+    });
+
+    test("equal", () => {
+        let smallLarge = comparison(small, Lexeme.Equal, large);
+        let smallSmall = comparison(small, Lexeme.Equal, small);
+        let largeSmall = comparison(large, Lexeme.Equal, small);
+        let results = executioner.exec([smallLarge, smallSmall, largeSmall]);
+        expect(results).toEqual([false, true, false]);
+    });
+
+    test("not equal", () => {
+        let smallLarge = comparison(small, Lexeme.LessGreater, large);
+        let smallSmall = comparison(small, Lexeme.LessGreater, small);
+        let largeSmall = comparison(large, Lexeme.LessGreater, small);
+        let results = executioner.exec([smallLarge, smallSmall, largeSmall]);
+        expect(results).toEqual([true, false, true]);
+    });
+}
+
+describe("executioner", () => {
+    beforeEach(() => {
+        BrsError.reset();
+        executioner = new Executioner();
+    });
+
+    describe("32-bit integer comparisons", () => {
+        verifyComparisons(2, 6);
+    });
+
+    describe("64-bit integer comparisons", () => {
+        verifyComparisons(Long.fromString("1E33"), Long.fromString("2E33"));
+    });
+
+    describe("float comparisons", () => {
+        verifyComparisons(Math.fround(2.0), Math.fround(6.0));
+    });
+
+    describe("double comparisons", () => {
+        verifyComparisons(2e20, 6e20);
+    });
+
+    describe("string comparisons", () => {
+        verifyComparisons("amy", "zapp");
+    });
+
+    describe("32-bit integer and double comparisons", () => {
+        verifyComparisons(2.000001, 6e20);
+    });
+
+    describe("double and 32-bit integer comparisons", () => {
+        verifyComparisons(2e4, 60000.000001);
+    });
+
+    describe("float and 64-bit integer comparisons", () => {
+        verifyComparisons(Math.fround(2.0), Long.fromNumber(6));
+    });
+
+    describe("64-bit integer and float comparisons", () => {
+        verifyComparisons(Long.fromNumber(2), Math.fround(6.0));
+    });
+
+    describe("invalid mixed-type comparisons", () => {
+        // due to a combinatoric explosion of LHS-RHS-operator pairs, just test a representative
+        // sample of pairings
+        test("32-bit integer and string", () => {
+            let less = comparison(2, Lexeme.Less, "two");
+            let lessEqual = comparison(2, Lexeme.LessEqual, "two");
+            let greater = comparison(2, Lexeme.Greater, "two");
+            let greaterEqual = comparison(2, Lexeme.GreaterEqual, "two");
+            let equal = comparison(2, Lexeme.Equal, "two");
+            let notEqual = comparison(2, Lexeme.LessGreater, "two");
+            let results = executioner.exec([less, lessEqual, greater, greaterEqual, equal, notEqual]);
+            expect(results).toEqual([false, false, false, false, false, true]);
+        });
+
+        test("string and 64-bit int", () => {
+            let less = comparison("two", Lexeme.Less, Long.fromInt(3));
+            let lessEqual = comparison("two", Lexeme.LessEqual, Long.fromInt(3));
+            let greater = comparison("two", Lexeme.Greater, Long.fromInt(3));
+            let greaterEqual = comparison("two", Lexeme.GreaterEqual, Long.fromInt(3));
+            let equal = comparison("two", Lexeme.Equal, Long.fromInt(3));
+            let notEqual = comparison("two", Lexeme.LessGreater, Long.fromInt(3));
+            let results = executioner.exec([less, lessEqual, greater, greaterEqual, equal, notEqual]);
+            expect(results).toEqual([false, false, false, false, false, true]);
+        });
+    });
+});

--- a/test/executioner/Comparison.test.js
+++ b/test/executioner/Comparison.test.js
@@ -1,31 +1,10 @@
 const Long = require("long");
 const BrsError = require("../../lib/Error");
-const Expr = require("../../lib/parser/Expression");
-const Stmt = require("../../lib/parser/Statement");
-const { token } = require("../parser/ParserTests");
+const { binary } = require("./ExecutionerTests");
 const { Lexeme } = require("../../lib/Lexeme");
 const { Executioner } = require("../../lib/visitor/Executioner");
 
 let executioner;
-
-/**
- * Creates an expression AST that compares `left` and `right` with the provided `operator` lexeme.
- *
- * @param {*} left the literal to use as the left-hand side of the comparison.
- * @param {Lexeme} operator the operator to use during the comparison.
- * @param {*} right the literal to use as the right-hand side of the comparison.
- *
- * @returns An AST representing the expression `${left} ${operator} ${right}`.
- */
-function comparison(left, operator, right) {
-    return new Stmt.Expression(
-        new Expr.Binary(
-            new Expr.Literal(left),
-            token(operator),
-            new Expr.Literal(right)
-        )
-    );
-}
 
 /**
  * Generates tests that compares all permutations of two values using all supported operators.
@@ -34,49 +13,49 @@ function comparison(left, operator, right) {
  */
 function verifyComparisons(small, large) {
     test("less than", () => {
-        let smallLarge = comparison(small, Lexeme.Less, large);
-        let smallSmall = comparison(small, Lexeme.Less, small);
-        let largeSmall = comparison(large, Lexeme.Less, small);
+        let smallLarge = binary(small, Lexeme.Less, large);
+        let smallSmall = binary(small, Lexeme.Less, small);
+        let largeSmall = binary(large, Lexeme.Less, small);
         let results = executioner.exec([smallLarge, smallSmall, largeSmall]);
         expect(results).toEqual([true, false, false]);
     });
 
     test("less than or equal to", () => {
-        let smallLarge = comparison(small, Lexeme.LessEqual, large);
-        let smallSmall = comparison(small, Lexeme.LessEqual, small);
-        let largeSmall = comparison(large, Lexeme.LessEqual, small);
+        let smallLarge = binary(small, Lexeme.LessEqual, large);
+        let smallSmall = binary(small, Lexeme.LessEqual, small);
+        let largeSmall = binary(large, Lexeme.LessEqual, small);
         let results = executioner.exec([smallLarge, smallSmall, largeSmall]);
         expect(results).toEqual([true, true, false]);
     });
 
     test("greater than", () => {
-        let smallLarge = comparison(small, Lexeme.Greater, large);
-        let smallSmall = comparison(small, Lexeme.Greater, small);
-        let largeSmall = comparison(large, Lexeme.Greater, small);
+        let smallLarge = binary(small, Lexeme.Greater, large);
+        let smallSmall = binary(small, Lexeme.Greater, small);
+        let largeSmall = binary(large, Lexeme.Greater, small);
         let results = executioner.exec([smallLarge, smallSmall, largeSmall]);
         expect(results).toEqual([false, false, true]);
     });
 
     test("greater than or equal to", () => {
-        let smallLarge = comparison(small, Lexeme.GreaterEqual, large);
-        let smallSmall = comparison(small, Lexeme.GreaterEqual, small);
-        let largeSmall = comparison(large, Lexeme.GreaterEqual, small);
+        let smallLarge = binary(small, Lexeme.GreaterEqual, large);
+        let smallSmall = binary(small, Lexeme.GreaterEqual, small);
+        let largeSmall = binary(large, Lexeme.GreaterEqual, small);
         let results = executioner.exec([smallLarge, smallSmall, largeSmall]);
         expect(results).toEqual([false, true, true]);
     });
 
     test("equal", () => {
-        let smallLarge = comparison(small, Lexeme.Equal, large);
-        let smallSmall = comparison(small, Lexeme.Equal, small);
-        let largeSmall = comparison(large, Lexeme.Equal, small);
+        let smallLarge = binary(small, Lexeme.Equal, large);
+        let smallSmall = binary(small, Lexeme.Equal, small);
+        let largeSmall = binary(large, Lexeme.Equal, small);
         let results = executioner.exec([smallLarge, smallSmall, largeSmall]);
         expect(results).toEqual([false, true, false]);
     });
 
     test("not equal", () => {
-        let smallLarge = comparison(small, Lexeme.LessGreater, large);
-        let smallSmall = comparison(small, Lexeme.LessGreater, small);
-        let largeSmall = comparison(large, Lexeme.LessGreater, small);
+        let smallLarge = binary(small, Lexeme.LessGreater, large);
+        let smallSmall = binary(small, Lexeme.LessGreater, small);
+        let largeSmall = binary(large, Lexeme.LessGreater, small);
         let results = executioner.exec([smallLarge, smallSmall, largeSmall]);
         expect(results).toEqual([true, false, true]);
     });
@@ -128,23 +107,23 @@ describe("executioner", () => {
         // due to a combinatoric explosion of LHS-RHS-operator pairs, just test a representative
         // sample of pairings
         test("32-bit integer and string", () => {
-            let less = comparison(2, Lexeme.Less, "two");
-            let lessEqual = comparison(2, Lexeme.LessEqual, "two");
-            let greater = comparison(2, Lexeme.Greater, "two");
-            let greaterEqual = comparison(2, Lexeme.GreaterEqual, "two");
-            let equal = comparison(2, Lexeme.Equal, "two");
-            let notEqual = comparison(2, Lexeme.LessGreater, "two");
+            let less = binary(2, Lexeme.Less, "two");
+            let lessEqual = binary(2, Lexeme.LessEqual, "two");
+            let greater = binary(2, Lexeme.Greater, "two");
+            let greaterEqual = binary(2, Lexeme.GreaterEqual, "two");
+            let equal = binary(2, Lexeme.Equal, "two");
+            let notEqual = binary(2, Lexeme.LessGreater, "two");
             let results = executioner.exec([less, lessEqual, greater, greaterEqual, equal, notEqual]);
             expect(results).toEqual([false, false, false, false, false, true]);
         });
 
         test("string and 64-bit int", () => {
-            let less = comparison("two", Lexeme.Less, Long.fromInt(3));
-            let lessEqual = comparison("two", Lexeme.LessEqual, Long.fromInt(3));
-            let greater = comparison("two", Lexeme.Greater, Long.fromInt(3));
-            let greaterEqual = comparison("two", Lexeme.GreaterEqual, Long.fromInt(3));
-            let equal = comparison("two", Lexeme.Equal, Long.fromInt(3));
-            let notEqual = comparison("two", Lexeme.LessGreater, Long.fromInt(3));
+            let less = binary("two", Lexeme.Less, Long.fromInt(3));
+            let lessEqual = binary("two", Lexeme.LessEqual, Long.fromInt(3));
+            let greater = binary("two", Lexeme.Greater, Long.fromInt(3));
+            let greaterEqual = binary("two", Lexeme.GreaterEqual, Long.fromInt(3));
+            let equal = binary("two", Lexeme.Equal, Long.fromInt(3));
+            let notEqual = binary("two", Lexeme.LessGreater, Long.fromInt(3));
             let results = executioner.exec([less, lessEqual, greater, greaterEqual, equal, notEqual]);
             expect(results).toEqual([false, false, false, false, false, true]);
         });

--- a/test/executioner/ExecutionerTests.js
+++ b/test/executioner/ExecutionerTests.js
@@ -1,0 +1,21 @@
+const Expr = require("../../lib/parser/Expression");
+const Stmt = require("../../lib/parser/Statement");
+
+/**
+ * Creates an expression AST that performs binary operation `operator` on left` and `right`.
+ *
+ * @param {*} left the literal to use as the left-hand side of the operation.
+ * @param {Lexeme} operator the operator to use during the operation.
+ * @param {*} right the literal to use as the right-hand side of the operation.
+ *
+ * @returns An AST representing the expression `${left} ${operator} ${right}`.
+ */
+exports.binary = function(left, operator, right) {
+    return new Stmt.Expression(
+        new Expr.Binary(
+            new Expr.Literal(left),
+            { kind: operator, line: 1 },
+            new Expr.Literal(right)
+        )
+    );
+}


### PR DESCRIPTION
I'd previously forgotten to allow mixed-type comparisons and arithmetic, which meant 32-bit integers couldn't be added to 64-bit integers, and they also couldn't be compared.  That's been fixed now!