### PR TITLE
feat(lex,parse,interp,e2e): Implement print lists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export function execute(filename: string, options: OutputStreams = processOutput
 }
 
 export function repl() {
+    const replInterpreter = new Interpreter();
     const rl = readline.createInterface({
         input: process.stdin,
         output: process.stdout,
@@ -45,7 +46,7 @@ export function repl() {
     rl.setPrompt("brs> ");
 
     rl.on("line", (line) => {
-        let results = run(line);
+        let results = run(line, processOutput, replInterpreter);
         if (results) {
             results.map(result => console.log(stringify(result.value)));
         }
@@ -57,7 +58,7 @@ export function repl() {
     rl.prompt();
 }
 
-function run(contents: string, options: OutputStreams = processOutput) {
+function run(contents: string, options: OutputStreams = processOutput, interpreter?: Interpreter) {
     const tokens: ReadonlyArray<Token> = Lexer.scan(contents);
     const statements = Parser.parse(tokens);
 
@@ -68,7 +69,7 @@ function run(contents: string, options: OutputStreams = processOutput) {
     if (!statements) { return; }
 
     try {
-        return new Interpreter(options).exec(statements);
+        return (interpreter || new Interpreter(options)).exec(statements);
     } catch (e) {
         options.stderr.write(e.message);
         return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,17 @@ const processOutput: OutputStreams = {
     stderr: process.stderr
 };
 
+/**
+ * Executes a BrightScript file by path and writes its output to the streams
+ * provided in `options`.
+ *
+ * @param filename the absolute path to the `.brs` file to be executed
+ * @param options the streams to use for `stdout` and `stderr`. Mostly used for
+ *                testing.
+ *
+ * @returns a `Promise` that will be resolve if `filename` is successfully
+ *          executed, or be rejected if an error occurs.
+ */
 export function execute(filename: string, options: OutputStreams = processOutput) {
     return new Promise((resolve, reject) => {
         fs.readFile(filename, "utf-8", (err, contents) => {
@@ -37,6 +48,12 @@ export function execute(filename: string, options: OutputStreams = processOutput
     });
 }
 
+/**
+ * Launches an interactive read-execute-print loop, which reads input from
+ * `stdin` and executes it.
+ *
+ * **NOTE:** Currently limited to single-line inputs :(
+ */
 export function repl() {
     const replInterpreter = new Interpreter();
     const rl = readline.createInterface({
@@ -58,6 +75,17 @@ export function repl() {
     rl.prompt();
 }
 
+/**
+ * Runs an arbitrary string of BrightScript code.
+ * @param contents the BrightScript code to lex, parse, and interpret.
+ * @param options the streams to use for `stdout` and `stderr`. Mostly used for
+ *                testing.
+ * @param interpreter an interpreter to use when executing `contents`. Required
+ *                    for `repl` to have persistent state between user inputs.
+ * @returns an array of statement execution results, indicating why each
+ *          statement exited and what its return value was, or `undefined` if
+ *          `interpreter` threw an Error.
+ */
 function run(contents: string, options: OutputStreams = processOutput, interpreter?: Interpreter) {
     const tokens: ReadonlyArray<Token> = Lexer.scan(contents);
     const statements = Parser.parse(tokens);

--- a/src/interpreter/OutputProxy.ts
+++ b/src/interpreter/OutputProxy.ts
@@ -1,8 +1,17 @@
+/** Proxies a `stdout`-like stream to provide current-column tracking. */
 export class OutputProxy {
     currentLineLength = 0;
 
+    /** 
+     * Creates a new proxy that tracks the current column of the provided stream.
+     * @param outputStream the stream to proxy writes to
+     */
     constructor(private outputStream: NodeJS.WriteStream) { }
 
+    /**
+     * Writes a string's worth of data to the proxied stream and updates the current output column.
+     * @param str the string to write to the proxied stream
+     */
     write(str: string) {
         this.outputStream.write(str);
 
@@ -18,6 +27,14 @@ export class OutputProxy {
         this.currentLineLength += str.length; 
     }
 
+    /**
+     * Calculates and returns the column that the next written character will
+     * be placed in. If the proxied stream is a TTY, the current position will
+     * be in the range `[0, proxiedStream.columns)`.
+     * 
+     * @returns the zero-indexed position at which the next written character
+     *          will be placed in the proxied output stream.
+     */
     position() {
         if (!this.outputStream.isTTY || !this.outputStream.columns) {
             return this.currentLineLength;

--- a/src/interpreter/OutputProxy.ts
+++ b/src/interpreter/OutputProxy.ts
@@ -1,0 +1,28 @@
+export class OutputProxy {
+    currentLineLength = 0;
+
+    constructor(private outputStream: NodeJS.WriteStream) { }
+
+    write(str: string) {
+        this.outputStream.write(str);
+
+        let lines = str.split("\n");
+
+        if (lines.length > 1) {
+            // the length of the most recent line is now the current line length
+            this.currentLineLength = lines[lines.length - 1].length;
+            return;
+        }
+
+        // but if this wasn't a multi-line string, we're just appending to the current line
+        this.currentLineLength += str.length; 
+    }
+
+    position() {
+        if (!this.outputStream.isTTY || !this.outputStream.columns) {
+            return this.currentLineLength;
+        }
+
+        return this.currentLineLength % this.outputStream.columns;
+    }
+}

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -403,7 +403,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         let typeMismatchFound = false;
         for (const index in args) {
             const signatureArg = callee.signature.args[index];
-            if (signatureArg.type !== args[index].kind) {
+            if (signatureArg.type !== ValueKind.Dynamic && signatureArg.type !== args[index].kind) {
                 typeMismatchFound = true;
                 BrsError.make(
                     `Type mismatch in '${functionName}': argument '${signatureArg.name}' must be ` +

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -41,7 +41,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
      * Creates a new Interpreter, including any global properties and functions.
      * @param outputStreams the WriteStreams to use for `stdout` and `stderr`.
      */
-    constructor(outputStreams: OutputStreams) {
+    constructor(outputStreams: OutputStreams = process) {
         this.stdout = outputStreams.stdout;
         this.stderr = outputStreams.stderr;
 

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -68,20 +68,21 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     }
 
     visitPrint(statement: Stmt.Print): Stmt.Result {
-        let output = statement.expressions.map(printable => {
-            switch (printable) {
-                case Stmt.PrintSeparator.Comma:
-                    // TODO: Figure out a good way to limit this to 16-char increments
-                    return " ".repeat(16);
-                case Stmt.PrintSeparator.Semicolon:
-                    return " ";
-                default:
-                    let result = this.evaluate(printable);
-                    return stringify(result);
-            }
-        }).join("");
+        let output = statement.expressions.reduce(
+            (combined: string, printable: Expr.Expression | Stmt.PrintSeparator) => {
+                switch (printable) {
+                    case Stmt.PrintSeparator.Tab:
+                        return combined + " ".repeat(16 - (combined.length % 16));
+                    case Stmt.PrintSeparator.Space:
+                        return combined + " ";
+                    default:
+                        return combined + stringify(this.evaluate(printable));
+                }
+            },
+            ""
+        );
 
-        if (statement.expressions[statement.expressions.length - 1] !== Stmt.PrintSeparator.Semicolon) {
+        if (statement.expressions[statement.expressions.length - 1] !== Stmt.PrintSeparator.Space) {
             output += "\n";
         }
 

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -54,8 +54,26 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     }
 
     visitPrint(statement: Stmt.Print): Stmt.Result {
-        let result = this.evaluate(statement.expression);
-        console.log(stringify(result));
+        for (const printable of statement.expressions) {
+            switch (printable) {
+                case Stmt.PrintSeparator.Comma:
+                    // TODO: Figure out a good way to limit this to 16-char increments
+                    process.stdout.write(" ".repeat(16));
+                    break;
+                case Stmt.PrintSeparator.Semicolon:
+                    process.stdout.write(" ");
+                    break;
+                default:
+                    let result = this.evaluate(printable);
+                    process.stdout.write(stringify(result));
+                    break;
+            }
+        }
+
+        if (statement.expressions[statement.expressions.length - 1] !== Stmt.PrintSeparator.Semicolon) {
+            process.stdout.write("\n");
+        }
+
         return {
             value: BrsInvalid.Instance,
             reason: Stmt.StopReason.End

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -69,11 +69,17 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
     visitPrint(statement: Stmt.Print): Stmt.Result {
         let output = statement.expressions.reduce(
-            (combined: string, printable: Expr.Expression | Stmt.PrintSeparator) => {
+            (combined: string, printable: Expr.Expression | Stmt.PrintSeparator, index: number) => {
                 switch (printable) {
                     case Stmt.PrintSeparator.Tab:
                         return combined + " ".repeat(16 - (combined.length % 16));
                     case Stmt.PrintSeparator.Space:
+                        if (index === statement.expressions.length - 1) {
+                            // Don't append an extra space for trailing `;` in print lists.
+                            // They're used to suppress trailing newlines in `print` statements
+                            return combined;
+                        }
+
                         return combined + " ";
                     default:
                         return combined + stringify(this.evaluate(printable));

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -89,6 +89,7 @@ function scanToken(): void {
         case "^": addToken(Lexeme.Caret); break;
         case "\\": addToken(Lexeme.Backslash); break;
         case ":": addToken(Lexeme.Colon); break;
+        case ";": addToken(Lexeme.Semicolon); break;
         case "?": addToken(Lexeme.Print); break;
         case "<":
             switch (peek()) {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -34,7 +34,14 @@ export interface Visitor<T> {
     visitWhile(statement: While): Result;
 }
 
+/** A BrightScript statement */
 export interface Statement {
+    /**
+     * Handles the enclosing `Statement` with `visitor`.
+     * @param visitor the `Visitor` that will handle the enclosing `Statement`
+     * @returns a BrightScript value (typically `invalid`) and the reason why
+     *          the statement exited (typically `StopReason.End`)
+     */
     accept <R> (visitor: Visitor<R>): Result;
 }
 
@@ -107,12 +114,26 @@ export class If implements Statement {
     }
 }
 
+/** The set of all accepted `print` statement separators. */
 export enum PrintSeparator {
+    /**
+     * Used to indent the current `print` position to the next
+     * 16-character-width output zone.
+     */
     Tab,
+    /** Used to insert a single whitespace character at the current `print` position. */
     Space
 }
 
+/**
+ * Represents a `print` statement within BrightScript.
+ */
 export class Print implements Statement {
+    /**
+     * Creates a new internal representation of a BrightScript `print` statement.
+     * @param expressions an array of expressions or `PrintSeparator`s to be
+     *                    evaluated and printed.
+     */
     constructor(
         readonly expressions: (Expr.Expression | PrintSeparator)[]
     ) {}

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -108,8 +108,8 @@ export class If implements Statement {
 }
 
 export enum PrintSeparator {
-    Comma,
-    Semicolon
+    Tab,
+    Space
 }
 
 export class Print implements Statement {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -107,9 +107,14 @@ export class If implements Statement {
     }
 }
 
+export enum PrintSeparator {
+    Comma,
+    Semicolon
+}
+
 export class Print implements Statement {
     constructor(
-        readonly expression: Expr.Expression
+        readonly expressions: (Expr.Expression | PrintSeparator)[]
     ) {}
 
     accept<R>(visitor: Visitor<R>): Result {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -219,11 +219,11 @@ function printStatement(...additionalterminators: BlockTerminator[]): Stmt.Print
 
     while (!check(Lexeme.Newline, Lexeme.Colon, ...additionalterminators) && !isAtEnd()) {
         if (match(Lexeme.Semicolon)) {
-            values.push(Stmt.PrintSeparator.Semicolon);
+            values.push(Stmt.PrintSeparator.Space);
         }
 
         if (match(Lexeme.Comma)) {
-            values.push(Stmt.PrintSeparator.Comma);
+            values.push(Stmt.PrintSeparator.Tab);
         }
 
         if (!check(Lexeme.Newline, Lexeme.Colon) && !isAtEnd()) {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -213,12 +213,25 @@ function expressionStatement(...additionalterminators: BlockTerminator[]): Stmt.
     return new Stmt.Expression(expr);
 }
 
-function printStatement(...additionalterminators: BlockTerminator[]): Stmt.Expression {
-    let value = expression();
-    if (!check(...additionalterminators)) {
-        consume("Expected newline or ':' after printed value", Lexeme.Newline, Lexeme.Colon, Lexeme.Eof);
+function printStatement(...additionalterminators: BlockTerminator[]): Stmt.Print {
+    let values: (Expr.Expression | Stmt.PrintSeparator)[] = [];
+    values.push(expression());
+
+    while (!check(Lexeme.Newline, Lexeme.Colon) && !isAtEnd()) {
+        if (match(Lexeme.Semicolon)) {
+            values.push(Stmt.PrintSeparator.Semicolon);
+        }
+
+        if (match(Lexeme.Comma)) {
+            values.push(Stmt.PrintSeparator.Comma);
+        }
+
+        if (!check(Lexeme.Newline, Lexeme.Colon) && !isAtEnd()) {
+            values.push(expression());
+        }
     }
-    return new Stmt.Print(value);
+
+    return new Stmt.Print(values);
 }
 
 /**

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -386,8 +386,7 @@ function primary(): Expression {
             Lexeme.Double,
             Lexeme.String
         ):
-            let p = previous();
-            let lit = new Expr.Literal(p.literal!);
+            let lit = new Expr.Literal(previous().literal!);
             return lit;
         case match(Lexeme.Identifier):
             return new Expr.Variable(previous());
@@ -395,6 +394,9 @@ function primary(): Expression {
             let expr = expression();
             consume("Unmatched '(' - expected ')' after expression", Lexeme.RightParen);
             return new Expr.Grouping(expr);
+        case match(Lexeme.Pos, Lexeme.Tab):
+            let token = Object.assign(previous(), { kind: Lexeme.Identifier });
+            return new Expr.Variable(token);
         default:
             throw ParseError.make(peek(), `Found unexpected token '${peek().text}'`);
     }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -217,7 +217,7 @@ function printStatement(...additionalterminators: BlockTerminator[]): Stmt.Print
     let values: (Expr.Expression | Stmt.PrintSeparator)[] = [];
     values.push(expression());
 
-    while (!check(Lexeme.Newline, Lexeme.Colon) && !isAtEnd()) {
+    while (!check(Lexeme.Newline, Lexeme.Colon, ...additionalterminators) && !isAtEnd()) {
         if (match(Lexeme.Semicolon)) {
             values.push(Stmt.PrintSeparator.Semicolon);
         }
@@ -229,6 +229,10 @@ function printStatement(...additionalterminators: BlockTerminator[]): Stmt.Print
         if (!check(Lexeme.Newline, Lexeme.Colon) && !isAtEnd()) {
             values.push(expression());
         }
+    }
+
+    if (!check(...additionalterminators)) {
+        consume("Expected newline or ':' after printed values", Lexeme.Newline, Lexeme.Colon, Lexeme.Eof);
     }
 
     return new Stmt.Print(values);

--- a/src/stdlib/Print.ts
+++ b/src/stdlib/Print.ts
@@ -1,0 +1,32 @@
+import { Callable, ValueKind, BrsString, Int32 } from "../brsTypes";
+import { Interpreter } from "../interpreter";
+
+export const Tab = new Callable(
+    {
+        name: "Tab",
+        args: [{ name: "position", type: ValueKind.Int32 }]
+    },
+    (interpreter: Interpreter, position: Int32) => {
+        let target = position.getValue();
+        if (target < 0 || target < interpreter.stdout.position()) {
+            return new BrsString("");
+        }
+
+        // TODO: this probably won't handle text wrapping well, but I'm not
+        // sure what the reference implementation does here yet
+        return new BrsString(" ".repeat(target - interpreter.stdout.position()));
+    }
+);
+
+export const Pos = new Callable(
+    {
+        name: "Tab",
+        // `pos` expects an argument and doesn't use it. The refreence
+        // implementation's documentation even says it must be provided but
+        // isn't used: https://sdkdocs.roku.com/display/sdkdoc/Program+Statements#ProgramStatements-PRINTitemlist
+        args: [{ name: "dummy", type: ValueKind.Dynamic }]
+    },
+    (interpreter: Interpreter) => {
+        return new Int32(interpreter.stdout.position());
+    }
+);

--- a/src/stdlib/Print.ts
+++ b/src/stdlib/Print.ts
@@ -1,6 +1,12 @@
 import { Callable, ValueKind, BrsString, Int32 } from "../brsTypes";
 import { Interpreter } from "../interpreter";
 
+/**
+ * Moves the cursor to the specified position on the current line. If the
+ * provided position is greater than the current console width and the output
+ * is a TTY, the resulting position is modulo'd by the current console width.
+ * May be used several times in a `print` list.
+ */
 export const Tab = new Callable(
     {
         name: "Tab",
@@ -18,6 +24,11 @@ export const Tab = new Callable(
     }
 );
 
+/**
+ * Returns a number from 0 to the current console width, indicating the
+ * position of the output cursor. Requires a "dummy argument" of any type, as
+ * it's completely ignored.
+ */
 export const Pos = new Callable(
     {
         name: "Pos",

--- a/src/stdlib/Print.ts
+++ b/src/stdlib/Print.ts
@@ -20,7 +20,7 @@ export const Tab = new Callable(
 
 export const Pos = new Callable(
     {
-        name: "Tab",
+        name: "Pos",
         // `pos` expects an argument and doesn't use it. The refreence
         // implementation's documentation even says it must be provided but
         // isn't used: https://sdkdocs.roku.com/display/sdkdoc/Program+Statements#ProgramStatements-PRINTitemlist

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -18,4 +18,6 @@ export const RebootSystem = new Callable(
     },
     rebootSystemImpl
 );
+
 export * from "./String";
+export * from "./Print";

--- a/test/e2e/E2ETests.js
+++ b/test/e2e/E2ETests.js
@@ -13,8 +13,6 @@ exports.resourceFile = function(filename) {
  */
 exports.allArgs = function(jestMock) {
     return jestMock.mock.calls
-            // remove trailing newlines from final argument
-            .map(args => args.map((a, i) => i + 1=== args.length ? a.replace(/\n$/, "") : a))
             // flatten arguments to `stdout.write` into a single array
             .reduce((allArgs, thisCall) => allArgs.concat(thisCall), []);
 }

--- a/test/e2e/E2ETests.js
+++ b/test/e2e/E2ETests.js
@@ -21,10 +21,10 @@ exports.allArgs = function(jestMock) {
 
 /** Creates a set of mocked streams, suitable for use in place of `process.stdout` and `process.stderr`. */
 exports.createMockStreams = function() {
-    const stdout = new stream.PassThrough();
-    const stderr = new stream.PassThrough();
-    jest.spyOn(stdout, "write");
-    jest.spyOn(stderr, "write");
+    const stdout = Object.assign(new stream.PassThrough(), process.stdout);
+    const stderr = Object.assign(new stream.PassThrough(), process.stderr);
+    jest.spyOn(stdout, "write").mockImplementation(() => {});
+    jest.spyOn(stderr, "write").mockImplementation(() => {});
 
     return { stdout, stderr };
 }

--- a/test/e2e/E2ETests.js
+++ b/test/e2e/E2ETests.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const stream = require("stream");
 
 /** Returns the path to a file in `resources/`. */
 exports.resourceFile = function(filename) {
@@ -11,5 +12,19 @@ exports.resourceFile = function(filename) {
  * @returns an array containing every argument from every call to a Jest mock.
  */
 exports.allArgs = function(jestMock) {
-    return jestMock.mock.calls.reduce((allArgs, thisCall) => allArgs.concat(thisCall), []);
+    return jestMock.mock.calls
+            // remove trailing newlines from final argument
+            .map(args => args.map((a, i) => i + 1=== args.length ? a.replace(/\n$/, "") : a))
+            // flatten arguments to `stdout.write` into a single array
+            .reduce((allArgs, thisCall) => allArgs.concat(thisCall), []);
+}
+
+/** Creates a set of mocked streams, suitable for use in place of `process.stdout` and `process.stderr`. */
+exports.createMockStreams = function() {
+    const stdout = new stream.PassThrough();
+    const stderr = new stream.PassThrough();
+    jest.spyOn(stdout, "write");
+    jest.spyOn(stderr, "write");
+
+    return { stdout, stderr };
 }

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -22,7 +22,9 @@ describe("end to end standard libary", () => {
 
     test("stdlib/strings.brs", () => {
         return execute(resourceFile(path.join("stdlib", "strings.brs")), outputStreams).then(() => {
-            expect(allArgs(outputStreams.stdout.write)).toEqual([
+            expect(
+                allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")
+            ).toEqual([
                 "MIXED CASE",
                 "mixed case",
                 "12359",

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -3,22 +3,26 @@ const path = require("path");
 const { execute } = require("../../lib/");
 const BrsError = require("../../lib/Error");
 
-const { resourceFile, allArgs } = require("./E2ETests");
+const { createMockStreams, resourceFile, allArgs } = require("./E2ETests");
 
 describe("end to end standard libary", () => {
-    let stdout;
+    let outputStreams;
 
     beforeAll(() => {
-        stdout = jest.spyOn(console, "log").mockImplementation(() => {});
+        outputStreams = createMockStreams();
     });
 
-    afterEach(() => stdout.mockReset());
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
 
-    afterAll(() => stdout.mockRestore());
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
 
     test("stdlib/strings.brs", () => {
-        return execute(resourceFile(path.join("stdlib", "strings.brs"))).then(() => {
-            expect(allArgs(stdout)).toEqual([
+        return execute(resourceFile(path.join("stdlib", "strings.brs")), outputStreams).then(() => {
+            expect(allArgs(outputStreams.stdout.write)).toEqual([
                 "MIXED CASE",
                 "mixed case",
                 "12359",

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -1,28 +1,33 @@
+const fs = require("fs");
 const { execute } = require("../../lib/");
 const BrsError = require("../../lib/Error");
 
-const { resourceFile, allArgs } = require("./E2ETests");
+const { createMockStreams, resourceFile, allArgs } = require("./E2ETests");
 
 describe("end to end syntax", () => {
-    let stdout;
+    let outputStreams;
 
     beforeAll(() => {
-        stdout = jest.spyOn(console, "log").mockImplementation(() => {});
+        outputStreams = createMockStreams();
     });
 
-    afterEach(() => stdout.mockReset());
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
 
-    afterAll(() => stdout.mockRestore());
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
 
     test("comments.brs", () => {
-        return execute(resourceFile("comments.brs")).then(() => {
-            expect(stdout).not.toBeCalled();
+        return execute(resourceFile("comments.brs"), outputStreams).then(() => {
+            expect(outputStreams.stdout.write).not.toBeCalled();
         });
     });
 
     test("printLiterals.brs", () => {
-        return execute(resourceFile("printLiterals.brs")).then(() => {
-            expect(allArgs(stdout)).toEqual([
+        return execute(resourceFile("printLiterals.brs"), outputStreams).then(() => {
+            expect(allArgs(outputStreams.stdout.write)).toEqual([
                 "invalid",
                 "true",
                 "false",
@@ -36,8 +41,8 @@ describe("end to end syntax", () => {
     });
 
     test("arithmetic.brs", () => {
-        return execute(resourceFile("arithmetic.brs")).then(() => {
-            expect(allArgs(stdout)).toEqual([
+        return execute(resourceFile("arithmetic.brs"), outputStreams).then(() => {
+            expect(allArgs(outputStreams.stdout.write)).toEqual([
                 "3", "3", "3", "3",       // addition
                 "5", "5", "5", "5",       // subtraction
                 "15", "15", "15", "15",   // multiplication
@@ -48,24 +53,24 @@ describe("end to end syntax", () => {
     });
 
     test("assignment.brs", () => {
-        return execute(resourceFile("assignment.brs")).then(() => {
-            expect(allArgs(stdout)).toEqual([
+        return execute(resourceFile("assignment.brs"), outputStreams).then(() => {
+            expect(allArgs(outputStreams.stdout.write)).toEqual([
                 "new value"
             ]);
         });
     });
 
     test("conditionals.brs", () => {
-        return execute(resourceFile("conditionals.brs")).then(() => {
-            expect(allArgs(stdout)).toEqual([
+        return execute(resourceFile("conditionals.brs"), outputStreams).then(() => {
+            expect(allArgs(outputStreams.stdout.write)).toEqual([
                 "1", "2", "3", "4", "5", "6"
             ]);
         });
     });
 
     test("while-loops.brs", () => {
-        return execute(resourceFile("while-loops.brs")).then(() => {
-            expect(allArgs(stdout)).toEqual([
+        return execute(resourceFile("while-loops.brs"), outputStreams).then(() => {
+            expect(allArgs(outputStreams.stdout.write)).toEqual([
                 "0", "1", "2", "3", "4", // count up
                 "5", "4"                 // count down with exit
             ]);
@@ -73,8 +78,8 @@ describe("end to end syntax", () => {
     });
 
     test("for-loops.brs", () => {
-        return execute(resourceFile("for-loops.brs")).then(() => {
-            expect(allArgs(stdout)).toEqual([
+        return execute(resourceFile("for-loops.brs"), outputStreams).then(() => {
+            expect(allArgs(outputStreams.stdout.write)).toEqual([
                 "0", "2", "4", "6", // count up
                 "8",                // i after loop
                 "3", "2", "1", "0", // count down

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -27,7 +27,9 @@ describe("end to end syntax", () => {
 
     test("printLiterals.brs", () => {
         return execute(resourceFile("printLiterals.brs"), outputStreams).then(() => {
-            expect(allArgs(outputStreams.stdout.write)).toEqual([
+            expect(
+                allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")
+            ).toEqual([
                 "invalid",
                 "true",
                 "false",
@@ -42,7 +44,9 @@ describe("end to end syntax", () => {
 
     test("arithmetic.brs", () => {
         return execute(resourceFile("arithmetic.brs"), outputStreams).then(() => {
-            expect(allArgs(outputStreams.stdout.write)).toEqual([
+            expect(
+                allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")
+            ).toEqual([
                 "3", "3", "3", "3",       // addition
                 "5", "5", "5", "5",       // subtraction
                 "15", "15", "15", "15",   // multiplication
@@ -54,7 +58,9 @@ describe("end to end syntax", () => {
 
     test("assignment.brs", () => {
         return execute(resourceFile("assignment.brs"), outputStreams).then(() => {
-            expect(allArgs(outputStreams.stdout.write)).toEqual([
+            expect(
+                allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")
+            ).toEqual([
                 "new value"
             ]);
         });
@@ -62,7 +68,9 @@ describe("end to end syntax", () => {
 
     test("conditionals.brs", () => {
         return execute(resourceFile("conditionals.brs"), outputStreams).then(() => {
-            expect(allArgs(outputStreams.stdout.write)).toEqual([
+            expect(
+                allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")
+            ).toEqual([
                 "1", "2", "3", "4", "5", "6"
             ]);
         });
@@ -70,7 +78,9 @@ describe("end to end syntax", () => {
 
     test("while-loops.brs", () => {
         return execute(resourceFile("while-loops.brs"), outputStreams).then(() => {
-            expect(allArgs(outputStreams.stdout.write)).toEqual([
+            expect(
+                allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")
+            ).toEqual([
                 "0", "1", "2", "3", "4", // count up
                 "5", "4"                 // count down with exit
             ]);
@@ -79,7 +89,9 @@ describe("end to end syntax", () => {
 
     test("for-loops.brs", () => {
         return execute(resourceFile("for-loops.brs"), outputStreams).then(() => {
-            expect(allArgs(outputStreams.stdout.write)).toEqual([
+            expect(
+                allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")
+            ).toEqual([
                 "0", "2", "4", "6", // count up
                 "8",                // i after loop
                 "3", "2", "1", "0", // count down

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -101,4 +101,22 @@ describe("end to end syntax", () => {
             ]);
         });
     });
+
+    test("print.brs", () => {
+        return execute(resourceFile("print.brs"), outputStreams).then(() => {
+            expect(allArgs(outputStreams.stdout.write).join("")).toEqual(
+                "lorem 1psum\n" +
+                "9  is equal to 9\n" +
+            //   0   0   0   1   1   2   2   2   3   3   4   4   4   5   5
+            //   0   4   8   2   6   0   4   8   2   6   0   4   8   2   6
+                "column a        column b        column c        column d\n" +
+            //   0   0   0   1   1   2   2   2   3   3   4   4   4   5   5
+            //   0   4   8   2   6   0   4   8   2   6   0   4   8   2   6
+                "   I started at col 3    I started at col 25\n" +
+                "01234\n" +
+                "lorem    ipsum    dolor    sit    amet\n" +
+                "no newline"
+            );
+        });
+    });
 });

--- a/test/e2e/TypeChecking.test.js
+++ b/test/e2e/TypeChecking.test.js
@@ -3,10 +3,10 @@ const path = require("path");
 const { execute } = require("../../lib/");
 const BrsError = require("../../lib/Error");
 
-const { resourceFile, allArgs } = require("./E2ETests");
+const { createMockStreams, resourceFile, allArgs } = require("./E2ETests");
 
 describe("function argument type checking", () => {
-    let stderr;
+    let outputStreams;
     let originalNodeEnv;
 
     beforeAll(() => {
@@ -15,6 +15,7 @@ describe("function argument type checking", () => {
         process.env.NODE_ENV = "jest";
         // but make console.error empty so we don't clutter test output
         stderr = jest.spyOn(console, "error").mockImplementation(() => {});
+        outputStreams = createMockStreams();
     });
 
     afterEach(() => {
@@ -28,21 +29,21 @@ describe("function argument type checking", () => {
     });
 
     it("errors when too few args are passed", () => {
-        return execute(resourceFile(path.join("type-checking", "too-few-args.brs"))).catch(() => {
+        return execute(resourceFile(path.join("type-checking", "too-few-args.brs")), outputStreams).catch(() => {
             const output = allArgs(stderr);
             expect(output[0]).toMatch(/\[Line .\] 'UCase' requires at least 1 arguments, but received 0\./);
         });
     });
 
     it("errors when too many args are passed", () => {
-        return execute(resourceFile(path.join("type-checking", "too-many-args.brs"))).catch(() => {
+        return execute(resourceFile(path.join("type-checking", "too-many-args.brs")), outputStreams).catch(() => {
             const output = allArgs(stderr);
             expect(output[0]).toMatch(/\[Line .\] 'RebootSystem' accepts at most 0 arguments, but received 1\./);
         });
     });
 
     it("errors when mismatched types are provided", () => {
-        return execute(resourceFile(path.join("type-checking", "arg-type-mismatch.brs"))).catch(() => {
+        return execute(resourceFile(path.join("type-checking", "arg-type-mismatch.brs")), outputStreams).catch(() => {
             const output = allArgs(stderr);
             expect(output[0]).toMatch(
                 /\[Line .\] Type mismatch in 'LCase': argument 's' must be of type String, but received Boolean./

--- a/test/e2e/resources/print.brs
+++ b/test/e2e/resources/print.brs
@@ -1,0 +1,21 @@
+' All examples inspired by Roku documentation:
+' https://sdkdocs.roku.com/display/sdkdoc/Program+Statements#ProgramStatements-PRINTitemlist
+
+' no separators
+print "lorem " 1 "psum"
+
+' arbitrary mixes of separators
+print 9; " is equal to"; 3^2
+print "column a", "column b", "column c", "column d"
+
+' arbitrary tabbing
+print tab(3) "I started at col 3"; tab(25) "I started at col 25"
+
+' print position
+print "0123" pos(0)
+
+' calculate tabs based on position, though you'd probably want to just define "    " as a variable
+print "lorem" tab(pos(0) + 4) "ipsum" tab(pos(0) + 4) "dolor" tab(pos(0) + 4) "sit" tab(pos(0) + 4) "amet"
+
+' suppress trailing newline
+print "no newline";

--- a/test/interpreter/PrintStatements.test.js
+++ b/test/interpreter/PrintStatements.test.js
@@ -78,4 +78,20 @@ describe("interperter print statements", () => {
             "foo             barbara         baz\n"
         ]);
     });
+
+    it("skips cursor-return with a trailing semicolon", () => {
+        const ast = new Stmt.Print([
+            new Expr.Literal(new BrsString("foo")),
+            Stmt.PrintSeparator.Space,
+            new Expr.Literal(new BrsString("bar")),
+            Stmt.PrintSeparator.Space,
+            new Expr.Literal(new BrsString("baz")),
+            Stmt.PrintSeparator.Space,
+        ]);
+
+        const [ result ] = interpreter.exec([ast]);
+        expect(result.value).toEqual(BrsInvalid.Instance);
+        expect(stdout.write).toHaveBeenCalledTimes(1);
+        expect(stdout.write).toHaveBeenCalledWith("foo bar baz");
+    });
 });

--- a/test/interpreter/PrintStatements.test.js
+++ b/test/interpreter/PrintStatements.test.js
@@ -98,4 +98,40 @@ describe("interperter print statements", () => {
             "foo bar baz"
         );
     });
+
+    it("inserts the current position via `pos`", () => {
+        const ast = new Stmt.Print([
+            new Expr.Literal(new BrsString("foo")),
+            Stmt.PrintSeparator.Space,
+            new Expr.Call(
+                new Expr.Variable(identifier("Pos")),
+                { kind: Lexeme.RightParen, text: ")", line: 1 },
+                [ new Expr.Literal(new Int32(0)) ]
+            )
+        ]);
+
+        const [ result ] = interpreter.exec([ast]);
+        expect(result.value).toEqual(BrsInvalid.Instance);
+        expect(allArgs(stdout.write).join("")).toEqual(
+            "foo 4\n"
+        );
+    });
+
+    it("indents to an arbitrary position via `tab`", () => {
+        const ast = new Stmt.Print([
+            new Expr.Literal(new BrsString("foo")),
+            new Expr.Call(
+                new Expr.Variable(identifier("Tab")),
+                { kind: Lexeme.RightParen, text: ")", line: 1 },
+                [ new Expr.Literal(new Int32(6)) ]
+            ),
+            new Expr.Literal(new BrsString("bar"))
+        ]);
+
+        const [ result ] = interpreter.exec([ast]);
+        expect(result.value).toEqual(BrsInvalid.Instance);
+        expect(allArgs(stdout.write).join("")).toEqual(
+            "foo   bar\n"
+        );
+    });
 });

--- a/test/interpreter/PrintStatements.test.js
+++ b/test/interpreter/PrintStatements.test.js
@@ -6,7 +6,7 @@ const { Lexeme } = require("../../lib/Lexeme");
 const { Interpreter } = require("../../lib/interpreter");
 const { Int32, BrsString, BrsInvalid } = require("../../lib/brsTypes");
 
-const { createMockStreams } = require("../e2e/E2ETests");
+const { createMockStreams, allArgs } = require("../e2e/E2ETests");
 
 describe("interperter print statements", () => {
     let stdout, stderr, interpreter;
@@ -28,8 +28,9 @@ describe("interperter print statements", () => {
 
         const [ result ] = interpreter.exec([ast]);
         expect(result.value).toEqual(BrsInvalid.Instance);
-        expect(stdout.write).toHaveBeenCalledTimes(1);
-        expect(stdout.write).toHaveBeenCalledWith("foo\n");
+        expect(allArgs(stdout.write).join("")).toEqual(
+            "foo\n"
+        );
     });
 
     it("prints multiple values with no separators", () => {
@@ -41,8 +42,9 @@ describe("interperter print statements", () => {
 
         const [ result ] = interpreter.exec([ast]);
         expect(result.value).toEqual(BrsInvalid.Instance);
-        expect(stdout.write).toHaveBeenCalledTimes(1);
-        expect(stdout.write).toHaveBeenCalledWith("foobarbaz\n");
+        expect(allArgs(stdout.write).join("")).toEqual(
+            "foobarbaz\n"
+        );
     });
 
     it("prints multiple values with space separators", () => {
@@ -52,12 +54,14 @@ describe("interperter print statements", () => {
             new Expr.Literal(new BrsString("bar")),
             Stmt.PrintSeparator.Space,
             new Expr.Literal(new BrsString("baz")),
+
         ]);
 
         const [ result ] = interpreter.exec([ast]);
         expect(result.value).toEqual(BrsInvalid.Instance);
-        expect(stdout.write).toHaveBeenCalledTimes(1);
-        expect(stdout.write).toHaveBeenCalledWith("foo bar baz\n");
+        expect(allArgs(stdout.write).join("")).toEqual(
+            "foo bar baz\n"
+        );
     });
 
     it("aligns values to 16-charcater tab stops", () => {
@@ -71,12 +75,11 @@ describe("interperter print statements", () => {
 
         const [ result ] = interpreter.exec([ast]);
         expect(result.value).toEqual(BrsInvalid.Instance);
-        expect(stdout.write).toHaveBeenCalledTimes(1);
-        expect(stdout.write.mock.calls[0]).toEqual([
+        expect(allArgs(stdout.write).join("")).toEqual(
         //   0   0   0   1   1   2   2   2   3
         //   0   4   8   2   6   0   4   8   2
             "foo             barbara         baz\n"
-        ]);
+        );
     });
 
     it("skips cursor-return with a trailing semicolon", () => {
@@ -91,7 +94,8 @@ describe("interperter print statements", () => {
 
         const [ result ] = interpreter.exec([ast]);
         expect(result.value).toEqual(BrsInvalid.Instance);
-        expect(stdout.write).toHaveBeenCalledTimes(1);
-        expect(stdout.write).toHaveBeenCalledWith("foo bar baz");
+        expect(allArgs(stdout.write).join("")).toEqual(
+            "foo bar baz"
+        );
     });
 });

--- a/test/interpreter/PrintStatements.test.js
+++ b/test/interpreter/PrintStatements.test.js
@@ -1,0 +1,81 @@
+const BrsError = require("../../lib/Error");
+const Expr = require("../../lib/parser/Expression");
+const Stmt = require("../../lib/parser/Statement");
+const { identifier, token } = require("../parser/ParserTests");
+const { Lexeme } = require("../../lib/Lexeme");
+const { Interpreter } = require("../../lib/interpreter");
+const { Int32, BrsString, BrsInvalid } = require("../../lib/brsTypes");
+
+const { createMockStreams } = require("../e2e/E2ETests");
+
+describe("interperter print statements", () => {
+    let stdout, stderr, interpreter;
+
+    beforeEach(() => {
+        BrsError.reset();
+        const outputStreams = createMockStreams();
+        interpreter = new Interpreter(outputStreams);
+
+        stdout = outputStreams.stdout;
+        stderr = outputStreams.stderr;
+    });
+
+    it("prints single values on their own line", () => {
+        const ast = new Stmt.Print([
+            new Expr.Literal(new BrsString("foo"))
+        ]);
+
+
+        const [ result ] = interpreter.exec([ast]);
+        expect(result.value).toEqual(BrsInvalid.Instance);
+        expect(stdout.write).toHaveBeenCalledTimes(1);
+        expect(stdout.write).toHaveBeenCalledWith("foo\n");
+    });
+
+    it("prints multiple values with no separators", () => {
+        const ast = new Stmt.Print([
+            new Expr.Literal(new BrsString("foo")),
+            new Expr.Literal(new BrsString("bar")),
+            new Expr.Literal(new BrsString("baz")),
+        ]);
+
+        const [ result ] = interpreter.exec([ast]);
+        expect(result.value).toEqual(BrsInvalid.Instance);
+        expect(stdout.write).toHaveBeenCalledTimes(1);
+        expect(stdout.write).toHaveBeenCalledWith("foobarbaz\n");
+    });
+
+    it("prints multiple values with space separators", () => {
+        const ast = new Stmt.Print([
+            new Expr.Literal(new BrsString("foo")),
+            Stmt.PrintSeparator.Space,
+            new Expr.Literal(new BrsString("bar")),
+            Stmt.PrintSeparator.Space,
+            new Expr.Literal(new BrsString("baz")),
+        ]);
+
+        const [ result ] = interpreter.exec([ast]);
+        expect(result.value).toEqual(BrsInvalid.Instance);
+        expect(stdout.write).toHaveBeenCalledTimes(1);
+        expect(stdout.write).toHaveBeenCalledWith("foo bar baz\n");
+    });
+
+    it("aligns values to 16-charcater tab stops", () => {
+        const ast = new Stmt.Print([
+            new Expr.Literal(new BrsString("foo")),
+            Stmt.PrintSeparator.Tab,
+            new Expr.Literal(new BrsString("barbara")),
+            Stmt.PrintSeparator.Tab,
+            new Expr.Literal(new BrsString("baz")),
+        ]);
+
+        const [ result ] = interpreter.exec([ast]);
+        expect(result.value).toEqual(BrsInvalid.Instance);
+        expect(stdout.write).toHaveBeenCalledTimes(1);
+        expect(stdout.write.mock.calls[0]).toEqual([
+        //   0   0   0   1   1   2   2   2   3
+        //   0   4   8   2   6   0   4   8   2
+            "foo             barbara         baz\n"
+        ]);
+    });
+});

--- a/test/parser/controlFlow/__snapshots__/While.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/While.test.js.snap
@@ -6,12 +6,14 @@ Array [
     "body": Block {
       "statements": Array [
         Print {
-          "expression": Literal {
-            "value": BrsString {
-              "kind": 2,
-              "value": "looping",
+          "expressions": Array [
+            Literal {
+              "value": BrsString {
+                "kind": 2,
+                "value": "looping",
+              },
             },
-          },
+          ],
         },
         ExitWhile {},
       ],
@@ -32,12 +34,14 @@ Array [
     "body": Block {
       "statements": Array [
         Print {
-          "expression": Literal {
-            "value": BrsString {
-              "kind": 2,
-              "value": "looping",
+          "expressions": Array [
+            Literal {
+              "value": BrsString {
+                "kind": 2,
+                "value": "looping",
+              },
             },
-          },
+          ],
         },
       ],
     },

--- a/test/parser/statement/PrintStatements.test.js
+++ b/test/parser/statement/PrintStatements.test.js
@@ -8,10 +8,40 @@ describe("parser", () => {
     afterEach(() => BrsError.reset());
 
     describe("print statements", () => {
-        it("parses print statements", () => {
+        it("parses singular print statements", () => {
             let parsed = Parser.parse([
                 token(Lexeme.Print),
                 token(Lexeme.String, "Hello, world"),
+                EOF
+            ]);
+
+            expect(parsed).toBeDefined();
+            expect(parsed).not.toBeNull();
+            expect(parsed).toMatchSnapshot();
+        });
+
+        it("parses print lists with no separator", () => {
+            let parsed = Parser.parse([
+                token(Lexeme.Print),
+                token(Lexeme.String, "Foo"),
+                token(Lexeme.String, "bar"),
+                token(Lexeme.String, "baz"),
+                EOF
+            ]);
+
+            expect(parsed).toBeDefined();
+            expect(parsed).not.toBeNull();
+            expect(parsed).toMatchSnapshot();
+        });
+
+        it("parses print lists with separators", () => {
+            let parsed = Parser.parse([
+                token(Lexeme.Print),
+                token(Lexeme.String, "Foo"),
+                token(Lexeme.Semicolon),
+                token(Lexeme.String, "bar"),
+                token(Lexeme.Comma),
+                token(Lexeme.String, "baz"),
                 EOF
             ]);
 

--- a/test/parser/statement/__snapshots__/PrintStatements.test.js.snap
+++ b/test/parser/statement/__snapshots__/PrintStatements.test.js.snap
@@ -3,9 +3,11 @@
 exports[`parser print statements parses print statements 1`] = `
 Array [
   Print {
-    "expression": Literal {
-      "value": "Hello, world",
-    },
+    "expressions": Array [
+      Literal {
+        "value": "Hello, world",
+      },
+    ],
   },
 ]
 `;

--- a/test/parser/statement/__snapshots__/PrintStatements.test.js.snap
+++ b/test/parser/statement/__snapshots__/PrintStatements.test.js.snap
@@ -1,6 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`parser print statements parses print statements 1`] = `
+exports[`parser print statements parses print lists with no separator 1`] = `
+Array [
+  Print {
+    "expressions": Array [
+      Literal {
+        "value": "Foo",
+      },
+      Literal {
+        "value": "bar",
+      },
+      Literal {
+        "value": "baz",
+      },
+    ],
+  },
+]
+`;
+
+exports[`parser print statements parses print lists with separators 1`] = `
+Array [
+  Print {
+    "expressions": Array [
+      Literal {
+        "value": "Foo",
+      },
+      1,
+      Literal {
+        "value": "bar",
+      },
+      0,
+      Literal {
+        "value": "baz",
+      },
+    ],
+  },
+]
+`;
+
+exports[`parser print statements parses singular print statements 1`] = `
 Array [
   Print {
     "expressions": Array [

--- a/test/stdlib/Print.test.js
+++ b/test/stdlib/Print.test.js
@@ -1,0 +1,57 @@
+const { Pos, Tab } = require("../../lib/stdlib/index");
+const { Interpreter } = require("../../lib/interpreter");
+const { BrsString, BrsBoolean, Int32 } = require("../../lib/brsTypes");
+
+const { createMockStreams } = require("../e2e/E2ETests");
+
+
+describe("print utility functions", () => {
+    let interpreter;
+
+    beforeEach(() => {
+        interpreter = new Interpreter(createMockStreams());
+    });
+
+    describe("Pos", () => {
+        it("returns the current output cursor position", () => {
+            interpreter.stdout.write("ends in a newline so doesn't affect pos\n");
+            interpreter.stdout.write("lorem");
+
+            expect(
+                Pos.call(interpreter, new Int32(0))
+            ).toEqual(new Int32(5));
+        });
+
+        it("handles multi-line output correctly", () => {
+            interpreter.stdout.write("foo\nbar\nbaz");
+
+            expect(
+                Pos.call(interpreter, new Int32(0))
+            ).toEqual(new Int32(3));
+        });
+    });
+
+    describe("Tab", () => {
+        it("ignores indentations", () => {
+            expect(
+                Tab.call(interpreter, new Int32(-33))
+            ).toEqual(new BrsString(""));
+        });
+
+        it("ignores intendations less than current `pos`", () => {
+            interpreter.stdout.write("lorem ipsum dolor sit amet");
+
+            expect(
+                Tab.call(interpreter, new Int32(8))
+            ).toEqual(new BrsString(""));
+        });
+
+        it("provides whitespace to indent to the desired column", () => {
+            interpreter.stdout.write("lorem");
+
+            expect(
+                Tab.call(interpreter, new Int32(8))
+            ).toEqual(new BrsString("   "));
+        });
+    });
+});

--- a/test/stdlib/String.test.js
+++ b/test/stdlib/String.test.js
@@ -7,7 +7,6 @@ const interpreter = new Interpreter();
 describe("global string functions", () => {
     describe("UCase", () => {
         it("converts a BRS string to its uppercase form", () => {
-            const upperCase =
             expect(
                 UCase.call(interpreter, new BrsString("l0rEm"))
             ).toEqual(new BrsString("L0REM"));
@@ -16,7 +15,6 @@ describe("global string functions", () => {
 
     describe("LCase", () => {
         it("converts a BRS string to its lowercase form", () => {
-            const lowercase =
             expect(
                 LCase.call(interpreter, new BrsString("l0rEm"))
             ).toEqual(new BrsString("l0rem"));


### PR DESCRIPTION
Roku's BrightScript [supports printing multiple things with one `print` statement](https://sdkdocs.roku.com/display/sdkdoc/Program+Statements#ProgramStatements-PRINTitemlist), so we should too!  This was surprisingly more difficult than I expected, but a pretty big part of that was making it possible to spy on output without messing with `process.stdout.write`.

Merging this PR will result in the following file being valid according to `brs`:

```brightscript
' All examples inspired by Roku documentation:
' https://sdkdocs.roku.com/display/sdkdoc/Program+Statements#ProgramStatements-PRINTitemlist

' no separators
print "lorem " 1 "psum"

' arbitrary mixes of separators
print 9; " is equal to"; 3^2
print "column a", "column b", "column c", "column d"

' arbitrary tabbing
print tab(3) "I started at col 3"; tab(25) "I started at col 25"

' print position
print "0123" pos(0)

' calculate tabs based on position, though you'd probably want to just define "    " as a variable
print "lorem" tab(pos(0) + 4) "ipsum" tab(pos(0) + 4) "dolor" tab(pos(0) + 4) "sit" tab(pos(0) + 4) "amet"

' suppress trailing newline
print "no newline";
```