### PR TITLE
implements file I/O operations for issue #87

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
   "dependencies": {
     "commander": "^2.12.2",
     "long": "^3.2.0",
-    "memfs": "2.13.1"
+    "memory-fs": "^0.4.1"
   },
   "devDependencies": {
     "@types/jest": "^22.0.0",
     "@types/long": "^3.0.32",
+    "@types/memory-fs": "^0.3.2",
     "@types/node": "^8.5.2",
     "jest": "^22.0.4",
     "npm-run-all": "^4.1.2",

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -30,7 +30,8 @@ import { OutputProxy } from "./OutputProxy";
 import { toCallable } from "./BrsFunction";
 import { BlockEnd, StopReason } from "../parser/Statement";
 import { AssociativeArray } from "../brsTypes/components/AssociativeArray";
-import { Volume } from "memfs/lib/volume";
+//import { Volume } from "memfs/lib/volume";
+const MemoryFileSystem = require("memory-fs");
 
 export interface OutputStreams {
     stdout: NodeJS.WriteStream,
@@ -42,7 +43,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
     readonly stdout: OutputProxy;
     readonly stderr: OutputProxy;
-    readonly temporaryVolume = new Volume();
+    readonly temporaryVolume: typeof MemoryFileSystem = new MemoryFileSystem();
 
     get environment() {
         return this._environment;
@@ -98,6 +99,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             { name: "Fix",          func: StdLib.Fix },
             { name: "Int",          func: StdLib.Int },
             { name: "Sgn",          func: StdLib.Sgn },
+            { name: "ListDir",      func: StdLib.ListDir },
             { name: "ReadAsciiFile", func: StdLib.ReadAsciiFile },
             { name: "WriteAsciiFile", func: StdLib.WriteAsciiFile },
             { name: "StrToI",       func: StdLib.StrToI }

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -30,8 +30,7 @@ import { OutputProxy } from "./OutputProxy";
 import { toCallable } from "./BrsFunction";
 import { BlockEnd, StopReason } from "../parser/Statement";
 import { AssociativeArray } from "../brsTypes/components/AssociativeArray";
-//import { Volume } from "memfs/lib/volume";
-const MemoryFileSystem = require("memory-fs");
+import MemoryFileSystem from "memory-fs";
 
 export interface OutputStreams {
     stdout: NodeJS.WriteStream,
@@ -43,7 +42,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
     readonly stdout: OutputProxy;
     readonly stderr: OutputProxy;
-    readonly temporaryVolume: typeof MemoryFileSystem = new MemoryFileSystem();
+    readonly temporaryVolume: MemoryFileSystem = new MemoryFileSystem();
 
     get environment() {
         return this._environment;

--- a/src/stdlib/File.ts
+++ b/src/stdlib/File.ts
@@ -189,7 +189,9 @@ export const FormatDrive = new Callable(
             returns: ValueKind.Boolean
         },
         impl: (interpreter: Interpreter, dir: BrsString) => {
-            console.warn("`FormatDrive` is not implemented in `brs`.");
+            if (process.env.NODE_ENV !== "test") {
+                console.error("`FormatDrive` is not implemented in `brs`.");
+            }
             return BrsBoolean.False;
         }
     }

--- a/src/stdlib/File.ts
+++ b/src/stdlib/File.ts
@@ -1,7 +1,7 @@
 import { Callable, ValueKind, BrsString, BrsBoolean, BrsArray } from "../brsTypes";
 import { Interpreter } from "../interpreter";
 import { URL } from "url";
-const MemoryFileSystem = require("memory-fs");
+import MemoryFileSystem from "memory-fs";
 
 /*
  * Returns a memfs volume based on the brs path uri.  For example, passing in
@@ -9,7 +9,7 @@ const MemoryFileSystem = require("memory-fs");
  * 
  * Returns invalid in no appopriate volume is found for the path
  */
-export function getVolumeByPath(interpreter: Interpreter, path: string): typeof MemoryFileSystem | null {
+export function getVolumeByPath(interpreter: Interpreter, path: string): MemoryFileSystem | null {
     try {
         const protocol = new URL(path).protocol;
         if (protocol === "tmp:") return interpreter.temporaryVolume;
@@ -27,6 +27,175 @@ export function getMemfsPath(fileUri: string) {
     return new URL(fileUri).pathname;
 }
 
+/** Copies a file from src to dst, return true if successful */
+export const CopyFile = new Callable(
+    "CopyFile",
+    {
+        signature: {
+            args: [
+                {name: "source", type: ValueKind.String},
+                {name: "destination", type: ValueKind.String}
+            ],
+            returns: ValueKind.Boolean
+        },
+        impl: (interpreter: Interpreter, src: BrsString, dst: BrsString) => {
+            const srcVolume = getVolumeByPath(interpreter, src.value);
+            if (srcVolume === null) {
+                return BrsBoolean.False;
+            }
+            const dstVolume = getVolumeByPath(interpreter, dst.value);
+            if (dstVolume === null) {
+                return BrsBoolean.False;
+            }
+
+            const srcMemfsPath = getMemfsPath(src.value);
+            const dstMemfsPath = getMemfsPath(dst.value);
+            try {
+                let contents = srcVolume.readFileSync(srcMemfsPath);
+                dstVolume.writeFileSync(dstMemfsPath, contents);
+                return BrsBoolean.True;
+            } catch (err) {
+                return BrsBoolean.False;
+            }
+        }
+    }
+);
+
+/** Copies a file from src to dst, return true if successful */
+export const MoveFile = new Callable(
+    "MoveFile",
+    {
+        signature: {
+            args: [
+                {name: "source", type: ValueKind.String},
+                {name: "destination", type: ValueKind.String}
+            ],
+            returns: ValueKind.Boolean
+        },
+        impl: (interpreter: Interpreter, src: BrsString, dst: BrsString) => {
+            const srcVolume = getVolumeByPath(interpreter, src.value);
+            if (srcVolume === null) {
+                return BrsBoolean.False;
+            }
+            const dstVolume = getVolumeByPath(interpreter, dst.value);
+            if (dstVolume === null) {
+                return BrsBoolean.False;
+            }
+
+            const srcMemfsPath = getMemfsPath(src.value);
+            const dstMemfsPath = getMemfsPath(dst.value);
+            try {
+                let contents = srcVolume.readFileSync(srcMemfsPath);
+                dstVolume.writeFileSync(dstMemfsPath, contents);
+                srcVolume.unlinkSync(srcMemfsPath);
+                return BrsBoolean.True;
+            } catch (err) {
+                return BrsBoolean.False;
+            }
+        }
+    }
+);
+
+/** Deletes a file, return true if successful */
+export const DeleteFile = new Callable(
+    "DeleteFile",
+    {
+        signature: {
+            args: [
+                {name: "file", type: ValueKind.String}
+            ],
+            returns: ValueKind.Boolean
+        },
+        impl: (interpreter: Interpreter, file: BrsString) => {
+            const volume = getVolumeByPath(interpreter, file.value);
+            if (volume === null) {
+                return BrsBoolean.False;
+            }
+
+            const memfsPath = getMemfsPath(file.value);
+            try {
+                volume.unlinkSync(memfsPath);
+                return BrsBoolean.True;
+            } catch (err) {
+                return BrsBoolean.False;
+            }
+        }
+    }
+);
+
+/** Deletes a directory (if empty), return true if successful */
+export const DeleteDirectory = new Callable(
+    "DeleteDirectory",
+    {
+        signature: {
+            args: [
+                {name: "dir", type: ValueKind.String}
+            ],
+            returns: ValueKind.Boolean
+        },
+        impl: (interpreter: Interpreter, dir: BrsString) => {
+            const volume = getVolumeByPath(interpreter, dir.value);
+            if (volume === null) {
+                return BrsBoolean.False;
+            }
+
+            const memfsPath = getMemfsPath(dir.value);
+            try {
+                volume.rmdirSync(memfsPath);
+                return BrsBoolean.True;
+            } catch (err) {
+                return BrsBoolean.False;
+            }
+        }
+    }
+);
+
+/** Creates a directory, return true if successful */
+export const CreateDirectory = new Callable(
+    "CreateDirectory",
+    {
+        signature: {
+            args: [
+                {name: "dir", type: ValueKind.String}
+            ],
+            returns: ValueKind.Boolean
+        },
+        impl: (interpreter: Interpreter, dir: BrsString) => {
+            const volume = getVolumeByPath(interpreter, dir.value);
+            if (volume === null) {
+                return BrsBoolean.False;
+            }
+
+            const memfsPath = getMemfsPath(dir.value);
+            try {
+                volume.mkdirSync(memfsPath);
+                return BrsBoolean.True;
+            } catch (err) {
+                return BrsBoolean.False;
+            }
+        }
+    }
+);
+
+/** Stubbed function for formatting a drive; always returns false */
+export const FormatDrive = new Callable(
+    "FormatDrive",
+    {
+        signature: {
+            args: [
+                {name: "drive", type: ValueKind.String},
+                {name: "fs_type", type: ValueKind.String}
+            ],
+            returns: ValueKind.Boolean
+        },
+        impl: (interpreter: Interpreter, dir: BrsString) => {
+            console.warn("`FormatDrive` is not implemented in `brs`.");
+            return BrsBoolean.False;
+        }
+    }
+);
+
+/** Returns an array of paths in a directory */
 export const ListDir = new Callable(
     "ListDir",
     {
@@ -44,14 +213,14 @@ export const ListDir = new Callable(
 
             const memfsPath = getMemfsPath(path.value);
             try {
-                let subPaths = volume.readdirSync(memfsPath);
+                let subPaths = volume.readdirSync(memfsPath).map((s) => new BrsString(s));
                 return new BrsArray(subPaths);
             } catch (err) {
                 return new BrsArray([]);
             }
         }
     }
-)
+);
 
 /** Reads ascii file from file system. */
 export const ReadAsciiFile = new Callable(

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -24,7 +24,15 @@ describe("end to end standard libary", () => {
                 allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")
             ).toEqual([
                 "false",
-                "true"
+                "true",
+                "true",
+                "true",
+                "true",
+                "true",
+                "false",
+                "true",
+                "false",
+                "<Component: roArray> =\n[\n    test_backup.txt\n]"
             ]);
         });
     });

--- a/test/e2e/resources/stdlib/files.brs
+++ b/test/e2e/resources/stdlib/files.brs
@@ -1,7 +1,10 @@
-' write bad path
-success = WriteAsciiFile("x", "some test contents")
-print(success)
-
-' write good path
-success = WriteAsciiFile("tmp:///test.txt", "some test contents")
-print(success)
+print WriteAsciiFile("x", "some test contents") ' write bad path
+print WriteAsciiFile("tmp:///test.txt", "some test contents") ' write good path
+print CopyFile("tmp:///test.txt", "tmp:///test_backup.txt") ' copy good path
+print MoveFile("tmp:///test.txt", "tmp:///test1.txt") ' good move
+print DeleteFile("tmp:///test1.txt") ' good delete
+print CreateDirectory("tmp:///test_dir") ' good create
+print DeleteDirectory("tmp:///test_dir/some_no_exist_sub") ' bad delete
+print DeleteDirectory("tmp:///test_dir") ' good delete
+print FormatDrive("does not matter", "will always fail") ' always fail
+print ListDir("tmp:///") 'what's left?

--- a/test/stdlib/File.test.js
+++ b/test/stdlib/File.test.js
@@ -1,4 +1,4 @@
-const { ListDir, ReadAsciiFile, WriteAsciiFile, getMemfsPath, getVolumeByPath } = require("../../lib/stdlib/index");
+const { ListDir, CopyFile, MoveFile, DeleteFile, DeleteDirectory, CreateDirectory, FormatDrive, ReadAsciiFile, WriteAsciiFile, getMemfsPath, getVolumeByPath } = require("../../lib/stdlib/index");
 const { Interpreter } = require("../../lib/interpreter");
 const { BrsTypes } = require("brs");
 const { BrsString } = BrsTypes;
@@ -30,13 +30,127 @@ describe("global file I/O functions", () => {
 
             expect(
                 ListDir.call(interpreter, new BrsString("tmp:///")).elements
-            ).toEqual([ "test1.txt", "test2.txt", "test_dir" ]);
+            ).toEqual([ new BrsString("test1.txt"), new BrsString("test2.txt"), new BrsString("test_dir") ]);
         });
 
         it("returns nothing on a bad path", () => {
             expect(
                 ListDir.call(interpreter, new BrsString("tmp:///ack")).elements
             ).toEqual([]);
+        });
+    });
+
+    describe("CopyFile", () => {
+        it("copies a file", () => {
+            interpreter.temporaryVolume.writeFileSync("/test1.txt", "test contents 1");
+
+            expect(
+                CopyFile.call(interpreter, new BrsString("tmp:///test1.txt"), new BrsString("tmp:///test1.1.txt")).value
+            ).toBeTruthy();
+            expect(interpreter.temporaryVolume.existsSync("/test1.txt")).toBeTruthy();
+            expect(interpreter.temporaryVolume.existsSync("/test1.1.txt")).toBeTruthy();
+        });
+
+        it("fails with a false", () => {
+            expect(
+                CopyFile.call(interpreter, new BrsString("tmp:///test1.txt"), new BrsString("ack:///test1.txt")).value
+            ).toBeFalsy();
+
+            expect(
+                CopyFile.call(interpreter, new BrsString("tmp:///no_such_file.txt"), new BrsString("tmp:///test1.txt")).value
+            ).toBeFalsy();
+        });
+    });
+
+    describe("MoveFile", () => {
+        it("moves a file", () => {
+            interpreter.temporaryVolume.writeFileSync("/test1.txt", "test contents 1");
+
+            expect(
+                MoveFile.call(interpreter, new BrsString("tmp:///test1.txt"), new BrsString("tmp:///test5.txt")).value
+            ).toBeTruthy();
+            expect(interpreter.temporaryVolume.existsSync("/test1.txt")).toBeFalsy();
+            expect(interpreter.temporaryVolume.existsSync("/test5.txt")).toBeTruthy();
+        });
+
+        it("fails with a false", () => {
+            expect(
+                MoveFile.call(interpreter, new BrsString("tmp:///test1.txt"), new BrsString("ack:///test1.txt")).value
+            ).toBeFalsy();
+
+            expect(
+                MoveFile.call(interpreter, new BrsString("tmp:///no_such_file.txt"), new BrsString("tmp:///test1.txt")).value
+            ).toBeFalsy();
+        });
+    });
+
+    describe("DeleteFile", () => {
+        it("deletes a file", () => {
+            interpreter.temporaryVolume.writeFileSync("/test1.txt", "test contents 1");
+
+            expect(
+                DeleteFile.call(interpreter, new BrsString("tmp:///test1.txt")).value
+            ).toBeTruthy();
+            expect(interpreter.temporaryVolume.existsSync("/test1.txt")).toBeFalsy();
+        });
+
+        it("fails with a false", () => {
+            expect(
+                DeleteFile.call(interpreter, new BrsString("tmp:///test1.txt")).value
+            ).toBeFalsy();
+        });
+    });
+
+    describe("DeleteDirectory", () => {
+        it("deletes a directory", () => {
+            interpreter.temporaryVolume.mkdirSync("/test_dir");
+
+            expect(
+                DeleteDirectory.call(interpreter, new BrsString("tmp:///test_dir")).value
+            ).toBeTruthy();
+            expect(interpreter.temporaryVolume.existsSync("/test_dir")).toBeFalsy();
+        });
+
+        it("fails with a false", () => {
+            interpreter.temporaryVolume.mkdirSync("/test_dir");
+            interpreter.temporaryVolume.writeFileSync("/test_dir/test1.txt", "test contents 1");
+
+            // can't remove a non-empty directory
+            expect(
+                DeleteDirectory.call(interpreter, new BrsString("tmp:///test_dir/test1.txt")).value
+            ).toBeFalsy();
+        });
+    });
+
+    describe("CreateDirectory", () => {
+        it("creates a directory", () => {
+            expect(
+                CreateDirectory.call(interpreter, new BrsString("tmp:///test_dir")).value
+            ).toBeTruthy();
+            expect(interpreter.temporaryVolume.existsSync("/test_dir")).toBeTruthy();
+
+            expect(
+                CreateDirectory.call(interpreter, new BrsString("tmp:///test_dir/test_sub_dir")).value
+            ).toBeTruthy();
+            expect(interpreter.temporaryVolume.existsSync("/test_dir/test_sub_dir")).toBeTruthy();
+
+        });
+
+        it("fails with a false", () => {
+            interpreter.temporaryVolume.mkdirSync("/test_dir");
+
+            // can't recreate a directory
+            expect(
+                CreateDirectory.call(interpreter, new BrsString("tmp:///test_dir")).value
+            ).toBeFalsy();
+        });
+    });
+
+    describe("FormatDrive", () => {
+        it("fails", () => {
+            expect(
+                FormatDrive.call(interpreter, new BrsString("foo"), new BrsString("bar")).value
+            ).toBeFalsy();
         });
     });
 

--- a/test/stdlib/File.test.js
+++ b/test/stdlib/File.test.js
@@ -1,4 +1,4 @@
-const { ReadAsciiFile, WriteAsciiFile, getMemfsPath, getVolumeByPath } = require("../../lib/stdlib/index");
+const { ListDir, ReadAsciiFile, WriteAsciiFile, getMemfsPath, getVolumeByPath } = require("../../lib/stdlib/index");
 const { Interpreter } = require("../../lib/interpreter");
 const { BrsTypes } = require("brs");
 const { BrsString } = BrsTypes;
@@ -21,6 +21,24 @@ describe("global file I/O functions", () => {
         })
     });
 
