### PR TITLE
feat(interp,stdlib): Add call-time type checking

### DIFF
--- a/src/Error.ts
+++ b/src/Error.ts
@@ -6,7 +6,7 @@ export function make(message: string, line: number, file?: string) {
 }
 
 export function runtime(message: string, line: number, file?: string) {
-    let location = file ? `${file}: ${line}` : `line ${line}`;
+    let location = file ? `${file}: ${line}` : `Line ${line}`;
     let error = new Error(`[${location}] ${message}`);
     if (process.env.NODE_ENV !== "test") {
         console.error(error.message);

--- a/src/Error.ts
+++ b/src/Error.ts
@@ -9,7 +9,7 @@ export function runtime(message: string, line: number, file?: string) {
     let location = file ? `${file}: ${line}` : `line ${line}`;
     let error = new Error(`[${location}] ${message}`);
     if (process.env.NODE_ENV !== "test") {
-        console.error(error);
+        console.error(error.message);
     }
     return error;
 }

--- a/src/brsTypes/BrsType.ts
+++ b/src/brsTypes/BrsType.ts
@@ -10,8 +10,29 @@ export enum ValueKind {
     Float,
     Double,
     // TODO: Add Object types (associative arrays, lists, etc.)
-    Callable
+    Callable,
+    Dynamic
 };
+
+export namespace ValueKind {
+    /**
+     * Converts a `ValueKind` enum member to a human-readable string representation.
+     * @returns a textual representation of the provided value kind.
+     */
+    export function toString(kind: ValueKind): string {
+        switch (kind) {
+            case ValueKind.Invalid: return "Invalid";
+            case ValueKind.Boolean: return "Boolean";
+            case ValueKind.String: return "String";
+            case ValueKind.Int32: return "Integer";
+            case ValueKind.Int64: return "LongInteger";
+            case ValueKind.Float: return "Float";
+            case ValueKind.Double: return "Double";
+            case ValueKind.Callable: return "Function";
+            case ValueKind.Dynamic: return "Dynamic";
+        }
+    }
+}
 
 /** The base for all BrightScript types. */
 export interface BrsValue {

--- a/src/brsTypes/Callable.ts
+++ b/src/brsTypes/Callable.ts
@@ -1,21 +1,51 @@
 import { Interpreter } from "../interpreter";
-import { BrsType, BrsValue, ValueKind, BrsBoolean } from "./";
+import * as Brs from "./";
+import { Token } from "../Token";
+
+export class Argument {
+    constructor(
+        readonly name: string,
+        readonly type: Brs.ValueKind = Brs.ValueKind.Dynamic,
+        readonly defaultValue?: Brs.BrsType
+    ) {}
+}
+
+/** Describes the number of required and optional arguments for a `Callable`. */
+export interface Arity {
+    /** The minimum number of arguments required for this function call. */
+    required: number,
+    /** The number of optional arguments accepted by this function. */
+    optional: number
+}
+
+export interface Signature {
+    name: string,
+    args: Argument[]
+}
 
 /** A `function` or `sub` (either "native" or implemented in BrightScript) that can be called in a BrightScript file. */
-export abstract class Callable implements BrsValue {
-    readonly kind = ValueKind.Callable;
+export abstract class Callable implements Brs.BrsValue {
+    readonly kind = Brs.ValueKind.Callable;
 
-    /** The number of arguments expected by this function. */
-    abstract readonly arity: {
-        /**
-         * The minimum number of arguments required for this function call. Is equal to `arity.max`
-         * when all arguments are required.
-         */
-        required: number;
+    /** The arity of this callable stored after it was first calculated. */
+    private memoizedArity?: Arity;
 
-        /** The number of optional arguments accepted by this function. */
-        optional: number;
+    /**
+     * Calculates and returns the number of arguments expected by this function.
+     * @returns an object containing the number of required and optional arguments.
+     */
+    arity(): Arity {
+        if (!this.memoizedArity) {
+            this.memoizedArity = {
+                required: this.signature.args.filter(a => !a.defaultValue).length,
+                optional: this.signature.args.filter(a => !!a.defaultValue).length
+            };
+        }
+
+        return this.memoizedArity;
     };
+
+    abstract readonly signature: Signature;
 
     /**
      * Calls the function this `Callable` represents with the provided `arg`uments using the
@@ -26,18 +56,18 @@ export abstract class Callable implements BrsValue {
      *
      * @returns the return value of the function, or `invalid` if nothing is explicitly returned.
      */
-    abstract call(interpreter: Interpreter, ...args: BrsType[]): BrsType;
+    abstract call(interpreter: Interpreter, ...args: Brs.BrsType[]): Brs.BrsType;
 
-    lessThan(other: BrsType): BrsBoolean {
-        return BrsBoolean.False;
+    lessThan(other: Brs.BrsType): Brs.BrsBoolean {
+        return Brs.BrsBoolean.False;
     }
 
-    greaterThan(other: BrsType): BrsBoolean {
-        return BrsBoolean.False;
+    greaterThan(other: Brs.BrsType): Brs.BrsBoolean {
+        return Brs.BrsBoolean.False;
     }
 
-    equalTo(other: BrsType): BrsBoolean {
-        return BrsBoolean.from(this === other);
+    equalTo(other: Brs.BrsType): Brs.BrsBoolean {
+        return Brs.BrsBoolean.from(this === other);
     }
 
     toString(): string {

--- a/src/brsTypes/index.ts
+++ b/src/brsTypes/index.ts
@@ -3,7 +3,7 @@ import { Int32 } from "./Int32";
 import { Int64 } from "./Int64";
 import { Float } from "./Float";
 import { Double } from "./Double";
-import { Callable } from "./Callable";
+import { Callable, CallableImplementation } from "./Callable";
 
 export * from "./BrsType";
 export * from "./Int32";

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,8 @@ export function execute(filename: string) {
             } else {
                 run(contents);
                 if (BrsError.found()) {
-                    reject({ 
-                        "message" : "Error occurred" 
+                    reject({
+                        "message" : "Error occurred"
                     });
                 } else {
                     resolve();
@@ -63,5 +63,10 @@ function run(contents: string) {
 
     if (!statements) { return; }
 
-    return interpreter.exec(statements);
+    try {
+        return interpreter.exec(statements);
+    } catch (e) {
+        console.error(e.message);
+        return;
+    }
 }

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -367,7 +367,9 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         }
 
         if (typeMismatchFound) {
-            throw new Error("Type mismatch(es) detected.");
+            throw new Error(
+                `[Line ${expression.closingParen.line}] Type mismatch(es) detected.`
+            );
         }
 
         return callee.call(this, ...args);

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -356,6 +356,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         for (const index in args) {
             const signatureArg = callee.signature.args[index];
             if (signatureArg.type !== args[index].kind) {
+                typeMismatchFound = true;
                 BrsError.make(
                     `Type mismatch in '${functionName}': argument '${signatureArg.name}' must be ` +
                         `of type ${ValueKind.toString(signatureArg.type)}, but received ` +

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -336,7 +336,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         }
 
         // ensure argument counts match
-        const arity = callee.arity();
+        const arity = callee.arity;
         if (expression.args.length < arity.required) {
             throw BrsError.make(
                 `'${functionName}' requires at least ${arity.required} arguments, ` +

--- a/src/stdlib/String.ts
+++ b/src/stdlib/String.ts
@@ -1,65 +1,36 @@
-import { BrsType, Callable, ValueKind, BrsString, BrsNumber, Int32, Int64 } from "../brsTypes";
+import { BrsType, Callable, ValueKind, BrsString, Int32 } from "../brsTypes";
 import { Interpreter } from "../interpreter";
 
-class UCaseCallable extends Callable {
-    signature = {
+/** Converts the string to all uppercase. */
+export const UCase = new Callable(
+    {
         name: "UCase",
         args: [{ name: "s", type: ValueKind.String }]
-    }
-
-    call(interpreter: Interpreter, str: BrsString): BrsType {
-        return new BrsString(str.value.toUpperCase());
-    }
-}
-
-class LCaseCallable extends Callable {
-    signature = {
-        name: "LCase",
-        args: [{ name: "s", type: ValueKind.String }]
-    }
-
-    call(interpreter: Interpreter, str: BrsString): BrsType {
-        return new BrsString(str.value.toLowerCase());
-    }
-}
-
-class AscCallable extends Callable {
-    signature = {
-        name: "Asc",
-        args: [{ name: "letter", type: ValueKind.String }]
-    }
-
-    call(interpreter: Interpreter, str: BrsString): BrsType {
-        return new Int32(str.value.charCodeAt(0) || 0);
-    }
-}
-
-class ChrCallable extends Callable {
-    signature = {
-        name: "Chr",
-        args: [{ name: "ch", type: ValueKind.Int32 }]
-    }
-
-    call(interpreter: Interpreter, value: Int32): BrsType {
-        const num = value.getValue();
-        if (num <= 0)
-            return new BrsString("");
-        else
-            return new BrsString(String.fromCharCode(num));
-    }
-}
-
-/** Converts the string to all uppercase. */
-export const UCase: Callable = new UCaseCallable();
+    },
+    (interpreter: Interpreter, s: BrsString) => new BrsString(s.value.toUpperCase())
+);
 
 /** Converts the string to all lowercase. */
-export const LCase: Callable = new LCaseCallable();
+export const LCase = new Callable(
+    {
+        name: "LCase",
+        args: [{ name: "s", type: ValueKind.String }]
+    },
+    (interpreter: Interpreter, s: BrsString) => new BrsString(s.value.toLowerCase())
+);
+
 
 /**
  * Returns the Unicode ("ASCII") value for the first character of the specified string.
  * An empty string argument will return `0`.
  */
-export const Asc: Callable = new AscCallable();
+export const Asc = new Callable(
+    {
+        name: "Asc",
+        args: [{ name: "letter", type: ValueKind.String }]
+    },
+    (interpreter: Interpreter, str: BrsString) => new Int32(str.value.charCodeAt(0) || 0)
+);
 
 /**
  * Performs the inverse of the `Asc` function: returns a one-character string whose character has
@@ -67,4 +38,16 @@ export const Asc: Callable = new AscCallable();
  *
  * Returns empty string (`""`) if the specified value is `0` or an invalid Unicode value.
  */
-export const Chr: Callable = new ChrCallable();
+export const Chr = new Callable(
+    {
+        name: "Chr",
+        args: [{ name: "ch", type: ValueKind.Int32 }]
+    },
+    (interpreter: Interpreter, ch: Int32) => {
+        const num = ch.getValue();
+        if (num <= 0)
+            return new BrsString("");
+        else
+            return new BrsString(String.fromCharCode(num));
+    }
+);

--- a/src/stdlib/String.ts
+++ b/src/stdlib/String.ts
@@ -2,22 +2,21 @@ import { BrsType, Callable, ValueKind, BrsString, BrsNumber, Int32, Int64 } from
 import { Interpreter } from "../interpreter";
 
 class UCaseCallable extends Callable {
-    arity = {
-        required: 1,
-        optional: 0
-    };
+    signature = {
+        name: "UCase",
+        args: [{ name: "s", type: ValueKind.String }]
+    }
 
     call(interpreter: Interpreter, str: BrsString): BrsType {
-        // TODO: Figure out how to handle type checking centrally
         return new BrsString(str.value.toUpperCase());
     }
 }
 
 class LCaseCallable extends Callable {
-    arity = {
-        required: 1,
-        optional: 0
-    };
+    signature = {
+        name: "LCase",
+        args: [{ name: "s", type: ValueKind.String }]
+    }
 
     call(interpreter: Interpreter, str: BrsString): BrsType {
         return new BrsString(str.value.toLowerCase());
@@ -25,9 +24,9 @@ class LCaseCallable extends Callable {
 }
 
 class AscCallable extends Callable {
-    arity = {
-        required: 1,
-        optional: 0
+    signature = {
+        name: "Asc",
+        args: [{ name: "letter", type: ValueKind.String }]
     }
 
     call(interpreter: Interpreter, str: BrsString): BrsType {
@@ -36,25 +35,36 @@ class AscCallable extends Callable {
 }
 
 class ChrCallable extends Callable {
-    arity = {
-        required: 1,
-        optional: 0
+    signature = {
+        name: "Chr",
+        args: [{ name: "ch", type: ValueKind.Int32 }]
     }
 
-    call(interpreter: Interpreter, value: BrsType): BrsType {
-        if (value.kind === ValueKind.Int32) {
-            const num = value.getValue();
-            if (num <= 0)
-                return new BrsString("");
-            else
-                return new BrsString(String.fromCharCode(num));
-        } else {
+    call(interpreter: Interpreter, value: Int32): BrsType {
+        const num = value.getValue();
+        if (num <= 0)
             return new BrsString("");
-        }
+        else
+            return new BrsString(String.fromCharCode(num));
     }
 }
 
+/** Converts the string to all uppercase. */
 export const UCase: Callable = new UCaseCallable();
+
+/** Converts the string to all lowercase. */
 export const LCase: Callable = new LCaseCallable();
+
+/**
+ * Returns the Unicode ("ASCII") value for the first character of the specified string.
+ * An empty string argument will return `0`.
+ */
 export const Asc: Callable = new AscCallable();
+
+/**
+ * Performs the inverse of the `Asc` function: returns a one-character string whose character has
+ * the specified Unicode value.
+ *
+ * Returns empty string (`""`) if the specified value is `0` or an invalid Unicode value.
+ */
 export const Chr: Callable = new ChrCallable();

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -1,23 +1,21 @@
 import { Callable, ValueKind, BrsType, BrsInvalid } from "../brsTypes";
 import { Interpreter } from "../interpreter";
 
-class RebootSystemCallable extends Callable {
-    static WarningShown = false;
-
-    signature = {
-        name: "RebootSystem",
-        args: []
-    };
-
-    call(interpreter: Interpreter): BrsInvalid {
-        if (!RebootSystemCallable.WarningShown) {
-            console.warn("`RebootSystem` is not implemented in `brs`.");
-            RebootSystemCallable.WarningShown = true;
-        }
-
-        return BrsInvalid.Instance;
+let warningShown = false;
+function rebootSystemImpl(interpreter: Interpreter): BrsInvalid {
+    if (!warningShown) {
+        console.warn("`RebootSystem` is not implemented in `brs`.");
+        warningShown = true;
     }
+
+    return BrsInvalid.Instance;
 };
 
-export const RebootSystem: Callable = new RebootSystemCallable();
+export const RebootSystem = new Callable(
+    {
+        name: "RebootSystem",
+        args: []
+    },
+    rebootSystemImpl
+);
 export * from "./String";

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -3,9 +3,10 @@ import { Interpreter } from "../interpreter";
 
 class RebootSystemCallable extends Callable {
     static WarningShown = false;
-    arity = {
-        required: 0,
-        optional: 0
+
+    signature = {
+        name: "RebootSystem",
+        args: []
     };
 
     call(interpreter: Interpreter): BrsInvalid {

--- a/test/brsTypes/Callable.test.js
+++ b/test/brsTypes/Callable.test.js
@@ -103,7 +103,7 @@ describe.only("Callable", () => {
             });
         });
 
-        it("allows funtions with both required and optional args", () => {
+        it("allows functions with both required and optional args", () => {
             const required = new BrsTypes.Callable(
                 {
                     name: "requiredAndOptional",

--- a/test/brsTypes/Callable.test.js
+++ b/test/brsTypes/Callable.test.js
@@ -55,4 +55,68 @@ describe.only("Callable", () => {
 
         expect(UCase.equalTo(UCase)).toBe(BrsTypes.BrsBoolean.True);
     });
+
+    describe("arity", () => {
+        it("allows no-args functions", () => {
+            const noArgs = new BrsTypes.Callable(
+                {
+                    name: "acceptsNoArgs",
+                    args: []
+                },
+                () => {}
+            );
+            expect(noArgs.arity).toEqual({
+                required: 0,
+                optional: 0
+            });
+        });
+
+        it("allows functions with only required args", () => {
+            const required = new BrsTypes.Callable(
+                {
+                    name: "requiredOnly",
+                    args: [
+                        { name: "foo", type: BrsTypes.ValueKind.String },
+                        { name: "bar", type: BrsTypes.ValueKind.Int32 },
+                    ]
+                }
+            );
+            expect(required.arity).toEqual({
+                required: 2,
+                optional: 0
+            });
+        });
+
+        it("allows functions with only optional args", () => {
+            const required = new BrsTypes.Callable(
+                {
+                    name: "optionalOnly",
+                    args: [
+                        { name: "foo", type: BrsTypes.ValueKind.String, defaultValue: new BrsTypes.BrsString("okay") },
+                        { name: "bar", type: BrsTypes.ValueKind.Int32, defaultValue: new BrsTypes.Int32(-1) },
+                    ]
+                }
+            );
+            expect(required.arity).toEqual({
+                required: 0,
+                optional: 2
+            });
+        });
+
+        it("allows funtions with both required and optional args", () => {
+            const required = new BrsTypes.Callable(
+                {
+                    name: "requiredAndOptional",
+                    args: [
+                        { name: "foo", type: BrsTypes.ValueKind.String },
+                        { name: "bar", type: BrsTypes.ValueKind.Int32, defaultValue: new BrsTypes.Int32(-1) },
+                    ]
+                }
+            );
+            expect(required.arity).toEqual({
+                required: 1,
+                optional: 1
+            });
+        });
+    });
 });

--- a/test/e2e/TypeChecking.test.js
+++ b/test/e2e/TypeChecking.test.js
@@ -1,0 +1,52 @@
+const path = require("path");
+
+const { execute } = require("../../lib/");
+const BrsError = require("../../lib/Error");
+
+const { resourceFile, allArgs } = require("./E2ETests");
+
+describe("function argument type checking", () => {
+    let stderr;
+    let originalNodeEnv;
+
+    beforeAll(() => {
+        originalNodeEnv = process.env.NODE_ENV;
+        // switch NODE_ENV to not-test, to ensure errors get logged
+        process.env.NODE_ENV = "jest";
+        // but make console.error empty so we don't clutter test output
+        stderr = jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        stderr.mockClear();
+        BrsError.reset();
+    });
+
+    afterAll(() => {
+        stderr.mockRestore()
+        process.env.NODE_ENV = originalNodeEnv;
+    });
+
+    it("errors when too few args are passed", () => {
+        return execute(resourceFile(path.join("type-checking", "too-few-args.brs"))).catch(() => {
+            const output = allArgs(stderr);
+            expect(output[0]).toMatch(/\[Line .\] 'UCase' requires at least 1 arguments, but received 0\./);
+        });
+    });
+
+    it("errors when too many args are passed", () => {
+        return execute(resourceFile(path.join("type-checking", "too-many-args.brs"))).catch(() => {
+            const output = allArgs(stderr);
+            expect(output[0]).toMatch(/\[Line .\] 'RebootSystem' accepts at most 0 arguments, but received 1\./);
+        });
+    });
+
+    it("errors when mismatched types are provided", () => {
+        return execute(resourceFile(path.join("type-checking", "arg-type-mismatch.brs"))).catch(() => {
+            const output = allArgs(stderr);
+            expect(output[0]).toMatch(
+                /\[Line .\] Type mismatch in 'LCase': argument 's' must be of type String, but received Boolean./
+            );
+        });
+    });
+});

--- a/test/e2e/resources/type-checking/arg-type-mismatch.brs
+++ b/test/e2e/resources/type-checking/arg-type-mismatch.brs
@@ -1,0 +1,4 @@
+' call LCase with incorrect argument type; execution should exit
+LCase(false)
+
+print "Uh oh, `brs` didn't exit"

--- a/test/e2e/resources/type-checking/too-few-args.brs
+++ b/test/e2e/resources/type-checking/too-few-args.brs
@@ -1,0 +1,4 @@
+' call UCase without any arguments; execution should exit
+UCase()
+
+print "Uh oh, `brs` didn't exit"

--- a/test/e2e/resources/type-checking/too-many-args.brs
+++ b/test/e2e/resources/type-checking/too-many-args.brs
@@ -1,0 +1,4 @@
+' call RebootSystem some arguments (it doesn't accept any); execution should exit
+RebootSystem(5)
+
+print "Uh oh, `brs` didn't exit"

--- a/test/interpreter/Call.test.js
+++ b/test/interpreter/Call.test.js
@@ -56,4 +56,19 @@ describe("interpreter calls", () => {
         expect(() => interpreter.exec([call])).toThrow(/UCase.*arguments/);
         expect(BrsError.found()).toBe(true);
     });
+
+    it("errors when argument types are incorrect", () => {
+        const call = new Stmt.Expression(
+            new Expr.Call(
+                new Expr.Variable(identifier("UCase")),
+                { kind: Lexeme.RightParen, text: ")", line: 1 },
+                [
+                    new Expr.Literal(new BrsTypes.Int32(5)),
+                ]
+            )
+        );
+
+        expect(() => interpreter.exec([call])).toThrow(/Type mismatch/);
+        expect(BrsError.found()).toBe(true);
+    });
 });

--- a/test/stdlib/String.test.js
+++ b/test/stdlib/String.test.js
@@ -42,12 +42,6 @@ describe("global string functions", () => {
     });
 
     describe("Chr", () => {
-        it("converts a non-integer to an empty string", () => {
-            expect(
-                Chr.call(interpreter, new BrsString("some string"))
-            ).toEqual(new BrsString(""));
-        });
-
         it("converts a negative or zero to an empty string", () => {
             expect(
                 Chr.call(interpreter, new Int32(-1))


### PR DESCRIPTION
My use of BrightScript on Roku devices has a rich history of throwing vague `Type mismatch` errors and... well that's about it.  This interpreter needs centralized type checking for function calls, to ensure `brs` don't ungracefully crash when attempting to call `UCase(5)`.  The goal here is to provide more helpful error messages than the reference interpreter though, e.g.:

```
brs> UCase(5)
[line 1] Type mismatch in 'UCase': argument 's' must be of type String, but received Integer.
[Line 1] Type mismatch(es) detected.
brs> 
```

Perhaps I should add in argument indexes too?  Something like "Type mismatch in 'FunctionName': argument n, 'name', must be of type Foo, but received Bar." could be nice.

That can come in a future PR though I imagine :smile: 

fixes #39 