### PR TITLE
Implement CreateObject()

### DIFF
--- a/src/brsTypes/components/BrsObjects.ts
+++ b/src/brsTypes/components/BrsObjects.ts
@@ -1,0 +1,8 @@
+import { AssociativeArray } from "./AssociativeArray";
+import { BrsString } from "../BrsType";
+
+export const BrsObjects = new Map<string, Function>(
+    [
+        [ "roassociativearray", () => new AssociativeArray([]) ]
+    ]
+);

--- a/src/brsTypes/components/BrsObjects.ts
+++ b/src/brsTypes/components/BrsObjects.ts
@@ -1,6 +1,7 @@
 import { AssociativeArray } from "./AssociativeArray";
 import { BrsString } from "../BrsType";
 
+/** Map containing a list of brightscript components that can be created. */
 export const BrsObjects = new Map<string, Function>(
     [
         [ "roassociativearray", () => new AssociativeArray([]) ]

--- a/src/brsTypes/index.ts
+++ b/src/brsTypes/index.ts
@@ -14,6 +14,7 @@ export * from "./Float";
 export * from "./Double";
 export * from "./components/BrsArray";
 export * from "./components/AssociativeArray";
+export * from "./components/BrsObjects";
 export * from "./Callable";
 
 /**

--- a/src/stdlib/CreateObject.ts
+++ b/src/stdlib/CreateObject.ts
@@ -1,0 +1,19 @@
+import { Callable, ValueKind, BrsInvalid, BrsString } from "../brsTypes";
+import { BrsObjects } from "../brsTypes/components/BrsObjects";
+import { Interpreter } from "../interpreter";
+import { createObjectBindingPattern } from "typescript";
+import { AssociativeArray } from "../brsTypes/components/AssociativeArray";
+
+export const CreateObject = new Callable(
+    "CreateObject",
+    {
+        signature: {
+            args: [{ name: "objName", type: ValueKind.String }],
+            returns: ValueKind.Dynamic
+        },
+        impl: (interpreter: Interpreter, objName: BrsString) => {
+            let ctor = BrsObjects.get(objName.value.toLowerCase());
+            return ctor ? ctor() : BrsInvalid.Instance;
+        }
+    }
+);

--- a/src/stdlib/CreateObject.ts
+++ b/src/stdlib/CreateObject.ts
@@ -1,8 +1,6 @@
 import { Callable, ValueKind, BrsInvalid, BrsString } from "../brsTypes";
 import { BrsObjects } from "../brsTypes/components/BrsObjects";
 import { Interpreter } from "../interpreter";
-import { createObjectBindingPattern } from "typescript";
-import { AssociativeArray } from "../brsTypes/components/AssociativeArray";
 
 /** Creates a new instance of a given brightscript component (e.g. roAssociativeArray) */
 export const CreateObject = new Callable(

--- a/src/stdlib/CreateObject.ts
+++ b/src/stdlib/CreateObject.ts
@@ -4,6 +4,7 @@ import { Interpreter } from "../interpreter";
 import { createObjectBindingPattern } from "typescript";
 import { AssociativeArray } from "../brsTypes/components/AssociativeArray";
 
+/** Creates a new instance of a given brightscript component (e.g. roAssociativeArray) */
 export const CreateObject = new Callable(
     "CreateObject",
     {

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -25,3 +25,4 @@ export * from "./File";
 export * from "./Math";
 export * from "./String";
 export * from "./Print";
+export * from "./CreateObject";

--- a/test/brsTypes/BrsObjects.test.js
+++ b/test/brsTypes/BrsObjects.test.js
@@ -1,0 +1,13 @@
+const { AssociativeArray, BrsObjects } = require("../../lib/brsTypes");
+const BrsError = require("../../lib/Error");
+
+describe("BrsObjects", () => {
+    beforeEach(() => BrsError.reset());
+
+    describe("new object instances", () => {
+        it("maps a new instance of associative array", () => {
+            let obj = BrsObjects.get("roassociativearray")
+            expect(obj()).toEqual(new AssociativeArray([]));
+        });
+    });
+});

--- a/test/brsTypes/BrsObjects.test.js
+++ b/test/brsTypes/BrsObjects.test.js
@@ -2,8 +2,6 @@ const { AssociativeArray, BrsObjects } = require("../../lib/brsTypes");
 const BrsError = require("../../lib/Error");
 
 describe("BrsObjects", () => {
-    beforeEach(() => BrsError.reset());
-
     describe("new object instances", () => {
         it("maps a new instance of associative array", () => {
             let obj = BrsObjects.get("roassociativearray")

--- a/test/stdlib/CreateObject.test.ts
+++ b/test/stdlib/CreateObject.test.ts
@@ -1,0 +1,16 @@
+const { AssociativeArray, BrsObjects, CreateObject, BrsInvalid } = require("../../lib/brsTypes");
+const BrsError = require("../../lib/Error");
+
+describe("CreateObject", () => {
+    beforeEach(() => BrsError.reset());
+
+    it("creates a new instance of associative array", () => {
+        let obj = CreateObject("roAssociativeArray")
+        expect(obj).toEqual(new AssociativeArray([]));
+    });
+
+    it("returns invalid for an undefined BrsObject", () => {
+        let obj = CreateObject("notAnObject")
+        expect(obj).toEqual(BrsInvalid.Instance);
+    });
+});

--- a/test/stdlib/CreateObject.test.ts
+++ b/test/stdlib/CreateObject.test.ts
@@ -2,8 +2,6 @@ const { AssociativeArray, BrsObjects, CreateObject, BrsInvalid } = require("../.
 const BrsError = require("../../lib/Error");
 
 describe("CreateObject", () => {
-    beforeEach(() => BrsError.reset());
-
     it("creates a new instance of associative array", () => {
         let obj = CreateObject("roAssociativeArray");
         expect(obj).toEqual(new AssociativeArray([]));

--- a/test/stdlib/CreateObject.test.ts
+++ b/test/stdlib/CreateObject.test.ts
@@ -5,12 +5,12 @@ describe("CreateObject", () => {
     beforeEach(() => BrsError.reset());
 
     it("creates a new instance of associative array", () => {
-        let obj = CreateObject("roAssociativeArray")
+        let obj = CreateObject("roAssociativeArray");
         expect(obj).toEqual(new AssociativeArray([]));
     });
 
     it("returns invalid for an undefined BrsObject", () => {
-        let obj = CreateObject("notAnObject")
+        let obj = CreateObject("notAnObject");
         expect(obj).toEqual(BrsInvalid.Instance);
     });
 });


### PR DESCRIPTION
This implements brightscript's `createObject()` and a new `BrsObjects` map that will contain a list of brightscript components that can be created.