+    describe("ListDir", () => {
+        it("returns files in a directory", () => {
+            interpreter.temporaryVolume.writeFileSync("/test1.txt", "test contents 1");
+            interpreter.temporaryVolume.writeFileSync("/test2.txt", "test contents 2");
+            interpreter.temporaryVolume.mkdirpSync("/test_dir");
+            interpreter.temporaryVolume.writeFileSync("/test_dir/test3.txt", "test contents 3");
+
+            expect(
+                ListDir.call(interpreter, new BrsString("tmp:///")).elements
+            ).toEqual([ "test1.txt", "test2.txt", "test_dir" ]);
+        });
+
+        it("returns nothing on a bad path", () => {
+            expect(
+                ListDir.call(interpreter, new BrsString("tmp:///ack")).elements
+            ).toEqual([]);
+        });
+    });
 
     describe("ReadAsciiFile", () => {
         it("reads an ascii file", () => {
@@ -48,7 +66,7 @@ describe("global file I/O functions", () => {
                 WriteAsciiFile.call(interpreter, new BrsString("tmp:///hello.txt"), new BrsString("test contents")).value
             ).toBeTruthy();
 
-            expect(interpreter.temporaryVolume.toJSON()).toEqual({ "/hello.txt": "test contents" });
+            expect(interpreter.temporaryVolume.readFileSync("/hello.txt").toString()).toEqual("test contents");
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,6 +28,18 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-3.0.32.tgz#f4e5af31e9e9b196d8e5fca8a5e2e20aa3d60b69"
   integrity sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA==
 
+"@types/memory-fs@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@types/memory-fs/-/memory-fs-0.3.2.tgz#5d4753f9b390cb077c8c8af97bc96463399ceccd"
+  integrity sha512-j5AcZo7dbMxHoOimcHEIh0JZe5e1b8q8AqGSpZJrYc7xOgCIP79cIjTdx5jSDLtySnQDwkDTqwlC7Xw7uXw7qg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/node@*":
+  version "10.12.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
+  integrity sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==
+
 "@types/node@^8.5.2":
   version "8.10.38"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.38.tgz#e05c201a668492e534b48102aca0294898f449f6"
@@ -844,6 +856,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+errno@^0.1.3:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
+  integrity sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
+  dependencies:
+    prr "~1.0.1"
+
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -1028,11 +1047,6 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-extend@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/fast-extend/-/fast-extend-0.0.2.tgz#f5ec42cf40b9460f521a6387dfb52deeed671dbd"
-  integrity sha1-9exCz0C5Rg9SGmOH37Ut7u1nHb0=
-
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -1138,11 +1152,6 @@ fs-minipass@^1.2.5:
   integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
   dependencies:
     minipass "^2.2.1"
-
-fs-monkey@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-0.3.3.tgz#7960bb2b1fa2653731b9d0e2e84812a7e8b3664a"
-  integrity sha512-FNUvuTAJ3CqCQb5ELn+qCbGR/Zllhf2HtwsdAtBi59s1WeCjKMT81fHcSu7dwIskqGVK+MmOrb7VOBlq3/SItw==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2252,13 +2261,13 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-memfs@2.13.1:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-2.13.1.tgz#5a2057d3bd7f19775ffc89bebccf34e7d307fbf8"
-  integrity sha512-va1V7jgTXsH5wbxhp4n3MWQGXm8PYyWTFUsXOU4zJNr3oMz6uUJzdDjgG4z8C8ZQ5zskyFZ94qJPwy08xeS/og==
+memory-fs@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
+  integrity sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
   dependencies:
-    fast-extend "0.0.2"
-    fs-monkey "^0.3.3"
+    errno "^0.1.3"
+    readable-stream "^2.0.1"
 
 memorystream@^0.3.1:
   version "0.3.1"
@@ -2839,6 +2848,11 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
+
+prr@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+  integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
 pseudomap@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This implements the file functions not already covered with the exception of MatchFiles, which I'll move to another issue.  Most of these functions wrap existing fs functions that have similar behavior (ex. not allowing deletion of a non-empty directory).  

Functions defined include:
* ListDir
* CopyFile
* MoveFile
* DeleteFile
* DeleteDirectory
* CreateDirectory
* FormatDrive

Although, _FormatDrive_ is stubbed as not implemented.  

Closes #87