### PR TITLE
finishing implementation of Val int conversion

### DIFF
--- a/src/stdlib/String.ts
+++ b/src/stdlib/String.ts
@@ -1,6 +1,7 @@
 import { BrsType, Callable, ValueKind, BrsString, Int32, Float } from "../brsTypes";
 import * as Expr from "../parser/Expression";
 import { Interpreter } from "../interpreter";
+import { BrsNumber } from "../brsTypes/BrsNumber";
 
 /** Converts the string to all uppercase. */
 export const UCase = new Callable(
@@ -205,7 +206,7 @@ export const StrI = new Callable(
                     type: ValueKind.Int32
                 },
                 {
-                    name: "radis",
+                    name: "radix",
                     type: ValueKind.Int32,
                     defaultValue: new Expr.Literal(new Int32(10))
                 }
@@ -233,11 +234,30 @@ export const Val = new Callable(
     "Val",
     {
         signature: {
-            args: [{name: "s", type: ValueKind.String}],
-            returns: ValueKind.Float
+            args: [
+                {
+                    name: "s", 
+                    type: ValueKind.String
+                },
+                {
+                    name: "radix",
+                    type: ValueKind.Int32,
+                    defaultValue: new Expr.Literal(new Int32(10))
+                }
+            ],
+            returns: ValueKind.Dynamic
         },
-        impl: (interpreter: Interpreter, s: BrsString): Float => {
-            return new Float(Number(s.value));
+        impl: (interpreter: Interpreter, s: BrsString, brsRadix: Int32): BrsNumber => {
+            console.log(brsRadix);
+            function isBrsStrFloat(str: BrsString): boolean {
+                return str.value.includes(".");
+            }
+
+            if (isBrsStrFloat(s)) {
+                return new Float(Number(s.value));
+            } else {
+                return new Int32(parseInt(s.value, brsRadix.getValue()));
+            }
         }
     },
 );

--- a/src/stdlib/String.ts
+++ b/src/stdlib/String.ts
@@ -248,7 +248,6 @@ export const Val = new Callable(
             returns: ValueKind.Dynamic
         },
         impl: (interpreter: Interpreter, s: BrsString, brsRadix: Int32): BrsNumber => {
-            console.log(brsRadix);
             function isBrsStrFloat(str: BrsString): boolean {
                 return str.value.includes(".");
             }

--- a/test/stdlib/String.test.js
+++ b/test/stdlib/String.test.js
@@ -231,5 +231,23 @@ describe("global string functions", () => {
                 Val.call(interpreter, new BrsString("0.0"))
             ).toEqual(new Float(0.0));
         })
+
+        it("returns an integer from a string an radix", () => {
+            expect(
+                Val.call(interpreter, new BrsString("7"), new Int32(10))
+            ).toEqual(new Int32(7));
+
+            expect(
+                Val.call(interpreter, new BrsString("0x80"), new Int32(0))
+            ).toEqual(new Int32(128));
+
+            expect(
+                Val.call(interpreter, new BrsString("FF"), new Int32(16))
+            ).toEqual(new Int32(255));
+
+            expect(
+                Val.call(interpreter, new BrsString("1001"), new Int32(2))
+            ).toEqual(new Int32(9));
+        })
     });
 });


### PR DESCRIPTION
Most of issue #50 has been resolved, but the Val implementation didn't support int conversion.  This is much easier with the default parameter support.  The radix support was extremely simple, because it's handled in much the same way as javascript's parseInt().  For tests I included the examples from the Roku docs as well as the base-10 case.  

NOTE: I have a really cheesy way to detect if a string is a float just be checking for a decimal place.  Open to other ideas.  

Closes #50.  