### PR TITLE
fix(parse): Allow single-line 'if' to use 'else if'

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -125,8 +125,19 @@ function ifStatement(): Statement {
             match(Lexeme.Newline);
         }
     } else {
-        let thenStatement = statement(Lexeme.Else);
+        let thenStatement = statement(Lexeme.ElseIf, Lexeme.Else);
         thenBranch = new Stmt.Block([thenStatement]);
+
+        while(match(Lexeme.ElseIf)) {
+            let elseIfCondition = expression();
+            consume("Expected 'then' after 'else if ...condition...'", Lexeme.Then);
+            let elseIfThen = statement(Lexeme.ElseIf, Lexeme.Else);
+            elseIfBranches.push({
+                condition: elseIfCondition,
+                thenBranch: new Stmt.Block([elseIfThen])
+            });
+        }
+
         if (match(Lexeme.Else)) {
             let elseStatement = statement();
             elseBranch = new Stmt.Block([elseStatement]);

--- a/test/e2e/EndToEnd.test.js
+++ b/test/e2e/EndToEnd.test.js
@@ -67,7 +67,7 @@ describe("end to end", () => {
     test("conditionals.brs", () => {
         return execute(resourceFile("conditionals.brs")).then(() => {
             expect(allArgs(stdout)).toEqual([
-                "1", "2", "3", "4", "5"
+                "1", "2", "3", "4", "5", "6"
             ]);
         });
     });

--- a/test/e2e/resources/conditionals.brs
+++ b/test/e2e/resources/conditionals.brs
@@ -9,9 +9,12 @@ if foo < 0 then print "foo < 0"
 ' add an else
 if foo < 1 then print "foo < 1" else print 2
 
+' add an else if
+if foo < 1 then print "foo < 1" else if foo = 5 then print 3 else print "foo > 1 and not 5"
+
 ' just a simple if statement; no else
 if foo < 10 then
-    print 3
+    print 4
 end if
 
 ' this one should get skipped
@@ -23,7 +26,7 @@ end if
 if foo < 1 then
     print "foo < 1"
 else
-    print 4
+    print 5
 end if
 
 ' add an elseif
@@ -32,7 +35,7 @@ if foo < 1 then
 else if foo < 3 then
     print "foo < 3"
 else if foo = 5 then
-    print 5
+    print 6
 else if foo < 10 then
     print "foo < 10"
 else

--- a/test/parser/controlFlow/If.test.js
+++ b/test/parser/controlFlow/If.test.js
@@ -55,13 +55,7 @@ describe("parser if statements", () => {
             expect(parsed).toMatchSnapshot();
         });
 
-        it.skip("parses if-elseif-else", () => {
-            // TODO: Figure out if
-            // ```
-            //     if a < b then foo = a else if a = b then foo = invalid else foo = b`
-            // ```
-            // is legal on a Roku device.  Specifically, is `else if` allowed in the single-line
-            // form of if/then?
+        it("parses if-elseif-else", () => {
             let parsed = Parser.parse([
                 token(Lexeme.If),
                 token(Lexeme.Integer, new Int32(1)),
@@ -75,6 +69,7 @@ describe("parser if statements", () => {
                 token(Lexeme.Integer, new Int32(1)),
                 token(Lexeme.Equal),
                 token(Lexeme.Integer, new Int32(2)),
+                token(Lexeme.Then),
                 identifier("same"),
                 token(Lexeme.Equal),
                 token(Lexeme.True, BrsBoolean.True),

--- a/test/parser/controlFlow/__snapshots__/If.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/If.test.js.snap
@@ -364,3 +364,130 @@ Array [
   },
 ]
 `;
+
+exports[`parser if statements single-line if parses if-elseif-else 1`] = `
+Array [
+  If {
+    "condition": Binary {
+      "left": Literal {
+        "value": Int32 {
+          "kind": 3,
+          "value": 1,
+        },
+      },
+      "right": Literal {
+        "value": Int32 {
+          "kind": 3,
+          "value": 2,
+        },
+      },
+      "token": Object {
+        "kind": 15,
+        "line": 1,
+        "literal": undefined,
+      },
+    },
+    "elseBranch": Block {
+      "statements": Array [
+        Expression {
+          "expression": Binary {
+            "left": Variable {
+              "name": Object {
+                "kind": 21,
+                "line": 1,
+                "text": "foo",
+              },
+            },
+            "right": Literal {
+              "value": BrsBoolean {
+                "kind": 1,
+                "value": true,
+              },
+            },
+            "token": Object {
+              "kind": 19,
+              "line": 1,
+              "literal": undefined,
+            },
+          },
+        },
+      ],
+    },
+    "elseIfs": Array [
+      Object {
+        "condition": Binary {
+          "left": Literal {
+            "value": Int32 {
+              "kind": 3,
+              "value": 1,
+            },
+          },
+          "right": Literal {
+            "value": Int32 {
+              "kind": 3,
+              "value": 2,
+            },
+          },
+          "token": Object {
+            "kind": 19,
+            "line": 1,
+            "literal": undefined,
+          },
+        },
+        "thenBranch": Block {
+          "statements": Array [
+            Expression {
+              "expression": Binary {
+                "left": Variable {
+                  "name": Object {
+                    "kind": 21,
+                    "line": 1,
+                    "text": "same",
+                  },
+                },
+                "right": Literal {
+                  "value": BrsBoolean {
+                    "kind": 1,
+                    "value": true,
+                  },
+                },
+                "token": Object {
+                  "kind": 19,
+                  "line": 1,
+                  "literal": undefined,
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+    "thenBranch": Block {
+      "statements": Array [
+        Expression {
+          "expression": Binary {
+            "left": Variable {
+              "name": Object {
+                "kind": 21,
+                "line": 1,
+                "text": "foo",
+              },
+            },
+            "right": Literal {
+              "value": BrsBoolean {
+                "kind": 1,
+                "value": true,
+              },
+            },
+            "token": Object {
+              "kind": 19,
+              "line": 1,
+              "literal": undefined,
+            },
+          },
+        },
+      ],
+    },
+  },
+]
+`;


### PR DESCRIPTION
The [brs-testbed project](https://github.com/sjbarag/brs-testbed/blob/3218687043eecc11dea57080080f76b983d0d5b4/testfiles/elseif-in-single-line-if.brs) has proven that BrightScript definitely supports 'else if' in single-line if statements.  We should too!