### PR TITLE
chore(infra): Speed travis builds up a tick

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "6"
   - "8"
   - "10"
+# cache dependencies between jobs (on a per-runtime-version basis)
+cache: yarn
 before_script: yarn build
 script:
   - yarn lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ cache: yarn
 before_script: yarn build
 script:
   - yarn lint
-  - yarn test
+  # reduce process creation on Travis builds
+  - yarn test --runInBand


### PR DESCRIPTION
This enables a cache for yarn dependencies (saves ~5 seconds per job) and serializes all the unit test to reduce CPU thrashing (saves a little bit, but it's hard to tell because of variances in Travis' workload).

It can't hurt I guess?