### PR TITLE
chore(interp): Don't require explicit stdlib registration

### DIFF
--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -14,7 +14,8 @@ import {
     isIterable,
     SignatureAndMismatches,
     MismatchReason,
-    isComparable
+    isComparable,
+    Callable
 } from "../brsTypes";
 
 import * as Expr from "../parser/Expression";
@@ -56,54 +57,19 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         this.stdout = new OutputProxy(outputStreams.stdout);
         this.stderr = new OutputProxy(outputStreams.stderr);
 
-        [
-            { name: "RebootSystem", func: StdLib.RebootSystem },
-            { name: "UCase",        func: StdLib.UCase },
-            { name: "LCase",        func: StdLib.LCase },
-            { name: "Asc",          func: StdLib.Asc },
-            { name: "Chr",          func: StdLib.Chr },
-            { name: "Pos",          func: StdLib.Pos },
-            { name: "Left",         func: StdLib.Left },
-            { name: "Right",        func: StdLib.Right },
-            { name: "Instr",        func: StdLib.Instr },
-            { name: "Len",          func: StdLib.Len },
-            { name: "Mid",          func: StdLib.Mid },
-            { name: "RebootSystem", func: StdLib.RebootSystem },
-            { name: "UCase",        func: StdLib.UCase },
-            { name: "LCase",        func: StdLib.LCase },
-            { name: "Asc",          func: StdLib.Asc },
-            { name: "Chr",          func: StdLib.Chr },
-            { name: "Pos",          func: StdLib.Pos },
-            { name: "Left",         func: StdLib.Left },
-            { name: "Right",        func: StdLib.Right },
-            { name: "Instr",        func: StdLib.Instr },
-            { name: "Len",          func: StdLib.Len },
-            { name: "Mid",          func: StdLib.Mid },
-            { name: "Str",          func: StdLib.Str },
-            { name: "StrI",         func: StdLib.StrI },
-            { name: "Substitute",   func: StdLib.Substitute },
-            { name: "Val",          func: StdLib.Val },
-            { name: "Exp",          func: StdLib.Exp },
-            { name: "Log",          func: StdLib.Log },
-            { name: "Sqr",          func: StdLib.Sqr },
-            { name: "Rnd",          func: StdLib.Rnd },
-            { name: "Atn",          func: StdLib.Atn },
-            { name: "Cos",          func: StdLib.Cos },
-            { name: "Sin",          func: StdLib.Sin },
-            { name: "Tan",          func: StdLib.Tan },
-            { name: "Abs",          func: StdLib.Abs },
-            { name: "Cdbl",         func: StdLib.Cdbl },
-            { name: "Cint",         func: StdLib.Cint },
-            { name: "Csng",         func: StdLib.Csng },
-            { name: "Fix",          func: StdLib.Fix },
-            { name: "Int",          func: StdLib.Int },
-            { name: "Sgn",          func: StdLib.Sgn },
-            { name: "ReadAsciiFile", func: StdLib.ReadAsciiFile },
-            { name: "WriteAsciiFile", func: StdLib.WriteAsciiFile },
-            { name: "StrToI",       func: StdLib.StrToI }
-        ].forEach(({name, func}) =>
-            this._environment.define(Scope.Global, name, func)
-        );
+        Object.keys(StdLib)
+            .map(name => (StdLib as any)[name])
+            .filter(func => func instanceof Callable)
+            .filter((func: Callable) => {
+                if (!func.name) {
+                    throw new Error("Unnamed standard library function detected!");
+                }
+
+                return !!func.name;
+            })
+            .forEach((func: Callable) =>
+                this._environment.define(Scope.Global, func.name || "", func)
+            );
     }
 
     /**


### PR DESCRIPTION
We had stdlib function names duplicated a whole bunch, and it was really easy to forget to register a stdlib function.  Now it's automatic!  Just export it from `src/stdlib/` and it'll get registered.