### PR TITLE
fix(lex,parse,interp): Decouple reserved words and keywords

### DIFF
--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -39,7 +39,7 @@ export interface OutputStreams {
 
 export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType> {
     private _environment = new Environment();
-    
+
     readonly stdout: OutputProxy;
     readonly stderr: OutputProxy;
     readonly temporaryVolume = new Volume();
@@ -640,7 +640,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             counterName,
             new Expr.Binary(
                 new Expr.Variable(counterName),
-                { kind: Lexeme.Plus, text: "+", line: counterName.line },
+                { kind: Lexeme.Plus, text: "+", isReserved: false, line: counterName.line },
                 new Expr.Literal(increment)
             )
         );

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -132,6 +132,10 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     }
 
     visitNamedFunction(statement: Stmt.Function): BrsType {
+        if (statement.name.isReserved) {
+            throw BrsError.make(`Cannot create a named function with reserved name '${statement.name.text}'`, statement.name.line);
+        }
+
         if (this.environment.has(statement.name)) {
             // TODO: Figure out how to determine where the original version was declared
             // Maybe `Environment.define` records the location along with the value?
@@ -201,6 +205,10 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     }
 
     visitAssignment(statement: Stmt.Assignment): BrsType {
+        if (statement.name.isReserved) {
+            throw BrsError.make(`Cannot assign a value to reserved name '${statement.name}'`, statement.name.line);
+        }
+
         let value = this.evaluate(statement.value);
         this.environment.define(Scope.Function, statement.name.text!, value);
         return BrsInvalid.Instance;

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -1,6 +1,6 @@
 import { Lexeme } from "./Lexeme";
 import { Token } from "./Token";
-import { ReservedWords } from "./ReservedWords";
+import { ReservedWords, KeyWords } from "./ReservedWords";
 import * as BrsError from "../Error";
 import { isAlpha, isDigit, isAlphaNumeric } from "./Characters";
 
@@ -47,6 +47,7 @@ export function scan(toScan: string): ReadonlyArray<Token> {
 
     tokens.push({
         kind: Lexeme.Eof,
+        isReserved: false,
         line: line
     });
 
@@ -369,7 +370,7 @@ function identifier() {
         while (isAlphaNumeric(peek())) { advance(); } // read the next word
 
         let twoWords = source.slice(start, current);
-        let maybeTokenType = ReservedWords[twoWords.toLowerCase()];
+        let maybeTokenType = KeyWords[twoWords.toLowerCase()];
         if (maybeTokenType) {
             addToken(maybeTokenType);
             return;
@@ -382,8 +383,8 @@ function identifier() {
     // TODO: support type designators:
     // https://sdkdocs.roku.com/display/sdkdoc/Expressions%2C+Variables%2C+and+Types
 
-    let tokenType = ReservedWords[text.toLowerCase()] || Lexeme.Identifier;
-    if (tokenType === ReservedWords.rem) {
+    let tokenType = KeyWords[text.toLowerCase()] || Lexeme.Identifier;
+    if (tokenType === KeyWords.rem) {
         // The 'rem' keyword can be used to indicate comments as well, so
         // consume the rest of the line, but don't add the token; it's not
         // particularly useful.
@@ -407,9 +408,11 @@ function lastToken(): Token | undefined {
  * @param literal an optional literal value to include in the token.
  */
 function addToken(kind: Lexeme, literal?: BrsType): void {
+    let text = source.slice(start, current);
     tokens.push({
         kind: kind,
-        text: source.slice(start, current),
+        text: text,
+        isReserved: ReservedWords.has(text),
         literal: literal,
         line: line
     });

--- a/src/lexer/ReservedWords.ts
+++ b/src/lexer/ReservedWords.ts
@@ -57,7 +57,6 @@ export const ReservedWords = new Set([
  */
 export const KeyWords: {[key: string]: L} = {
     and: L.And,
-    box: L.Box,
     dim: L.Dim,
     else: L.Else,
     elseif: L.ElseIf,

--- a/src/lexer/ReservedWords.ts
+++ b/src/lexer/ReservedWords.ts
@@ -1,9 +1,63 @@
 import { Lexeme as L } from "./Lexeme";
 
-export const ReservedWords: {[key: string]: L} = {
+/**
+ * The set of all reserved words in the reference BrightScript runtime. These can't be used for any
+ * other purpose within a BrightScript file.
+ * @see https://sdkdocs.roku.com/display/sdkdoc/Reserved+Words
+ */
+export const ReservedWords = new Set([
+    "and",
+    "box",
+    "createobject",
+    "dim",
+    "each",
+    "else",
+    "elseif",
+    "endsub",
+    "endwhile",
+    "eval",
+    "exit",
+    "exitwhile",
+    "false",
+    "for",
+    "function",
+    "getglobalaa",
+    "getlastruncompileerror",
+    "getlastrunruntimeerror",
+    "goto",
+    "if",
+    "invalid",
+    "let",
+    "line_num",
+    "next",
+    "not",
+    "objfun",
+    "or",
+    "pos",
+    "print",
+    "rem",
+    "return",
+    "run",
+    "step",
+    "stop",
+    "sub",
+    "tab",
+    "then",
+    "to",
+    "true",
+    "type",
+    "while"
+]);
+
+/**
+ * The set of keywords in the refrence BrightScript runtime. Any of these that *are not* reserved
+ * words can be used within a BrightScript file for other purposes, e.g. `tab`.
+ *
+ * Unfortunately there's no canonical source for this!
+ */
+export const KeyWords: {[key: string]: L} = {
     and: L.And,
     box: L.Box,
-    createobject: L.CreateObject,
     dim: L.Dim,
     else: L.Else,
     elseif: L.ElseIf,
@@ -19,29 +73,22 @@ export const ReservedWords: {[key: string]: L} = {
     "end sub": L.EndSub,
     endwhile: L.EndWhile,
     "end while": L.EndWhile,
-    eval: L.Eval,
     exit: L.Exit,
-    "exit for": L.ExitFor, // note: 'exitfor' (no space) is *not* a reserved word
+    "exit for": L.ExitFor, // note: 'exitfor' (no space) is *not* a keyword
     exitwhile: L.ExitWhile,
     "exit while": L.ExitWhile,
     false: L.False,
     for: L.For,
-    "for each": L.ForEach, // note: 'foreach' (no space) is *not* a reserved word
+    "for each": L.ForEach, // note: 'foreach' (no space) is *not* a keyword
     function: L.Function,
-    getglobalaa: L.GetGlobalAA,
-    getlastruncompileerror: L.GetLastRunCompileError,
-    getlastrunruntimeerror: L.GetLastRunRunTimeError,
     goto: L.Goto,
     if: L.If,
     invalid: L.Invalid,
     let: L.Let,
     line_num: L.LineNum,
     mod: L.Mod,
-    next: L.Next,
     not: L.Not,
-    objfun: L.ObjFun,
     or: L.Or,
-    pos: L.Pos,
     print: L.Print,
     rem: L.Rem,
     return: L.Return,
@@ -49,10 +96,8 @@ export const ReservedWords: {[key: string]: L} = {
     step: L.Step,
     stop: L.Stop,
     sub: L.Sub,
-    tab: L.Tab,
     then: L.Then,
     to: L.To,
     true: L.True,
-    type: L.Type,
     while: L.While,
 };

--- a/src/lexer/Token.ts
+++ b/src/lexer/Token.ts
@@ -9,6 +9,8 @@ export interface Token {
     kind: Lexeme;
     /** The text found in the original BrightScript source, if any. */
     text?: string;
+    /** True if this token's `text` is a reserved word, otherwise `false`. */
+    isReserved: boolean;
     /** The literal value (using the BRS type system) associated with this token, if any. */
     literal?: BrsType;
     /** The line on which this token was found. */

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -2,7 +2,7 @@ import * as Expr from "./Expression";
 type Expression = Expr.Expression;
 import * as Stmt from "./Statement";
 type Statement = Stmt.Statement;
-import { Lexeme, Token, Identifier } from "../lexer";
+import { Lexeme, Token, Identifier, ReservedWords } from "../lexer";
 import * as ParseError from "./ParseError";
 
 import {
@@ -116,7 +116,7 @@ function functionDeclaration(isAnonymous: boolean) {
     args.reduce((haveFoundOptional: boolean, arg: Argument) => {
         if (haveFoundOptional && !arg.defaultValue) {
             throw ParseError.make(
-                { kind: Lexeme.Identifier, text: arg.name, line: name.line },
+                { kind: Lexeme.Identifier, text: arg.name, isReserved: ReservedWords.has(arg.name), line: name.line },
                 `Argument '${arg.name}' has no default value, but comes after arguments with default values`
             );
         }

--- a/test/interpreter/FunctionDeclaration.test.js
+++ b/test/interpreter/FunctionDeclaration.test.js
@@ -228,4 +228,19 @@ describe("interpreter function declarations", () => {
             { kind: Lexeme.Identifier, text: "input", line: 6 }
         )).toBe(false);
     });
+
+    it("disallows functions named after reserved words", () => {
+        let statements = [
+            new Stmt.Function(
+                { kind: Lexeme.Identifier, text: "type", isReserved: true, line: 1 },
+                new Expr.Function(
+                    [],
+                    ValueKind.Void,
+                    new Stmt.Block([])
+                )
+            ),
+        ];
+
+        expect(() => interpreter.exec(statements)).toThrow(/reserved name/);
+    });
 });

--- a/test/interpreter/Variables.test.js
+++ b/test/interpreter/Variables.test.js
@@ -3,8 +3,8 @@ const Expr = require("../../lib/parser/Expression");
 const Stmt = require("../../lib/parser/Statement");
 const { identifier } = require("../parser/ParserTests");
 const { Interpreter } = require("../../lib/interpreter");
-const { BrsTypes } = require("brs");
-const { Int32, BrsInvalid } = BrsTypes;
+const { Lexeme, BrsTypes } = require("brs");
+const { Int32, BrsString, BrsInvalid } = BrsTypes;
 
 let interpreter;
 
@@ -51,5 +51,16 @@ describe("interpreter variables", () => {
         );
         let results = interpreter.exec([ assign, retrieve ]);
         expect(results).toEqual([BrsInvalid.Instance, seven]);
+    });
+
+    it("disallows variables named after reserved words", () => {
+        let ast = [
+            new Stmt.Assignment(
+                { kind: Lexeme.Identifier, text: "type", isReserved: true, line: 1 },
+                new Expr.Literal(new BrsString("this will fail"))
+            )
+        ];
+
+        expect(() => interpreter.exec(ast)).toThrow(/reserved name/);
     });
 });

--- a/test/lexer/Lexer.test.js
+++ b/test/lexer/Lexer.test.js
@@ -194,14 +194,13 @@ describe("lexer", () => {
     });
 
     describe("identifiers", () => {
-        it("matches single-word reserved words", () => {
+        it("matches single-word keywords", () => {
             // test just a sample of single-word reserved words for now.
             // if we find any that we've missed
-            let words = Lexer.scan("and or box if else endif return true false");
+            let words = Lexer.scan("and or if else endif return true false");
             expect(words.map(w => w.kind)).toEqual([
                 Lexeme.And,
                 Lexeme.Or,
-                Lexeme.Box,
                 Lexeme.If,
                 Lexeme.Else,
                 Lexeme.EndIf,
@@ -213,7 +212,7 @@ describe("lexer", () => {
             expect(words.filter(w => !!w.literal).length).toBe(0);
         });
 
-        it("matches multi-word reserved words", () => {
+        it("matches multi-word keywords", () => {
             let words = Lexer.scan("else if end if end while End Sub end Function Exit wHILe");
             expect(words.map(w => w.kind)).toEqual([
                 Lexeme.ElseIf,
@@ -236,7 +235,7 @@ describe("lexer", () => {
             ]);
         });
 
-        it("matches reserved words with silly capitalization", () => {
+        it("matches keywords with silly capitalization", () => {
             let words = Lexer.scan("iF ELSE eNDIf FUncTioN");
             expect(words.map(w => w.kind)).toEqual([
                 Lexeme.If,


### PR DESCRIPTION
There's no need to consider `type` its own token if it's basically just an identifier.  Ditto `createObject`. If these reserved-words-but-not-keywords are treated like regular-old identifiers for most of the parsing logic, we're able to more-easily implement functions like `type`, `createObject`, etc.  Instead of having to check for specific tokens, those can be implemented like regular-old stdlib functions!

Plus now attempting to call `type(foo)` won't result in a parse failure; just a runtime failure because `type` doesn't exist yet :smile:

fixes #80