### PR TITLE
fix(parse): Allow optional 'then' in 'if' statements

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -302,7 +302,11 @@ function ifStatement(): Stmt.If {
     let thenBranch: Stmt.Block;
     let elseIfBranches: Stmt.ElseIf[] = [];
     let elseBranch: Stmt.Block | undefined;
-    consume("Expected 'then' after 'if ...condition...", Lexeme.Then);
+
+    if (check(Lexeme.Then)) {
+        // `then` is optional after `if ...condition...`, so only advance to the next token if `then` is present
+        advance();
+    }
 
     if (match(Lexeme.Newline)) {
         // we're parsing a multi-line ("block") form of the BrightScript if/then/else and must find
@@ -319,7 +323,10 @@ function ifStatement(): Stmt.If {
         // attempt to read a bunch of "else if" clauses
         while (match(Lexeme.ElseIf)) {
             let elseIfCondition = expression();
-            consume("Expected 'then' after 'else if ...condition...'", Lexeme.Then);
+            if (check(Lexeme.Then)) {
+                // `then` is optional after `else if ...condition...`, so only advance to the next token if `then` is present
+                advance();
+            }
             match(Lexeme.Newline);
             let elseIfThen = block(Lexeme.EndIf, Lexeme.Else, Lexeme.ElseIf);
             if (!elseIfThen) {
@@ -355,7 +362,10 @@ function ifStatement(): Stmt.If {
         while(match(Lexeme.ElseIf)) {
             let elseIf = previous();
             let elseIfCondition = expression();
-            consume("Expected 'then' after 'else if ...condition...'", Lexeme.Then);
+            if (check(Lexeme.Then)) {
+                // `then` is optional after `else if ...condition...`, so only advance to the next token if `then` is present
+                advance();
+            }
 
             let elseIfThen = declaration(Lexeme.ElseIf, Lexeme.Else);
             if (!elseIfThen) {

--- a/test/parser/controlFlow/If.test.js
+++ b/test/parser/controlFlow/If.test.js
@@ -85,6 +85,36 @@ describe("parser if statements", () => {
             expect(parsed).not.toBeNull();
             expect(parsed).toMatchSnapshot();
         });
+
+        it("allows 'then' to be skipped", () => {
+            let parsed = Parser.parse([
+                token(Lexeme.If),
+                token(Lexeme.Integer, new Int32(1)),
+                token(Lexeme.Less),
+                token(Lexeme.Integer, new Int32(2)),
+                identifier("foo"),
+                token(Lexeme.Equal),
+                token(Lexeme.True, BrsBoolean.True),
+                token(Lexeme.ElseIf),
+                token(Lexeme.Integer, new Int32(1)),
+                token(Lexeme.Equal),
+                token(Lexeme.Integer, new Int32(2)),
+                identifier("same"),
+                token(Lexeme.Equal),
+                token(Lexeme.True, BrsBoolean.True),
+                token(Lexeme.Else),
+                identifier("foo"),
+                token(Lexeme.Equal),
+                token(Lexeme.True, BrsBoolean.False),
+                token(Lexeme.Newline),
+                EOF
+            ]);
+
+            expect(BrsError.found()).toBe(false);
+            expect(parsed).toBeDefined();
+            expect(parsed).not.toBeNull();
+            expect(parsed).toMatchSnapshot();
+        });
     });
 
     describe("block if", () => {
@@ -163,6 +193,47 @@ describe("parser if statements", () => {
                 { kind: Lexeme.Greater, text: ">" },
                 { kind: Lexeme.Integer, literal: new Int32(2) },
                 { kind: Lexeme.Then, text: "then" },
+                { kind: Lexeme.Newline, text: "\n" },
+                { kind: Lexeme.Identifier, text: "foo" },
+                { kind: Lexeme.Equal, text: "=" },
+                { kind: Lexeme.Integer, literal: new Int32(3) },
+                { kind: Lexeme.Newline, text: "\n" },
+                { kind: Lexeme.Identifier, text: "bar" },
+                { kind: Lexeme.Equal, text: "=" },
+                { kind: Lexeme.True, literal: BrsBoolean.False },
+                { kind: Lexeme.Newline, text: "\n" },
+                { kind: Lexeme.Else, text: "else" },
+                { kind: Lexeme.Newline, text: "\n" },
+                { kind: Lexeme.Identifier, text: "foo" },
+                { kind: Lexeme.Equal, text: "=" },
+                { kind: Lexeme.False, literal: BrsBoolean.False },
+                { kind: Lexeme.Newline, text: "\n" },
+                { kind: Lexeme.EndIf, text: "end if" },
+                { kind: Lexeme.Newline, text: "\n" },
+                EOF
+            ]);
+
+            expect(BrsError.found()).toBe(false);
+            expect(parsed).toBeDefined();
+            expect(parsed).not.toBeNull();
+            expect(parsed).toMatchSnapshot();
+        });
+
+        it("allows 'then' to be skipped", () => {
+            let parsed = Parser.parse([
+                { kind: Lexeme.If, text: "if" },
+                { kind: Lexeme.Integer, literal: new Int32(1) },
+                { kind: Lexeme.Less, text: "<" },
+                { kind: Lexeme.Integer, literal: new Int32(2) },
+                { kind: Lexeme.Newline, text: "\n" },
+                { kind: Lexeme.Identifier, text: "foo" },
+                { kind: Lexeme.Equal, text: "=" },
+                { kind: Lexeme.True, literal: BrsBoolean.True },
+                { kind: Lexeme.Newline, text: "\n" },
+                { kind: Lexeme.ElseIf, text: "else if" },
+                { kind: Lexeme.Integer, literal: new Int32(1) },
+                { kind: Lexeme.Greater, text: ">" },
+                { kind: Lexeme.Integer, literal: new Int32(2) },
                 { kind: Lexeme.Newline, text: "\n" },
                 { kind: Lexeme.Identifier, text: "foo" },
                 { kind: Lexeme.Equal, text: "=" },

--- a/test/parser/controlFlow/__snapshots__/If.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/If.test.js.snap
@@ -1,5 +1,112 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parser if statements block if allows 'then' to be skipped 1`] = `
+Array [
+  If {
+    "condition": Binary {
+      "left": Literal {
+        "value": Int32 {
+          "kind": 3,
+          "value": 1,
+        },
+      },
+      "right": Literal {
+        "value": Int32 {
+          "kind": 3,
+          "value": 2,
+        },
+      },
+      "token": Object {
+        "kind": 15,
+        "text": "<",
+      },
+    },
+    "elseBranch": Block {
+      "statements": Array [
+        Assignment {
+          "name": Object {
+            "kind": 21,
+            "text": "foo",
+          },
+          "value": Literal {
+            "value": BrsBoolean {
+              "kind": 1,
+              "value": false,
+            },
+          },
+        },
+      ],
+    },
+    "elseIfs": Array [
+      Object {
+        "condition": Binary {
+          "left": Literal {
+            "value": Int32 {
+              "kind": 3,
+              "value": 1,
+            },
+          },
+          "right": Literal {
+            "value": Int32 {
+              "kind": 3,
+              "value": 2,
+            },
+          },
+          "token": Object {
+            "kind": 17,
+            "text": ">",
+          },
+        },
+        "thenBranch": Block {
+          "statements": Array [
+            Assignment {
+              "name": Object {
+                "kind": 21,
+                "text": "foo",
+              },
+              "value": Literal {
+                "value": Int32 {
+                  "kind": 3,
+                  "value": 3,
+                },
+              },
+            },
+            Assignment {
+              "name": Object {
+                "kind": 21,
+                "text": "bar",
+              },
+              "value": Literal {
+                "value": BrsBoolean {
+                  "kind": 1,
+                  "value": true,
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+    "thenBranch": Block {
+      "statements": Array [
+        Assignment {
+          "name": Object {
+            "kind": 21,
+            "text": "foo",
+          },
+          "value": Literal {
+            "value": BrsBoolean {
+              "kind": 1,
+              "value": true,
+            },
+          },
+        },
+      ],
+    },
+  },
+]
+`;
+
 exports[`parser if statements block if parses if only 1`] = `
 Array [
   If {
@@ -217,6 +324,106 @@ Array [
         Assignment {
           "name": Object {
             "kind": 21,
+            "text": "foo",
+          },
+          "value": Literal {
+            "value": BrsBoolean {
+              "kind": 1,
+              "value": true,
+            },
+          },
+        },
+      ],
+    },
+  },
+]
+`;
+
+exports[`parser if statements single-line if allows 'then' to be skipped 1`] = `
+Array [
+  If {
+    "condition": Binary {
+      "left": Literal {
+        "value": Int32 {
+          "kind": 3,
+          "value": 1,
+        },
+      },
+      "right": Literal {
+        "value": Int32 {
+          "kind": 3,
+          "value": 2,
+        },
+      },
+      "token": Object {
+        "kind": 15,
+        "line": 1,
+        "literal": undefined,
+      },
+    },
+    "elseBranch": Block {
+      "statements": Array [
+        Assignment {
+          "name": Object {
+            "kind": 21,
+            "line": 1,
+            "text": "foo",
+          },
+          "value": Literal {
+            "value": BrsBoolean {
+              "kind": 1,
+              "value": true,
+            },
+          },
+        },
+      ],
+    },
+    "elseIfs": Array [
+      Object {
+        "condition": Binary {
+          "left": Literal {
+            "value": Int32 {
+              "kind": 3,
+              "value": 1,
+            },
+          },
+          "right": Literal {
+            "value": Int32 {
+              "kind": 3,
+              "value": 2,
+            },
+          },
+          "token": Object {
+            "kind": 19,
+            "line": 1,
+            "literal": undefined,
+          },
+        },
+        "thenBranch": Block {
+          "statements": Array [
+            Assignment {
+              "name": Object {
+                "kind": 21,
+                "line": 1,
+                "text": "same",
+              },
+              "value": Literal {
+                "value": BrsBoolean {
+                  "kind": 1,
+                  "value": true,
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+    "thenBranch": Block {
+      "statements": Array [
+        Assignment {
+          "name": Object {
+            "kind": 21,
+            "line": 1,
             "text": "foo",
           },
           "value": Literal {


### PR DESCRIPTION
RBI allows 'then' to be dropped and the 'if' statement works the same way.  We should do the same.

fixes #98