### PR TITLE
Remove stray line from math.brs

### DIFF
--- a/test/e2e/resources/stdlib/math.brs
+++ b/test/e2e/resources/stdlib/math.brs
@@ -1,5 +1,3 @@
-mixedCase = "Mixed Case"
-
 print Exp(3.1)
 print Log(17.4)
 print Sqr(11.17)


### PR DESCRIPTION
This line looks like it was copied from `../strings.brs` by accident.

(Also the GitHub web editor adds a newline to files, apparently.)

/me goes back to lurking