### PR TITLE
fix(lex): Allow `end function` and others to use mixed case

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -359,7 +359,7 @@ function number() {
 function identifier() {
     while (isAlphaNumeric(peek())) { advance(); }
 
-    let text = source.slice(start, current);
+    let text = source.slice(start, current).toLowerCase();
 
     // some identifiers can be split into two words, so check the "next" word and see what we get
     if ((text === "end" || text === "else" || text === "exit" || text === "for") && peek() === " ") {

--- a/test/lexer/Lexer.test.js
+++ b/test/lexer/Lexer.test.js
@@ -214,7 +214,7 @@ describe("lexer", () => {
         });
 
         it("matches multi-word reserved words", () => {
-            let words = Lexer.scan("else if end if end while end sub end function exit while");
+            let words = Lexer.scan("else if end if end while End Sub end Function Exit wHILe");
             expect(words.map(w => w.kind)).toEqual([
                 Lexeme.ElseIf,
                 Lexeme.EndIf,


### PR DESCRIPTION
It's pretty common to use `End Function` instead of `end function` (see: https://github.com/Tubitv/rodash), and they're both valid.  Since RBI supports it, we should too!

closes #96 