### PR TITLE
test(stdlib): Add end-to-end tests for Chr and Asc

### DIFF
--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -20,7 +20,9 @@ describe("end to end standard libary", () => {
         return execute(resourceFile(path.join("stdlib", "strings.brs"))).then(() => {
             expect(allArgs(stdout)).toEqual([
                 "MIXED CASE",
-                "mixed case"
+                "mixed case",
+                "12359",
+                "ぇ"
             ]);
         });
     });

--- a/test/e2e/resources/stdlib/strings.brs
+++ b/test/e2e/resources/stdlib/strings.brs
@@ -2,3 +2,6 @@ mixedCase = "Mixed Case"
 
 print UCase(mixedCase)
 print LCase(mixedCase)
+
+print Asc("ぇ")
+print Chr(12359) ' UTF-16 decimal for "ぇ"

--- a/test/stdlib/String.test.js
+++ b/test/stdlib/String.test.js
@@ -28,7 +28,8 @@ describe("global string functions", () => {
             expect(
                 Asc.call(interpreter, new BrsString(""))
             ).toEqual(new Int32(0));
-        })
+        });
+
         it("converts a character to a UTF-16 representation", () => {
             expect(
                 Asc.call(interpreter, new BrsString("for"))
@@ -37,15 +38,15 @@ describe("global string functions", () => {
             expect(
                 Asc.call(interpreter, new BrsString("ぇ"))
             ).toEqual(new Int32(12359));
-        })
-    })
+        });
+    });
 
     describe("Chr", () => {
         it("converts a non-integer to an empty string", () => {
             expect(
                 Chr.call(interpreter, new BrsString("some string"))
             ).toEqual(new BrsString(""));
-        })
+        });
 
         it("converts a negative or zero to an empty string", () => {
             expect(
@@ -55,9 +56,9 @@ describe("global string functions", () => {
             expect(
                 Chr.call(interpreter, new Int32(0))
             ).toEqual(new BrsString(""));
-        })
+        });
 
-        it("converts an UTF-18 integer to character", () => {
+        it("converts an UTF-16 integer to character", () => {
             expect(
                 Chr.call(interpreter, new Int32(34))
             ).toEqual(new BrsString("\""));
@@ -65,8 +66,6 @@ describe("global string functions", () => {
             expect(
                 Chr.call(interpreter, new Int32(12359))
             ).toEqual(new BrsString("ぇ"));
-        })
-
-        
-    })
-})
+        });
+    });
+});


### PR DESCRIPTION
The actual logic in those functions is already handled in `test/stdlib/Strin.test.js`, so these don't need full coverage. End-to-end tests are helpful here to make sure those functions don't accidentally get removed from global scope :)