### PR TITLE
improved error handling of non-readable input files (issue #21)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -24,7 +24,10 @@ program
 let args = program.parse(process.argv);
 
 if (brsFile) {
-    brs.execute(brsFile);
+    brs.execute(brsFile).catch(err => {
+        console.error(err.message);
+        process.exit(1);
+    });
 } else {
     brs.repl();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,19 +15,20 @@ export function execute(filename: string) {
     return new Promise((resolve, reject) => {
         fs.readFile(filename, "utf-8", (err, contents) => {
             if (err) {
-                reject(err);
-            }
-            run(contents);
-            if (BrsError.found()) {
-                reject("Error occurred");
-                if (process.env["NODE_ENV"] !== "test") {
-                    // eventually, this probably shouldn't even call process.exit -- it should
-                    // happen in cli.js since it's a property of the CLI
-                    process.exit(1);
+                reject({
+                    "message" : `brs: can't open file '${filename}': [Errno ${err.errno}]`
+                });
+            } else {
+                run(contents);
+                if (BrsError.found()) {
+                    reject({ 
+                        "message" : "Error occurred" 
+                    });
+                } else {
+                    resolve();
                 }
+                // TODO: Wire up runtime errors so we can use a second exit code
             }
-            resolve();
-            // TODO: Wire up runtime errors so we can use a second exit code
         });
     });
 }


### PR DESCRIPTION
This uses the Promise handling to bubble up file-related problems to the command line handler instead of failing somewhere in the code.  

No arguments:
```
$ brs
brs>
```

Non-existent file:
```
$ brs foo
brs: can't open file 'foo': [Errno -2]
```

Non-readable file:
```
$ brs foo
brs: can't open file 'foo': [Errno -13]
```

Empty file (no error, no output similar to python):
```
$ brs foo
$
```

Confirmed that the cases above have the correct exit code (0 for pass, 1 for failure).  