### PR TITLE
feat: Add for/to loops

### DIFF
--- a/src/Lexeme.ts
+++ b/src/Lexeme.ts
@@ -53,6 +53,7 @@ export enum Lexeme {
     ElseIf,
     End,
     EndFunction,
+    EndFor,
     EndIf,
     EndSub,
     EndWhile,

--- a/src/ReservedWords.ts
+++ b/src/ReservedWords.ts
@@ -10,6 +10,8 @@ export const ReservedWords: {[key: string]: L} = {
     elseif: L.ElseIf,
     "else if": L.ElseIf,
     end: L.End,
+    endfor: L.EndFor,
+    "end for": L.EndFor,
     endfunction: L.EndFunction,
     "end function": L.EndFunction,
     endif: L.EndIf,

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -30,6 +30,7 @@ export interface Visitor<T> {
     visitPrint(statement: Print): Result;
     visitIf(statement: If): Result;
     visitBlock(block: Block): Result;
+    visitFor(statement: For): Result;
     visitWhile(statement: While): Result;
 }
 
@@ -124,6 +125,19 @@ export class Return implements Statement {
 
     accept<R>(visitor: Visitor<R>): Result {
         throw new Error("Method not implemented.");
+    }
+}
+
+export class For implements Statement {
+    constructor(
+        readonly counterDeclaration: Assignment,
+        readonly finalValue: Expr.Expression,
+        readonly increment: Expr.Expression,
+        readonly body: Block
+    ) {}
+
+    accept<R>(visitor: Visitor<R>): Result {
+        return visitor.visitFor(this);
     }
 }
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -30,7 +30,6 @@ export interface Visitor<T> {
     visitPrint(statement: Print): Result;
     visitIf(statement: If): Result;
     visitBlock(block: Block): Result;
-    visitFor(statement: For): Result;
     visitWhile(statement: While): Result;
 }
 
@@ -125,19 +124,6 @@ export class Return implements Statement {
 
     accept<R>(visitor: Visitor<R>): Result {
         throw new Error("Method not implemented.");
-    }
-}
-
-export class For implements Statement {
-    constructor(
-        readonly initialValue: Assignment,
-        readonly finalValue: Expr.Expression,
-        readonly step: Expr.Expression,
-        readonly body: Block
-    ) {}
-
-    accept<R>(visitor: Visitor<R>): Result {
-        return visitor.visitFor(this);
     }
 }
 

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -30,6 +30,7 @@ export interface Visitor<T> {
     visitPrint(statement: Print): Result;
     visitIf(statement: If): Result;
     visitBlock(block: Block): Result;
+    visitFor(statement: For): Result;
     visitWhile(statement: While): Result;
 }
 
@@ -124,6 +125,19 @@ export class Return implements Statement {
 
     accept<R>(visitor: Visitor<R>): Result {
         throw new Error("Method not implemented.");
+    }
+}
+
+export class For implements Statement {
+    constructor(
+        readonly initialValue: Assignment,
+        readonly finalValue: Expr.Expression,
+        readonly step: Expr.Expression,
+        readonly body: Block
+    ) {}
+
+    accept<R>(visitor: Visitor<R>): Result {
+        return visitor.visitFor(this);
     }
 }
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -227,11 +227,11 @@ function printStatement(...additionalterminators: BlockTerminator[]): Stmt.Expre
  *                    ignored.
  */
 function block(...terminators: BlockTerminator[]): Stmt.Block {
-    let statements: Statement[] = [];
+    const statements: Statement[] = [];
     while (!check(...terminators)) {
         const dec = declaration();
         if (dec) {
-            statements = statements.concat(dec);
+            statements.push(dec);
         }
     }
     return new Stmt.Block(statements);

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -9,13 +9,15 @@ import * as ParseError from "./ParseError";
 import {
     BrsInvalid,
     BrsBoolean,
-    BrsString
+    BrsString,
+    Int32
 } from "../brsTypes";
 
 /** Set of all keywords that end blocks. */
 type BlockTerminator =
     Lexeme.ElseIf |
     Lexeme.Else |
+    Lexeme.EndFor |
     Lexeme.EndIf |
     Lexeme.EndWhile |
     Lexeme.EndSub|
@@ -103,6 +105,27 @@ function exitWhile(): Stmt.ExitWhile {
     consume("Expected newline after 'exit while'", Lexeme.Newline);
     while (match(Lexeme.Newline)) {}
     return new Stmt.ExitWhile();
+}
+
+function forStatement(): Stmt.For {
+    const initializer = assignment();
+    consume("Expected 'to' after for loop counter declaration", Lexeme.To);
+    const finalValue = expression();
+    let step: Expression | undefined;
+
+    if (match(Lexeme.Step)) {
+        step = expression();
+    } else {
+        // BrightScript for/to/step loops default to a step of 1 if no `step` is provided
+        step = new Expr.Literal(new Int32(1));
+    }
+    while(match(Lexeme.Newline)) {}
+
+    const body = block(Lexeme.EndFor);
+    advance();
+    while(match(Lexeme.Newline)) {}
+
+    return new Stmt.For(initializer, finalValue, step, body);
 }
 
 function ifStatement(): Stmt.If {

--- a/src/visitor/Environment.ts
+++ b/src/visitor/Environment.ts
@@ -10,6 +10,10 @@ export default class Environment {
         this.values.set(name, value);
     }
 
+    public remove(name: string): void {
+        this.values.delete(name);
+    }
+
     public get(name: Token): BrsType {
         if (this.values.has(name.text!)) {
             return this.values.get(name.text!)!;

--- a/src/visitor/Interpreter.ts
+++ b/src/visitor/Interpreter.ts
@@ -285,7 +285,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         };
     }
 
-    visitExitFor(expression: Stmt.ExitFor) {
+    visitExitFor(statement: Stmt.ExitFor) {
         return {
             value: BrsInvalid.Instance,
             reason: Stmt.StopReason.ExitFor
@@ -308,14 +308,6 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
     visitGrouping(expr: Expr.Grouping) {
         return this.evaluate(expr.expression);
-    }
-
-    visitFor(statement: Stmt.For): Stmt.Result {
-        console.error("for loop interpreting not yet implemented!");
-        return {
-            value: BrsInvalid.Instance,
-            reason: Stmt.StopReason.End
-        }
     }
 
     visitWhile(statement: Stmt.While): Stmt.Result {

--- a/src/visitor/Interpreter.ts
+++ b/src/visitor/Interpreter.ts
@@ -310,6 +310,14 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         return this.evaluate(expr.expression);
     }
 
+    visitFor(statement: Stmt.For): Stmt.Result {
+        console.error("for loop interpreting not yet implemented!");
+        return {
+            value: BrsInvalid.Instance,
+            reason: Stmt.StopReason.End
+        }
+    }
+
     visitWhile(statement: Stmt.While): Stmt.Result {
         while (this.evaluate(statement.condition).equalTo(BrsBoolean.True).toBoolean()) {
             const blockResult = this.execute(statement.body);

--- a/src/visitor/Interpreter.ts
+++ b/src/visitor/Interpreter.ts
@@ -310,6 +310,54 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         return this.evaluate(expr.expression);
     }
 
+    visitFor(statement: Stmt.For): Stmt.Result {
+        // BrightScript for/to loops evaluate the counter initial value, final value, and increment
+        // values *only once*, at the top of the for/top loop.
+        this.execute(statement.counterDeclaration);
+        const finalValue = this.evaluate(statement.finalValue);
+        const increment = this.evaluate(statement.increment);
+
+        const counterName = statement.counterDeclaration.name;
+        const step = new Stmt.Assignment(
+            counterName,
+            new Expr.Binary(
+                new Expr.Variable(counterName),
+                { kind: Lexeme.Plus, text: "+", line: counterName.line },
+                new Expr.Literal(increment)
+            )
+        );
+
+        let blockResult: Stmt.Result = {
+            value: BrsInvalid.Instance,
+            reason: Stmt.StopReason.End
+        };
+
+        while (
+            this.evaluate(new Expr.Variable(counterName))
+                .equalTo(finalValue)
+                .not()
+                .toBoolean()
+        ) {
+            // execute the block
+            blockResult = this.execute(statement.body);
+            if (blockResult.reason === Stmt.StopReason.ExitFor) {
+                break;
+            }
+
+            // then increment the counter
+            this.execute(step);
+        }
+
+        // BrightScript for/to loops execute the body one more time when initial === final
+        if (blockResult.reason === Stmt.StopReason.End) {
+            blockResult = this.execute(statement.body);
+            // they also increments the counter once more
+            this.execute(step);
+        }
+
+        return blockResult;
+    }
+
     visitWhile(statement: Stmt.While): Stmt.Result {
         while (this.evaluate(statement.condition).equalTo(BrsBoolean.True).toBoolean()) {
             const blockResult = this.execute(statement.body);

--- a/test/e2e/EndToEnd.test.js
+++ b/test/e2e/EndToEnd.test.js
@@ -8,6 +8,11 @@ function resourceFile(filename) {
     return path.join(__dirname, "resources", filename);
 }
 
+/**
+ * Extracts all arguments from all calls to a Jest mock function.
+ * @param jestMock the mock to extract arguments from
+ * @returns an array containing every argument from every call to a Jest mock.
+ */
 function allArgs(jestMock) {
     return jestMock.mock.calls.reduce((allArgs, thisCall) => allArgs.concat(thisCall), []);
 }
@@ -77,7 +82,20 @@ describe("end to end", () => {
             expect(allArgs(stdout)).toEqual([
                 "0", "1", "2", "3", "4", // count up
                 "5", "4"                 // count down with exit
-            ])
+            ]);
+        });
+    });
+
+    test("for-loops.brs", () => {
+        return execute(resourceFile("for-loops.brs")).then(() => {
+            expect(allArgs(stdout)).toEqual([
+                "0", "2", "4", "6", // count up
+                "8",                // i after loop
+                "3", "2", "1", "0", // count down
+                "for loop exit",    // exit early
+                "0",                // e after loop
+                "initial = final"   // loop where initial equals final
+            ]);
         });
     });
 });

--- a/test/e2e/resources/for-loops.brs
+++ b/test/e2e/resources/for-loops.brs
@@ -1,0 +1,32 @@
+final = 3
+' start with a simple count up, and make sure the final value
+' doesn't change if `final` does.
+for i = 0 to final * 2
+    print i
+
+    ' modify the loop counter; it's effectively `step 2`
+    i = i + 1
+    final = final - 3
+end for
+
+' i should still exist, and should be (final * 2) + 1
+print i
+
+' make sure we can count down with a negative step
+for d = 3 to 0 step -1
+    print d
+end for
+
+' ensure for/to loops can be exited
+for e = 0 to 10
+    print "for loop exit"
+    exit for
+end for
+
+' e should still exist, but shouldn't have been incremented
+print e
+
+' ensure body is executed when initial=final
+for a = 0 to 0
+    print "initial = final"
+end for

--- a/test/interpreter/For.test.js
+++ b/test/interpreter/For.test.js
@@ -1,0 +1,134 @@
+const BrsError = require("../../lib/Error");
+const Expr = require("../../lib/parser/Expression");
+const Stmt = require("../../lib/parser/Statement");
+const { Lexeme } = require("../../lib/Lexeme");
+const { Interpreter } = require("../../lib/visitor/Interpreter");
+const { Int32 } = require("../../lib/brsTypes/Int32");
+const { identifier } = require("../parser/ParserTests");
+
+let interpreter;
+let decrementSpy;
+
+describe("interpreter while loops", () => {
+    const initializeCounter = new Stmt.Assignment(
+        { kind: Lexeme.Identifier, text: "i", line: 1 },
+        new Expr.Literal(new Int32(0))
+    );
+
+    beforeEach(() => {
+        BrsError.reset();
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    it("initializes the counter variable", () => {
+        const counterSpy = jest.spyOn(initializeCounter, "accept");
+
+        const statements = [
+            new Stmt.For(
+                initializeCounter,
+                /* final value */ new Expr.Literal(new Int32(5)),
+                /* step */ new Expr.Literal(new Int32(1)),
+                /* body */ new Stmt.Block([])
+            )
+        ];
+
+        interpreter.exec(statements);
+        expect(counterSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("evaluates final value expression only once", () => {
+        const finalValue = new Expr.Literal(new Int32(5));
+        const finalValueSpy = jest.spyOn(finalValue, "accept");
+
+        const statements = [
+            new Stmt.For(
+                initializeCounter,
+                finalValue,
+                /* step */ new Expr.Literal(new Int32(1)),
+                /* body */ new Stmt.Block([])
+            )
+        ];
+
+        interpreter.exec(statements);
+        expect(finalValueSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("evaluates step expression only once", () => {
+        const stepValue = new Expr.Literal(new Int32(1));
+        const stepValueSpy = jest.spyOn(stepValue, "accept");
+
+        const statements = [
+            new Stmt.For(
+                initializeCounter,
+                new Expr.Literal(new Int32(5)),
+                /* step */ stepValue,
+                /* body */ new Stmt.Block([])
+            )
+        ];
+
+        interpreter.exec(statements);
+        expect(stepValueSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("executes block one last time when `counter = finalValue`", () => {
+        const body = new Stmt.Block([]); // no need for anything in it
+        const bodySpy = jest.spyOn(body, "accept");
+
+        const statements = [
+            new Stmt.For(
+                initializeCounter,
+                new Expr.Literal(new Int32(5)),
+                new Expr.Literal(new Int32(1)),
+                body
+            )
+        ];
+
+        interpreter.exec(statements);
+        // i=0 through i=4, then when i=5 (final value)
+        expect(bodySpy).toHaveBeenCalledTimes(6);
+    });
+
+    it("leaves counter in-scope after loop", () => {
+        const statements = [
+            new Stmt.For(
+                initializeCounter,
+                /* finalValue */ new Expr.Literal(new Int32(5)),
+                /* step */ new Expr.Literal(new Int32(1)),
+                /* body */ new Stmt.Block([])
+            ),
+            new Stmt.Expression(
+                new Expr.Variable(
+                    { kind: Lexeme.Identifier, text: "i", line: 3 }
+                )
+            )
+        ];
+
+        const [forLoop, i] = interpreter.exec(statements);
+        // counter must get incremented after last body iteration
+        expect(i.value).toEqual(new Int32(6));
+    });
+
+    it("can be exited", () => {
+        const body = new Stmt.Block([
+            new Stmt.ExitFor()
+        ]);
+        const bodySpy = jest.spyOn(body, "accept");
+
+        const statements = [
+            new Stmt.For(
+                initializeCounter,
+                /* finalValue */ new Expr.Literal(new Int32(5)),
+                /* step */ new Expr.Literal(new Int32(1)),
+                body
+            )
+        ];
+
+        interpreter.exec(statements);
+        expect(bodySpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/test/interpreter/While.test.js
+++ b/test/interpreter/While.test.js
@@ -56,6 +56,29 @@ describe("interpreter while loops", () => {
         expect(decrementSpy).toHaveBeenCalledTimes(5);
     });
 
+    it("evaluates 'condition' before every loop", () => {
+        const greaterThanZero = new Expr.Binary(
+            new Expr.Variable(identifier("foo")),
+            { kind: Lexeme.Greater, text: ">" },
+            new Expr.Literal(new Int32(0))
+        );
+        jest.spyOn(greaterThanZero, "accept");
+
+        const statements = [
+            initializeFoo,
+            new Stmt.While(
+                greaterThanZero,
+                new Stmt.Block([
+                    decrementFoo
+                ])
+            )
+        ];
+
+        let results = interpreter.exec(statements);
+        // body executes five times, but the condition is evaluated once more to know it should exit
+        expect(greaterThanZero.accept).toHaveBeenCalledTimes(6);
+    });
+
     it("exits early when it encounters 'exit while'", () => {
         const statements = [
             initializeFoo,

--- a/test/parser/__snapshots__/Boolean.test.js.snap
+++ b/test/parser/__snapshots__/Boolean.test.js.snap
@@ -43,7 +43,7 @@ Array [
         },
       },
       "token": Object {
-        "kind": 61,
+        "kind": 62,
         "line": 1,
         "literal": undefined,
       },

--- a/test/parser/controlFlow/For.test.js
+++ b/test/parser/controlFlow/For.test.js
@@ -1,0 +1,61 @@
+const Parser = require("../../../lib/parser");
+const Expr = require("../../../lib/parser/Expression");
+const { Lexeme } = require("../../../lib/Lexeme");
+const BrsError = require("../../../lib/Error");
+const { BrsBoolean, Int32 } = require("../../../lib/brsTypes");
+
+const { EOF } = require("../ParserTests");
+
+describe("parser for loops", () => {
+    afterEach(() => BrsError.reset());
+
+    it("accepts a 'step' clause", () => {
+        let parsed = Parser.parse([
+            { kind: Lexeme.For, text: "for", line: 1 },
+            { kind: Lexeme.Identifier, text: "i", line: 1 },
+            { kind: Lexeme.Equal, text: "=", line: 1 },
+            { kind: Lexeme.Integer, text: "0", literal: new Int32(0), line: 1 },
+            { kind: Lexeme.To, text: "to", line: 1 },
+            { kind: Lexeme.Integer, text: "5", literal: new Int32(5), line: 1 },
+            { kind: Lexeme.Step, text: "step", line: 1 },
+            { kind: Lexeme.Integer, text: "2", literal: new Int32(2), line: 1 },
+            { kind: Lexeme.Newline, text: "\n", line: 1 },
+            // body would go here, but it's not necessary for this test
+            { kind: Lexeme.EndFor, text: "end for", line: 2 },
+            { kind: Lexeme.Newline, text: "\n", line: 1 },
+            EOF
+        ]);
+
+        expect(BrsError.found()).toBe(false);
+        expect(parsed).toBeDefined();
+        expect(parsed[0]).toBeDefined();
+        expect(parsed[0].increment).toBeDefined();
+        expect(parsed[0].increment.value).toEqual(new Int32(2));
+
+        expect(parsed).toMatchSnapshot();
+    });
+
+    it("defaults a missing 'step' clause to '1'", () => {
+        let parsed = Parser.parse([
+            { kind: Lexeme.For, text: "for", line: 1 },
+            { kind: Lexeme.Identifier, text: "i", line: 1 },
+            { kind: Lexeme.Equal, text: "=", line: 1 },
+            { kind: Lexeme.Integer, text: "0", literal: new Int32(0), line: 1 },
+            { kind: Lexeme.To, text: "to", line: 1 },
+            { kind: Lexeme.Integer, text: "5", literal: new Int32(5), line: 1 },
+            { kind: Lexeme.Newline, text: "\n", line: 1 },
+            // body would go here, but it's not necessary for this test
+            { kind: Lexeme.EndFor, text: "end for", line: 2 },
+            { kind: Lexeme.Newline, text: "\n", line: 1 },
+            EOF
+        ]);
+
+        expect(BrsError.found()).toBe(false);
+        expect(parsed).toBeDefined();
+        expect(parsed[0]).toBeDefined();
+        expect(parsed[0].increment).toBeDefined();
+        expect(parsed[0].increment.value).toEqual(new Int32(1));
+
+        expect(parsed).toMatchSnapshot();
+    });
+});

--- a/test/parser/controlFlow/__snapshots__/For.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/For.test.js.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parser for loops accepts a 'step' clause 1`] = `
+Array [
+  For {
+    "body": Block {
+      "statements": Array [],
+    },
+    "counterDeclaration": Assignment {
+      "name": Object {
+        "kind": 21,
+        "line": 1,
+        "text": "i",
+      },
+      "value": Literal {
+        "value": Int32 {
+          "kind": 3,
+          "value": 0,
+        },
+      },
+    },
+    "finalValue": Literal {
+      "value": Int32 {
+        "kind": 3,
+        "value": 5,
+      },
+    },
+    "increment": Literal {
+      "value": Int32 {
+        "kind": 3,
+        "value": 2,
+      },
+    },
+  },
+]
+`;
+
+exports[`parser for loops defaults a missing 'step' clause to '1' 1`] = `
+Array [
+  For {
+    "body": Block {
+      "statements": Array [],
+    },
+    "counterDeclaration": Assignment {
+      "name": Object {
+        "kind": 21,
+        "line": 1,
+        "text": "i",
+      },
+      "value": Literal {
+        "value": Int32 {
+          "kind": 3,
+          "value": 0,
+        },
+      },
+    },
+    "finalValue": Literal {
+      "value": Int32 {
+        "kind": 3,
+        "value": 5,
+      },
+    },
+    "increment": Literal {
+      "value": Int32 {
+        "kind": 3,
+        "value": 1,
+      },
+    },
+  },
+]
+`;

--- a/test/parser/expression/__snapshots__/Unary.test.js.snap
+++ b/test/parser/expression/__snapshots__/Unary.test.js.snap
@@ -50,31 +50,31 @@ Array [
   Expression {
     "expression": Unary {
       "operator": Object {
-        "kind": 59,
+        "kind": 60,
         "line": 1,
         "literal": undefined,
       },
       "right": Unary {
         "operator": Object {
-          "kind": 59,
+          "kind": 60,
           "line": 1,
           "literal": undefined,
         },
         "right": Unary {
           "operator": Object {
-            "kind": 59,
+            "kind": 60,
             "line": 1,
             "literal": undefined,
           },
           "right": Unary {
             "operator": Object {
-              "kind": 59,
+              "kind": 60,
               "line": 1,
               "literal": undefined,
             },
             "right": Unary {
               "operator": Object {
-                "kind": 59,
+                "kind": 60,
                 "line": 1,
                 "literal": undefined,
               },
@@ -115,7 +115,7 @@ Array [
   Expression {
     "expression": Unary {
       "operator": Object {
-        "kind": 59,
+        "kind": 60,
         "line": 1,
         "literal": undefined,
       },


### PR DESCRIPTION
BrightScript has two types of `for` loop: `FOR counter = exp TO exp [STEP exp] (...) END FOR` and `FOR EACH item IN object (...) END FOR`.  Since we don't have an object system yet we can't do `for each`.  But we *can* do `for ... to`!