### PR TITLE
fix(interp): Allow all types to be compared for equality to `invalid`

### DIFF
--- a/src/brsTypes/index.ts
+++ b/src/brsTypes/index.ts
@@ -6,6 +6,7 @@ import { Int64 } from "./Int64";
 import { Float } from "./Float";
 import { Double } from "./Double";
 import { Callable, CallableImplementation } from "./Callable";
+import { Lexeme } from "../lexer";
 
 export * from "./BrsType";
 export * from "./Int32";
@@ -62,7 +63,7 @@ export function isBrsCallable(value: BrsType): value is Callable {
 }
 
 /**
- * Determines whether or not the provided value is an instance of a interable BrightScript type.
+ * Determines whether or not the provided value is an instance of a iterable BrightScript type.
  * @param value the BrightScript value in question.
  * @returns `true` if `value` can be iterated across, otherwise `false`.
  */
@@ -72,11 +73,6 @@ export function isIterable(value: BrsType): value is Iterable {
     }
 
     return value.getElements != null;
-}
-
-/** Determines whether or not the provided value is comparable to other BrightScript values. */
-export function isComparable(value: BrsType): value is BrsPrimitive {
-    return value.kind < ValueKind.Dynamic;
 }
 
 /** The set of BrightScript numeric types. */

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -205,72 +205,66 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 if (isBrsNumber(left) && isBrsNumber(right)) {
                     return left.subtract(right);
                 } else {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to subtract non-numeric values.",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
             case Lexeme.Star:
                 if (isBrsNumber(left) && isBrsNumber(right)) {
                     return left.multiply(right);
                 } else {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to multiply non-numeric values.",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
             case Lexeme.Caret:
                 if (isBrsNumber(left) && isBrsNumber(right)) {
                     return left.pow(right);
                 } else {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to exponentiate non-numeric values.",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
             case Lexeme.Slash:
                 if (isBrsNumber(left) && isBrsNumber(right)) {
                     return left.divide(right);
                 }
-                BrsError.typeMismatch({
+                throw BrsError.typeMismatch({
                     message: "Attempting to dividie non-numeric values.",
                     left: left,
                     right: right,
                     line: expression.token.line
                 });
-                return BrsInvalid.Instance;
             case Lexeme.Mod:
                 if (isBrsNumber(left) && isBrsNumber(right)) {
                     return left.modulo(right);
                 } else {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to modulo non-numeric values.",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
             case Lexeme.Backslash:
                 if (isBrsNumber(left) && isBrsNumber(right)) {
                     return left.intDivide(right);
                 } else {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to integer-divide non-numeric values.",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
             case Lexeme.Plus:
                 if (isBrsNumber(left) && isBrsNumber(right)) {
@@ -278,83 +272,76 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 } else if (isBrsString(left) && isBrsString(right)) {
                     return left.concat(right);
                 } else {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to add non-homogeneous values.",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
             case Lexeme.Greater:
                 if (!isComparable(left) || !isComparable(right)) {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to compare non-primitive values.",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
 
                 return left.greaterThan(right);
             case Lexeme.GreaterEqual:
                 if (!isComparable(left) || !isComparable(right)) {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to compare non-primitive values.",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
 
                 return left.greaterThan(right).or(left.equalTo(right));
             case Lexeme.Less:
                 if (!isComparable(left) || !isComparable(right)) {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to compare non-primitive values.",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
 
                 return left.lessThan(right);
             case Lexeme.LessEqual:
                 if (!isComparable(left) || !isComparable(right)) {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to compare non-primitive values.",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
 
                 return left.lessThan(right).or(left.equalTo(right));
             case Lexeme.Equal:
                 if (!isComparable(left) || !isComparable(right)) {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to compare non-primitive values.",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
 
                 return left.equalTo(right);
             case Lexeme.LessGreater:
                 if (!isComparable(left) || !isComparable(right)) {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to compare non-primitive values.",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
 
                 return left.equalTo(right).not();
@@ -368,13 +355,12 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                         return (left as BrsBoolean).and(right);
                     }
 
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to 'and' boolean with non-boolean value",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 } else if (isBrsNumber(left)) {
                     right = this.evaluate(expression.right);
 
@@ -384,21 +370,19 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                     }
 
                     // TODO: figure out how to handle 32-bit int AND 64-bit int
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to bitwise 'and' number with non-numberic value",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 } else {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to 'and' unexpected values",
                         left: left,
                         right: this.evaluate(expression.right),
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
             case Lexeme.Or:
                 if (isBrsBoolean(left) && left.toBoolean()) {
@@ -409,13 +393,12 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                     if (isBrsBoolean(right)) {
                         return (left as BrsBoolean).or(right);
                     } else {
-                        BrsError.typeMismatch({
+                        throw BrsError.typeMismatch({
                             message: "Attempting to 'or' boolean with non-boolean value",
                             left: left,
                             right: right,
                             line: expression.token.line
                         });
-                        return BrsInvalid.Instance;
                     }
                 } else if (isBrsNumber(left)) {
                     right = this.evaluate(expression.right);
@@ -424,21 +407,19 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                     }
 
                     // TODO: figure out how to handle 32-bit int OR 64-bit int
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to bitwise 'or' number with non-numeric expression",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 } else {
-                    BrsError.typeMismatch({
+                    throw BrsError.typeMismatch({
                         message: "Attempting to 'or' unexpected values",
                         left: left,
                         right: right,
                         line: expression.token.line
                     });
-                    return BrsInvalid.Instance;
                 }
             default:
                 BrsError.make(

--- a/test/interpreter/Arithmetic.test.js
+++ b/test/interpreter/Arithmetic.test.js
@@ -112,9 +112,8 @@ describe("interpreter arithmetic", () => {
             )
         );
 
-        let [ result ] = interpreter.exec([ast]);
+        expect(() => interpreter.exec([ast])).toThrow(/Attempting to add non-homogeneous values/);
         expect(BrsError.found()).toBe(true);
-        expect(result).toBe(BrsTypes.BrsInvalid.Instance);
     });
 
     it("bitwise ANDs integers", () => {

--- a/test/interpreter/BooleanAlgebra.test.js
+++ b/test/interpreter/BooleanAlgebra.test.js
@@ -48,9 +48,8 @@ describe("interpreter boolean algebra", () => {
             )
         );
 
-        let [result] = interpreter.exec([ast]);
+        expect(() => interpreter.exec([ast])).toThrow(/Attempting to 'and' boolean/);
         expect(BrsError.found()).toBe(true);
-        expect(result).toEqual(BrsTypes.BrsInvalid.Instance);
     });
 
     it("doesn't allow mixed-type ORs", () => {
@@ -62,8 +61,7 @@ describe("interpreter boolean algebra", () => {
             )
         );
 
-        let [result] = interpreter.exec([ast]);
+        expect(() => interpreter.exec([ast])).toThrow(/Attempting to 'or' boolean/);
         expect(BrsError.found()).toBe(true);
-        expect(result).toEqual(BrsTypes.BrsInvalid.Instance);
     });
 });

--- a/test/interpreter/Comparison.test.js
+++ b/test/interpreter/Comparison.test.js
@@ -99,11 +99,9 @@ describe("interpreter comparisons", () => {
             test(name, () => {
                 let arr = new BrsArray([]);
 
-                expect(
-                    interpreter.exec(
-                        [ binary(arr, operator, arr) ]
-                    )
-                ).toEqual([ BrsInvalid.Instance ]);
+                expect(() => interpreter.exec(
+                    [ binary(arr, operator, arr) ]
+                )).toThrow(/Attempting to compare non-primitive values/);
                 expect(BrsError.found()).toBe(true);
             });
         });

--- a/test/interpreter/Comparison.test.js
+++ b/test/interpreter/Comparison.test.js
@@ -2,7 +2,7 @@ const BrsError = require("../../lib/Error");
 const { binary } = require("./InterpreterTests");
 const { Interpreter } = require("../../lib/interpreter");
 const { Lexeme, BrsTypes } = require("brs");
-const { Int32, Int64, Float, Double, BrsString, BrsBoolean, BrsArray, BrsInvalid } = BrsTypes;
+const { Int32, Int64, Float, Double, BrsString, BrsBoolean, BrsArray, BrsInvalid, AssociativeArray } = BrsTypes;
 
 let interpreter;
 
@@ -107,7 +107,56 @@ describe("interpreter comparisons", () => {
         });
     });
 
-    describe("invalid mixed-type comparisons", () => {
+    describe("`invalid` comparisons", () => {
+        let invalid = BrsInvalid.Instance;
+
+        [
+            { name: "boolean", value: BrsBoolean.True },
+            { name: "string", value: new BrsString("foo") },
+            { name: "32-bit integer", value: new Int32(5) },
+            { name: "64-bit integer", value: new Int64(-1111111111) },
+            { name: "float", value: new Float(3.4) },
+            { name: "double", value: new Double(7.8) },
+            { name: "array", value: new BrsArray([]) },
+            { name: "associative array", value: new AssociativeArray([]) }
+        ].forEach(({ name, value }) => {
+            test(name, () => {
+                expect(interpreter.exec([
+                    binary(value, Lexeme.Equal, invalid),
+                    binary(invalid, Lexeme.Equal, value),
+                    binary(value, Lexeme.LessGreater, invalid),
+                    binary(invalid, Lexeme.LessGreater, value),
+                ])).toEqual([
+                    BrsBoolean.False,
+                    BrsBoolean.False,
+                    BrsBoolean.True,
+                    BrsBoolean.True
+                ]);
+
+                [ Lexeme.Less, Lexeme.LessEqual, Lexeme.Greater, Lexeme.GreaterEqual ].forEach(operator => {
+                    expect(() => interpreter.exec([
+                        binary(value, operator, invalid)
+                    ])).toThrow(/Attempting to compare non-primitive values/);
+
+                    expect(() => interpreter.exec([
+                        binary(invalid, operator, value)
+                    ])).toThrow(/Attempting to compare non-primitive values/);
+                });
+            });
+        });
+
+        test("invalid", () =>
+            expect(interpreter.exec([
+                binary(invalid, Lexeme.Equal, invalid),
+                binary(invalid, Lexeme.LessGreater, invalid),
+            ])).toEqual([
+                BrsBoolean.True,
+                BrsBoolean.False
+            ])
+        );
+    });
+
+    describe("disallowed mixed-type comparisons", () => {
         let int32 = new Int32(2);
         let str = new BrsString("two");
         let int64 = new Int64(2);


### PR DESCRIPTION
Comparing runtime values for equality to `invalid` is the only way to check if a value exists, so it needs to be supported in this implementation.  This also prevents continued execution if a type mismatch _is_ encountered.

fixes #112 