### PR TITLE
feat(interp,env): Implement `m` pointer

### DIFF
--- a/src/brsTypes/Callable.ts
+++ b/src/brsTypes/Callable.ts
@@ -109,19 +109,17 @@ export class Callable implements Brs.BrsValue {
 
         let { signature, impl } = satisfiedSignature;
 
-        // first, we need to evaluate all of the parameter default values
-        // and define them in a new environment
-        let subEnvironment = interpreter.environment.createSubEnvironment();
-
         let mutableArgs = args.slice();
 
-        return interpreter.inSubEnv(subEnvironment, (subInterpreter) => {
+        return interpreter.inSubEnv(subInterpreter => {
+            // first, we need to evaluate all of the parameter default values
+            // and define them in a new environment
             signature.args.forEach((param, index) => {
                 if (param.defaultValue && mutableArgs[index] == null) {
                     mutableArgs[index] = subInterpreter.evaluate(param.defaultValue);
                 }
 
-                subEnvironment.define(Scope.Function, param.name, mutableArgs[index]);
+                subInterpreter.environment.define(Scope.Function, param.name, mutableArgs[index]);
             });
 
             // then return whatever the selected implementation would return

--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -71,6 +71,14 @@ export class Environment {
     }
 
     /**
+     * Retrieves the current value of the special `m` variable, which is analogous to JavaScript's `this`.
+     * @returns the current value used for the `m` pointer.
+     */
+    public getM(): AssociativeArray {
+        return this.mPointer;
+    }
+
+    /**
      * Removes a variable from this environment's function scope.
      * @param name the name of the variable to remove (in the form of an `Identifier`)
      */

--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -1,7 +1,7 @@
 import { Identifier } from "../lexer";
 import { BrsType, AssociativeArray } from "../brsTypes";
 
-/** The logical region from which a particular variable or function that defines where it may be accessed from. */
+/** The logical region from a particular variable or function that defines where it may be accessed from. */
 export enum Scope {
     /** The set of native functions that are always accessible, e.g. `RebootSystem`. */
     Global,
@@ -18,9 +18,7 @@ export class NotFound extends Error {
     }
 }
 
-/**
- * Holds a set of values in multiple scopes and provides access operations to them.
- */
+/** Holds a set of values in multiple scopes and provides access operations to them. */
 export class Environment {
     /**
      * Functions that are always accessible.
@@ -40,6 +38,12 @@ export class Environment {
     /** The BrightScript `m` pointer, analogous to JavaScript's `this` pointer. */
     private mPointer = new AssociativeArray([]);
 
+    /**
+     * Stores a `value` for the `name`d variable in the provided `scope`.
+     * @param scope The logical region from a particular variable or function that defines where it may be accessed from
+     * @param name the name of the variable to define (in the form of an `Identifier`)
+     * @param value the value of the variable to define
+     */
     public define(scope: Scope, name: string, value: BrsType): void {
         let destination: Map<string, BrsType>;
 
@@ -58,14 +62,28 @@ export class Environment {
         destination.set(name.toLowerCase(), value);
     }
 
+    /**
+     * Sets the value of the special `m` variable, which is analogous to JavaScript's `this`.
+     * @param newMPointer the new value to be used for the `m` pointer
+     */
     public setM(newMPointer: AssociativeArray): void {
         this.mPointer = newMPointer;
     }
 
+    /**
+     * Removes a variable from this environment's function scope.
+     * @param name the name of the variable to remove (in the form of an `Identifier`)
+     */
     public remove(name: string): void {
         this.function.delete(name.toLowerCase());
     }
 
+    /**
+     * Retrieves a variable from this environment, checking each internal scope in order of precedence.
+     * @param name the name of the variable to retrieve (in the form of an `Identifier`)
+     * @returns the value stored for `name` if any exist
+     * @throws a `NotFound` error if no value is stored for `name`
+     */
     public get(name: Identifier): BrsType {
         let lowercaseName = name.text.toLowerCase();
 
@@ -85,9 +103,17 @@ export class Environment {
         throw new NotFound(`Undefined variable '${name.text}'`);
     }
 
+    /**
+     * Determines whether or not a variable exists in this environment.
+     * @param name the name of the variable to search for (in the form of an `Identifier`)
+     * @returns `true` if this environment contains `name`, otherwise `false`
+     */
     public has(name: Identifier): boolean {
-        let lowercaseName = name.text.toLowerCase();
-        return [this.function, this.module, this.global].find(scope => scope.has(lowercaseName)) != null;
+        try {
+            return this.get(name) != null;
+        } catch (err) {
+            return false;
+        }
     }
 
     /**

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -514,7 +514,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
         if (satisfiedSignature) {
             try {
-                let mPointer = new AssociativeArray([]);
+                let mPointer = this._environment.getM();
 
                 if (expression.callee instanceof Expr.DottedGet || expression.callee instanceof Expr.IndexedGet) {
                     let maybeM = this.evaluate(expression.callee.obj);

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -110,14 +110,13 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
      * Temporarily sets an interpreter's environment to the provided one, then
      * passes the sub-interpreter to the provided JavaScript function. Always
      * reverts the current interpreter's environment to its original value.
-     * @param environment the sub-environment to use for the interpreter
-     *                    provided to `func`.
      * @param func the JavaScript function to execute with the sub interpreter.
      */
-    inSubEnv(environment: Environment, func: (interpreter: Interpreter) => BrsType): BrsType {
+    inSubEnv(func: (interpreter: Interpreter) => BrsType): BrsType {
         let originalEnvironment = this._environment;
+        let newEnv = this._environment.createSubEnvironment();
         try {
-            this._environment = environment;
+            this._environment = newEnv;
             return func(this);
         } finally {
             this._environment = originalEnvironment;
@@ -527,7 +526,6 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 }
 
                 return this.inSubEnv(
-                    this.environment.createSubEnvironment(),
                     (subInterpreter) => {
                         subInterpreter.environment.setM(mPointer);
                         return callee.call(this, ...args);

--- a/test/e2e/Functions.test.js
+++ b/test/e2e/Functions.test.js
@@ -62,6 +62,18 @@ describe("end to end functions", () => {
         });
     });
 
+    test("function/m-pointer.brs", () => {
+        return execute([ resourceFile("function", "m-pointer.brs") ], outputStreams).then(() => {
+            expect(BrsError.found()).toBe(false);
+            expect(
+                allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")
+            ).toEqual([
+                "carpenter.safetyGlassesOn = ", "true",
+                "m.houseAge = ", "old"
+            ]);
+        });
+    });
+
     test.skip("function/scoping.brs", () => {
         // TODO: fix this test once `type` has been implemented
         return execute([ resourceFile("function", "scoping.brs") ], outputStreams).then(() => {

--- a/test/e2e/resources/function/m-pointer.brs
+++ b/test/e2e/resources/function/m-pointer.brs
@@ -1,0 +1,29 @@
+sub Main()
+    m.houseAge = "newish"
+
+    carpenter = createCarpenter()
+    if carpenter.name = "Norm Abrams" setHouseAge()
+    carpenter.work()
+
+    print "carpenter.safetyGlassesOn = " carpenter.safetyGlassesOn
+    print "m.houseAge = " m.houseAge
+end sub
+
+sub createCarpenter()
+    return {
+        name: "Norm Abrams",
+        safetyGlassesOn: false
+        work: __work
+    }
+end sub
+
+sub __work()
+    ' always remember to wear these, safety glasses
+    m.safetyGlassesOn = true
+end sub
+
+sub setHouseAge()
+    m.houseAge = "old"
+end sub
+
+Main()

--- a/test/interpreter/Call.test.js
+++ b/test/interpreter/Call.test.js
@@ -3,6 +3,7 @@ const Expr = require("../../lib/parser/Expression");
 const Stmt = require("../../lib/parser/Statement");
 const { Interpreter } = require("../../lib/interpreter");
 const { Lexeme, BrsTypes } = require("brs");
+const { BrsString, ValueKind } = BrsTypes;
 
 const { identifier } = require("../parser/ParserTests");
 
@@ -24,6 +25,48 @@ describe("interpreter calls", () => {
         );
         const [ result ] = interpreter.exec([call]);
         expect(result.toString()).toBe("H@LL0");
+    });
+
+    it("sets a new `m` pointer when called from an associative array", () => {
+        const ast = [
+            new Stmt.Assignment(
+                { kind: Lexeme.Identifier, text: "foo", line: 2 },
+                new Expr.AALiteral([
+                    {
+                        name: new BrsString("setMId"),
+                        value: new Expr.Function(
+                            [],
+                            ValueKind.Void,
+                            new Stmt.Block([
+                                new Stmt.DottedSet(
+                                    new Expr.Variable({ kind: Lexeme.Identifier, text: "m", line: 3 }),
+                                    { kind: Lexeme.Identifier, text: "id", line: 3 },
+                                    new Expr.Literal(new BrsString("this is an ID"))
+                                )
+                            ])
+                        )
+                    }
+                ])
+            ),
+            new Stmt.Expression(
+                new Expr.Call(
+                    new Expr.DottedGet(
+                        new Expr.Variable({ kind: Lexeme.Identifier, text: "foo", line: 5 }),
+                        { kind: Lexeme.Identifier, text: "setMId" }
+                    ),
+                    { kind: Lexeme.RightParen, text: ")", line: 2 },
+                    [ ] // no args required
+                )
+            )
+        ];
+
+        interpreter.exec(ast);
+
+        let foo = interpreter.environment.get({ kind: Lexeme.Identifier, text: "foo", line: -1 });
+        expect(foo.kind).toBe(ValueKind.AssociativeArray);
+        expect(
+            foo.get(new BrsString("id"))
+        ).toEqual(new BrsString("this is an ID"));
     });
 
     it("errors when not enough arguments provided", () => {

--- a/test/interpreter/Environment.test.js
+++ b/test/interpreter/Environment.test.js
@@ -1,6 +1,6 @@
 const { Environment, Scope } = require("../../lib/interpreter/Environment");
 const { Lexeme, BrsTypes } = require("brs");
-const { BrsString } = BrsTypes;
+const { BrsString, AssociativeArray, Int32 } = BrsTypes;
 
 describe("Environment", () => {
     let env;
@@ -41,6 +41,17 @@ describe("Environment", () => {
         ).toBe(val);
     });
 
+    it("gets and sets an m pointer", () => {
+        let newM = new AssociativeArray([
+            { name: new BrsString("id"), value: new Int32(1738) }
+        ]);
+        env.setM(newM);
+
+        expect(
+            env.get({ kind: Lexeme.Identifier, text: "m", line: 1 })
+        ).toBe(newM);
+    });
+
     it("checks all sources for existence", () => {
         let foo = new BrsString("function scope");
         let bar = new BrsString("module scope");
@@ -49,6 +60,8 @@ describe("Environment", () => {
         env.define(Scope.Function, "foo", foo);
         env.define(Scope.Module, "bar", bar);
         env.define(Scope.Global, "baz", baz);
+
+        expect(env.has(identifier("m"))).toBe(true);
 
         expect(env.has(identifier("foo"))).toBe(true);
         expect(env.has(identifier("bar"))).toBe(true);
@@ -77,11 +90,17 @@ describe("Environment", () => {
         env.define(Scope.Function, "funcScoped", new BrsString("funcScoped"));
         env.define(Scope.Module, "moduleScoped", new BrsString("module-scoped"));
         env.define(Scope.Global, "globalScoped", new BrsString("global-scoped"));
+        env.setM(
+            new AssociativeArray([
+                { name: new BrsString("id"), value: new Int32(679) }
+            ])
+        );
 
         let subEnv = env.createSubEnvironment();
 
         expect(subEnv.has(identifier("funcScoped"))).toBe(false);
         expect(subEnv.has(identifier("moduleScoped"))).toBe(true);
         expect(subEnv.has(identifier("globalScoped"))).toBe(true);
+        expect(subEnv.has(identifier("m"))).toBe(true);
     });
 });


### PR DESCRIPTION
The Reference BrightScript Implementation includes a parallel to JavaScript's `this` variable:

> A BrightScript object is an roAssociativeArray which contains function pointers.  When a member function is called "from" an AssociativeArray, the special variable "m" is set to point to that AssociativeArray. "m" is accessible inside the called function to access other data in the AssociativeArray object.

(https://sdkdocs.roku.com/display/sdkdoc/Component+Architecture#ComponentArchitecture-%22m%22TheBrightScript%22thispointer%22)

This BrightScript implementation needs to have support for it as well.

Depends on #95 