### PR TITLE
implements file reads/writes using memfs library (#88)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   ],
   "dependencies": {
     "commander": "^2.12.2",
-    "long": "^3.2.0"
+    "long": "^3.2.0",
+    "memfs": "2.13.1"
   },
   "devDependencies": {
     "@types/jest": "^22.0.0",

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -30,6 +30,7 @@ import { OutputProxy } from "./OutputProxy";
 import { toCallable } from "./BrsFunction";
 import { BlockEnd, StopReason } from "../parser/Statement";
 import { AssociativeArray } from "../brsTypes/components/AssociativeArray";
+import { Volume } from "memfs/lib/volume";
 
 export interface OutputStreams {
     stdout: NodeJS.WriteStream,
@@ -38,8 +39,10 @@ export interface OutputStreams {
 
 export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType> {
     private _environment = new Environment();
+    
     readonly stdout: OutputProxy;
     readonly stderr: OutputProxy;
+    readonly temporaryVolume = new Volume();
 
     get environment() {
         return this._environment;
@@ -94,7 +97,9 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             { name: "Csng",         func: StdLib.Csng },
             { name: "Fix",          func: StdLib.Fix },
             { name: "Int",          func: StdLib.Int },
-            { name: "Sgn",          func: StdLib.Sgn }
+            { name: "Sgn",          func: StdLib.Sgn },
+            { name: "ReadAsciiFile", func: StdLib.ReadAsciiFile },
+            { name: "WriteAsciiFile", func: StdLib.WriteAsciiFile }
         ].forEach(({name, func}) =>
             this._environment.define(Scope.Global, name, func)
         );

--- a/src/stdlib/File.ts
+++ b/src/stdlib/File.ts
@@ -1,0 +1,87 @@
+import { Callable, ValueKind, BrsString, BrsBoolean } from "../brsTypes";
+import { Interpreter } from "../interpreter";
+import { Volume } from "memfs/lib/volume";
+
+/* Returns the brs-path uri scheme or an empty string if not found */
+export function parseVolumeName(path: string): string {
+    const volumeRegex = new RegExp("^([a-z]+):");
+    const volumePrefix = path.match(volumeRegex);
+    if (volumePrefix !== null) {
+        return volumePrefix[1];
+    } else {
+        return "";
+    }
+}
+
+/*
+ * Returns a memfs volume based on the brs path uri.  For example, passing in
+ * "tmp:///test.txt" will return the memfs temporary volume on the interpreter. 
+ * 
+ * Returns invalid in no appopriate volume is found for the path
+ */
+export function getVolumeByPath(interpreter: Interpreter, path: string): Volume | null {
+    const volumePrefix = parseVolumeName(path);
+    if (volumePrefix === "tmp") {
+        return interpreter.temporaryVolume;
+    } else {
+        return null;
+    }
+}
+
+/*
+ * Removed the scheme from the uri.
+ *    ex. "tmp:///test/test1.txt" -> "///test/test1.txt"
+ * 
+ * NOTE: memfs as well as other file systems correctly handle extraneous slashes
+ */
+function stripScheme(brsUri: string): string {
+    return brsUri.replace(parseVolumeName(brsUri) + ":", "");
+}
+
+/** Reads ascii file from file system. */
+export const ReadAsciiFile = new Callable(
+    "ReadAsciiFile",
+    {
+        signature: {
+            args: [
+                {name: "filepath", type: ValueKind.String}
+            ],
+            returns: ValueKind.String
+        },
+        impl: (interpreter: Interpreter, filepath: BrsString, text: BrsString) => {
+            const volume = getVolumeByPath(interpreter, filepath.value);
+            if (volume === null) {
+                //console.warn("unable to read file: " + filepath.value);
+                return new BrsString("");
+            }
+
+            const memfsPath = stripScheme(filepath.value);
+            return new BrsString(volume.readFileSync(memfsPath).toString());
+        }
+    }
+);
+
+/** Writes a string to a temporary file. */
+export const WriteAsciiFile = new Callable(
+    "WriteAsciiFile",
+    {
+        signature: {
+            args: [
+                {name: "filepath", type: ValueKind.String},
+                {name: "text", type: ValueKind.String}
+            ],
+            returns: ValueKind.Boolean
+        },
+        impl: (interpreter: Interpreter, filepath: BrsString, text: BrsString) => {
+            const volume = getVolumeByPath(interpreter, filepath.value);
+            if (volume === null) {
+                //console.warn("unable to write file: " + filepath.value);
+                return BrsBoolean.False;
+            }
+
+            volume.writeFileSync(filepath.value, text.value);
+            return BrsBoolean.True;
+        }
+    }
+);
+

--- a/src/stdlib/File.ts
+++ b/src/stdlib/File.ts
@@ -13,15 +13,11 @@ import { URL } from "url";
 export function getVolumeByPath(interpreter: Interpreter, path: string): Volume | null {
     try {
         const protocol = new URL(path).protocol;
-        switch (protocol) {
-            case "tmp:":
-                return interpreter.temporaryVolume;
-            default:
-                return null;
-        }
+        if (protocol === "tmp:") return interpreter.temporaryVolume;
     } catch (err) {
         return null;
     }
+    return null;
 }
 
 /*

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -21,6 +21,7 @@ export const RebootSystem = new Callable(
     }
 );
 
+export * from "./File";
 export * from "./Math";
 export * from "./String";
 export * from "./Print";

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -18,6 +18,17 @@ describe("end to end standard libary", () => {
         jest.restoreAllMocks();
     });
 
+    test("stdlib/files.brs", () => {
+        return execute(resourceFile("stdlib", "files.brs"), outputStreams).then(() => {
+            expect(
+                allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")
+            ).toEqual([
+                "false",
+                "true"
+            ]);
+        });
+    });
+
     test("stdlib/strings.brs", () => {
         return execute(resourceFile("stdlib", "strings.brs"), outputStreams).then(() => {
             expect(

--- a/test/e2e/resources/stdlib/files.brs
+++ b/test/e2e/resources/stdlib/files.brs
@@ -1,0 +1,7 @@
+' write bad path
+success = WriteAsciiFile("x", "some test contents")
+print(success)
+
+' write good path
+success = WriteAsciiFile("tmp:///test.txt", "some test contents")
+print(success)

--- a/test/stdlib/File.test.js
+++ b/test/stdlib/File.test.js
@@ -1,20 +1,24 @@
-const { ReadAsciiFile, WriteAsciiFile, parseVolumeName, getVolumeByPath } = require("../../lib/stdlib/index");
+const { ReadAsciiFile, WriteAsciiFile, getMemfsPath, getVolumeByPath } = require("../../lib/stdlib/index");
 const { Interpreter } = require("../../lib/interpreter");
 const { BrsTypes } = require("brs");
 const { BrsString } = BrsTypes;
 
-const interpreter = new Interpreter();
+let interpreter;
 
 describe("global file I/O functions", () => {
-    describe("file I/O utility utilities", () => {
-        it("gets a volume name", () => {
-            expect(parseVolumeName("tmp:///test.txt")).toEqual("tmp");
-            expect(parseVolumeName("/tmp:///")).toEqual("");
-        });
+    beforeEach(() => {
+        interpreter = new Interpreter(); // reset the file systems
+    });
 
+    describe("file I/O utility utilities", () => {
         it("gets a volume by path", () => {
             expect(getVolumeByPath(interpreter, "tmp:///test.txt")).toEqual(interpreter.temporaryVolume);
         });
+
+        it("converts a brs path to a memfs path", () => {
+            expect(getMemfsPath("tmp:/test.txt")).toEqual("/test.txt");
+            expect(getMemfsPath("tmp:///test.txt")).toEqual("/test.txt");
+        })
     });
 
 
@@ -32,16 +36,16 @@ describe("global file I/O functions", () => {
         });
     });
 
-    describe.skip("WriteAsciiFile", () => {
+    describe("WriteAsciiFile", () => {
         it("fails writing to bad paths", () => {
             expect(
-                WriteAsciiFile.call(interpreter, new BrsString("hello.text"), new BrsString("test contents")).value
+                WriteAsciiFile.call(interpreter, new BrsString("hello.txt"), new BrsString("test contents")).value
             ).toBeFalsy();
         });
 
         it("writes an ascii file", () => {
             expect(
-                WriteAsciiFile.call(interpreter, new BrsString("tmp:///hello.text"), new BrsString("test contents")).value
+                WriteAsciiFile.call(interpreter, new BrsString("tmp:///hello.txt"), new BrsString("test contents")).value
             ).toBeTruthy();
 
             expect(interpreter.temporaryVolume.toJSON()).toEqual({ "/hello.txt": "test contents" });

--- a/test/stdlib/File.test.js
+++ b/test/stdlib/File.test.js
@@ -1,0 +1,50 @@
+const { ReadAsciiFile, WriteAsciiFile, parseVolumeName, getVolumeByPath } = require("../../lib/stdlib/index");
+const { Interpreter } = require("../../lib/interpreter");
+const { BrsTypes } = require("brs");
+const { BrsString } = BrsTypes;
+
+const interpreter = new Interpreter();
+
+describe("global file I/O functions", () => {
+    describe("file I/O utility utilities", () => {
+        it("gets a volume name", () => {
+            expect(parseVolumeName("tmp:///test.txt")).toEqual("tmp");
+            expect(parseVolumeName("/tmp:///")).toEqual("");
+        });
+
+        it("gets a volume by path", () => {
+            expect(getVolumeByPath(interpreter, "tmp:///test.txt")).toEqual(interpreter.temporaryVolume);
+        });
+    });
+
+
+    describe("ReadAsciiFile", () => {
+        it("reads an ascii file", () => {
+            interpreter.temporaryVolume.writeFileSync("/test.txt", "test contents");
+            
+            expect(
+                ReadAsciiFile.call(interpreter, new BrsString("tmp:///test.txt")).value
+            ).toEqual("test contents");
+
+            expect(
+                ReadAsciiFile.call(interpreter, new BrsString("tmp:/test.txt")).value
+            ).toEqual("test contents");
+        });
+    });
+
+    describe.skip("WriteAsciiFile", () => {
+        it("fails writing to bad paths", () => {
+            expect(
+                WriteAsciiFile.call(interpreter, new BrsString("hello.text"), new BrsString("test contents")).value
+            ).toBeFalsy();
+        });
+
+        it("writes an ascii file", () => {
+            expect(
+                WriteAsciiFile.call(interpreter, new BrsString("tmp:///hello.text"), new BrsString("test contents")).value
+            ).toBeTruthy();
+
+            expect(interpreter.temporaryVolume.toJSON()).toEqual({ "/hello.txt": "test contents" });
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,6 +1028,11 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
+fast-extend@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/fast-extend/-/fast-extend-0.0.2.tgz#f5ec42cf40b9460f521a6387dfb52deeed671dbd"
+  integrity sha1-9exCz0C5Rg9SGmOH37Ut7u1nHb0=
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -1133,6 +1138,11 @@ fs-minipass@^1.2.5:
   integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
   dependencies:
     minipass "^2.2.1"
+
+fs-monkey@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-0.3.3.tgz#7960bb2b1fa2653731b9d0e2e84812a7e8b3664a"
+  integrity sha512-FNUvuTAJ3CqCQb5ELn+qCbGR/Zllhf2HtwsdAtBi59s1WeCjKMT81fHcSu7dwIskqGVK+MmOrb7VOBlq3/SItw==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2241,6 +2251,14 @@ mem@^1.1.0:
   integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
   dependencies:
     mimic-fn "^1.0.0"
+
+memfs@2.13.1:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-2.13.1.tgz#5a2057d3bd7f19775ffc89bebccf34e7d307fbf8"
+  integrity sha512-va1V7jgTXsH5wbxhp4n3MWQGXm8PYyWTFUsXOU4zJNr3oMz6uUJzdDjgG4z8C8ZQ5zskyFZ94qJPwy08xeS/og==
+  dependencies:
+    fast-extend "0.0.2"
+    fs-monkey "^0.3.3"
 
 memorystream@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
This adds the ReadAsciiFile() and WriteAsciiFile() functions to stdlib.  This implementation uses the _memfs_ library so all file operations will be in memory.  This will make working with files safer during brs development.  In the future we can support reading from the hard drive by copying files into the memfs volumes at startup of the interpreter.  

Right now only a single volume, _tmp_, is implemented and is attached to the interpreter object.  In the future we can add additional ones such as _common_ and _package_.  

I've written unit tests for this, but am having trouble with the end-to-end tests for some reason.  

closes #88 