### PR TITLE
fix(interp): Allow named functions to shadow global stdlib functions

### DIFF
--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -114,14 +114,22 @@ export class Environment {
     /**
      * Determines whether or not a variable exists in this environment.
      * @param name the name of the variable to search for (in the form of an `Identifier`)
+     * @param scopeFilter the set of scopes with which to limit searches for `name`
      * @returns `true` if this environment contains `name`, otherwise `false`
      */
-    public has(name: Identifier): boolean {
-        try {
-            return this.get(name) != null;
-        } catch (err) {
-            return false;
+    public has(name: Identifier, scopeFilter: Scope[] = [Scope.Global, Scope.Module, Scope.Function]): boolean {
+        if (name.text.toLowerCase() === "m") {
+            return true; // we always have an `m` scope of some sort!
         }
+
+        let lowercaseName = name.text.toLowerCase();
+        return scopeFilter.map(scopeName => {
+            switch (scopeName) {
+                case Scope.Global: return this.global;
+                case Scope.Module: return this.module;
+                case Scope.Function: return this.function;
+            }
+        }).find(scope => scope.has(lowercaseName)) != null;
     }
 
     /**

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -102,12 +102,12 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             throw BrsError.make(`Cannot create a named function with reserved name '${statement.name.text}'`, statement.name.line);
         }
 
-        if (this.environment.has(statement.name)) {
+        if (this.environment.has(statement.name, [Scope.Module])) {
             // TODO: Figure out how to determine where the original version was declared
             // Maybe `Environment.define` records the location along with the value?
             BrsError.make(
                 `Attempting to declare function '${statement.name.text}', but ` +
-                `a property of that name already exists.`,
+                `a property of that name already exists in this scope.`,
                 statement.name.line
             );
             return BrsInvalid.Instance;

--- a/test/interpreter/FunctionDeclaration.test.js
+++ b/test/interpreter/FunctionDeclaration.test.js
@@ -243,4 +243,19 @@ describe("interpreter function declarations", () => {
 
         expect(() => interpreter.exec(statements)).toThrow(/reserved name/);
     });
+
+    it("allows functions to override global stdlib functions", () => {
+        let statements = [
+            new Stmt.Function(
+                { kind: Lexeme.Identifier, text: "UCase", isReserved: false, line: 1 },
+                new Expr.Function(
+                    [], // accepts no arguments
+                    ValueKind.Void, // returns nothing
+                    new Stmt.Block([]) // does nothing. It's a really silly function, but the implementation doesn't matter
+                )
+            )
+        ];
+
+        expect(() => interpreter.exec(statements)).not.toThrow();
+    });
 });


### PR DESCRIPTION
This allows a custom `Substitute` function to be created that accepts more than the default three arguments!  Pretty handy.