### PR TITLE
fix(lex): Don't treat 'exitfor' as a reserved word

### DIFF
--- a/src/Lexeme.ts
+++ b/src/Lexeme.ts
@@ -58,9 +58,7 @@ export enum Lexeme {
     EndWhile,
     Eval,
     Exit,
-    // ExitFor isn't listed as a reserved word, but it seems like it'd match 'exitwhile'.
-    // TODO: Verify its reservedness on-device.
-    ExitFor,
+    ExitFor, // not technically a reserved word, but definitely a lexeme
     ExitWhile,
     False,
     For,

--- a/src/ReservedWords.ts
+++ b/src/ReservedWords.ts
@@ -20,6 +20,7 @@ export const ReservedWords: {[key: string]: L} = {
     "end while": L.EndWhile,
     eval: L.Eval,
     exit: L.Exit,
+    "exit for": L.ExitFor, // note: 'exitfor' (no space) is *not* a reserved word
     exitwhile: L.ExitWhile,
     "exit while": L.ExitWhile,
     false: L.False,

--- a/test/Lexer.test.js
+++ b/test/Lexer.test.js
@@ -230,6 +230,15 @@ describe("lexer", () => {
             expect(words.filter(w => !!w.literal).length).toBe(0);
         });
 
+        it("accepts 'exit for' but not 'exitfor'", () => {
+            let words = Lexer.scan("exit for exitfor");
+            expect(words.map(w => w.kind)).toEqual([
+                Lexeme.ExitFor,
+                Lexeme.Identifier,
+                Lexeme.Eof
+            ]);
+        });
+
         it("matches reserved words with silly capitalization", () => {
             let words = Lexer.scan("iF ELSE eNDIf FUncTioN");
             expect(words.map(w => w.kind)).toEqual([


### PR DESCRIPTION
While `exitwhile` is a reserved word and is an alias for `exit while`, the same isn't true for `exitfor` and `exit for`.  The only way to exit a `for` loop is with the two-word version "`exit for`".  Odd.

fixes #31