### PR TITLE
Add BRS runtime error handling

### DIFF
--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -81,6 +81,9 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         try {
             this._environment = newEnv;
             return func(this);
+        } catch (err) {
+            console.error("Runtime error encountered in BRS implementation: ", err);
+            throw err;
         } finally {
             this._environment = originalEnvironment;
         }

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -82,7 +82,9 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             this._environment = newEnv;
             return func(this);
         } catch (err) {
-            console.error("Runtime error encountered in BRS implementation: ", err);
+            if (err.kind == null) {
+                console.error("Runtime error encountered in BRS implementation: ", err);
+            }
             throw err;
         } finally {
             this._environment = originalEnvironment;


### PR DESCRIPTION
While working on `createObject("roTimespan")`, I noticed when calling a method it wasn't logging or returning anything. With @sjbarag's help it was discovered that were just weren't showing runtime errors in the interpreter. Now we should show them so we know what's going on! Useful! 