### PR TITLE
fix(lex,parse): Allow blank lines in executed BrightScript files

### DIFF
--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -118,8 +118,13 @@ function scanToken(): void {
             // ignore whitespace; indentation isn't signficant in BrightScript
             break;
         case "\n":
-            // but newlines _are_ important
-            addToken(Lexeme.Newline);
+            // consecutive newlines aren't significant, because they're just blank lines
+            // so only add blank lines when they're not consecutive
+            let previous = lastToken();
+            if (previous && previous.kind !== Lexeme.Newline) {
+                addToken(Lexeme.Newline);
+            }
+            // but always advance the line counter
             line++;
             break;
         case "\"":
@@ -358,6 +363,14 @@ function identifier() {
     } else {
         addToken(tokenType);
     }
+}
+
+/**
+ * Retrieves the token that was most recently added.
+ * @returns the most recently added token.
+ */
+function lastToken(): Token | undefined {
+    return tokens[tokens.length - 1];
 }
 
 /**

--- a/test/Lexer.test.js
+++ b/test/Lexer.test.js
@@ -14,11 +14,11 @@ describe("lexer", () => {
         expect(tokens.map(t => t.kind)).toEqual([ Lexeme.Eof ]);
     });
 
-    it("retains newlines", () => {
-        let tokens = Lexer.scan("\n\n\n");
+    it("retains one newline from consecutive newlines", () => {
+        let tokens = Lexer.scan("\n\n'foo\n\n\nprint 2\n\n");
         expect(tokens.map(t => t.kind)).toEqual([
-            Lexeme.Newline,
-            Lexeme.Newline,
+            Lexeme.Print,
+            Lexeme.Integer,
             Lexeme.Newline,
             Lexeme.Eof
         ]);


### PR DESCRIPTION
Completely blank lines are meaningless to the parser, so there's no
sense in passing them along from the lexer into the parser.  We do need
to keep track of line numbers though, and single newline characters are
still significant, so we can't ignore newlines entirely.

fixes #22