### PR TITLE
chore(cleanup): Remove unnecessary `Stringify` module

### DIFF
--- a/src/Stringify.ts
+++ b/src/Stringify.ts
@@ -1,5 +1,0 @@
-import { BrsType } from "./brsTypes";
-
-export function stringify(value: BrsType) {
-    return value.toString();
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ const readFile = promisify(fs.readFile);
 import { Token, Lexer } from "./lexer";
 import * as Parser from "./parser";
 import { Interpreter, OutputStreams } from "./interpreter";
-import { stringify } from "./Stringify";
 import * as BrsError from "./Error";
 
 export { Lexeme, Token, Lexer } from "./lexer";
@@ -92,7 +91,7 @@ export function repl() {
     rl.on("line", (line) => {
         let results = run(line, processOutput, replInterpreter);
         if (results) {
-            results.map(result => console.log(stringify(result)));
+            results.map(result => console.log(result.toString()));
         }
 
         BrsError.reset();

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -21,7 +21,6 @@ import {
 import * as Expr from "../parser/Expression";
 import * as Stmt from "../parser/Statement";
 import { Lexeme } from "../lexer";
-import { stringify } from "../Stringify";
 import * as BrsError from "../Error";
 
 import * as StdLib from "../stdlib";
@@ -160,9 +159,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                     break;
                 default:
                     this.stdout.write(
-                        stringify(
-                            this.evaluate(printable)
-                        )
+                        this.evaluate(printable).toString()
                     );
                     break;
             }


### PR DESCRIPTION
All it did was call `.toString()` on things.  That doesn't really warrant a separate function and module 🤷‍♂️.  It seemed like a good idea at the time!