### PR TITLE
chore(infra): Test on node 6, 8, and 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "6"
-  - "lts/*"
+  - "8"
   - "10"
 before_script: yarn build
 script:


### PR DESCRIPTION
We're in a neat time period where `node` 6.x is in the "maintenance LTS" phase, and both 8.x and 10.x are in the "active LTS" phase [[source]](https://github.com/nodejs/Release/tree/887d5e73cba5b3f9225dd81625f97a0f288e2079#release-schedule).  Let's make sure this project still works on all those versions!