### PR TITLE
chore(parse,interp): Remove unused Expressions

### DIFF
--- a/src/interpreter/AstPrinter.ts
+++ b/src/interpreter/AstPrinter.ts
@@ -14,10 +14,6 @@ export class AstPrinter implements Expr.Visitor<string> {
         return expression.accept(this);
     }
 
-    visitAssign(e: Expr.Assign): string {
-        return JSON.stringify(e, undefined, 2);
-    }
-
     visitAnonymousFunction(e: Expr.Function): string {
         return JSON.stringify(e, undefined, 2);
     }
@@ -45,12 +41,6 @@ export class AstPrinter implements Expr.Visitor<string> {
         return JSON.stringify(e, undefined, 2);
     }
     visitAALiteral(e: Expr.AALiteral): string {
-        return JSON.stringify(e, undefined, 2);
-    }
-    visitLogical(e: Expr.Logical): string {
-        return JSON.stringify(e, undefined, 2);
-    }
-    visitM(e: Expr.M): string {
         return JSON.stringify(e, undefined, 2);
     }
     visitDottedSet(e: Stmt.DottedSet): string {

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -116,10 +116,6 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         }
     }
 
-    visitAssign(statement: Expr.Assign): BrsType {
-        return BrsInvalid.Instance;
-    }
-
     visitNamedFunction(statement: Stmt.Function): BrsType {
         if (statement.name.isReserved) {
             throw BrsError.make(`Cannot create a named function with reserved name '${statement.name.text}'`, statement.name.line);
@@ -816,13 +812,6 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         );
     }
 
-    visitLogical(expression: Expr.Logical) {
-        return BrsInvalid.Instance;
-    }
-    visitM(expression: Expr.M) {
-        return BrsInvalid.Instance;
-    }
-
     visitDottedSet(statement: Stmt.DottedSet) {
         let source = this.evaluate(statement.obj);
         let value = this.evaluate(statement.value);
@@ -833,7 +822,6 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 line: statement.name.line,
                 left: source
             });
-            return BrsInvalid.Instance;
         }
 
         try {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -3,7 +3,6 @@ import { BrsType, Argument, ValueKind, BrsString } from "../brsTypes";
 import { Block } from "./Statement";
 
 export interface Visitor<T> {
-    visitAssign(expression: Assign): T;
     visitBinary(expression: Binary): T;
     visitCall(expression: Call): T;
     visitAnonymousFunction(func: Function): T;
@@ -13,25 +12,12 @@ export interface Visitor<T> {
     visitLiteral(expression: Literal): T;
     visitArrayLiteral(expression: ArrayLiteral): T;
     visitAALiteral(expression: AALiteral): T;
-    visitLogical(expression: Logical): T;
-    visitM(expression: M): T;
     visitUnary(expression: Unary): T;
     visitVariable(expression: Variable): T;
 }
 
 export interface Expression {
     accept <R> (visitor: Visitor<R>): R;
-}
-
-export class Assign implements Expression {
-    constructor(
-        readonly name: Token,
-        readonly value: Expression
-    ) {}
-
-    accept <R> (visitor: Visitor<R>): R {
-        return visitor.visitAssign(this);
-    }
 }
 
 export class Binary implements Expression {
@@ -136,26 +122,6 @@ export class AALiteral implements Expression {
 
     accept <R> (visitor: Visitor<R>): R {
         return visitor.visitAALiteral(this);
-    }
-}
-
-export class Logical implements Expression {
-    constructor(
-        readonly left: Expression,
-        readonly operator: Token,
-        readonly right: Expression
-    ) {}
-
-    accept<R>(visitor: Visitor<R>): R {
-        return visitor.visitLogical(this);
-    }
-}
-
-export class M implements Expression {
-    constructor(readonly keyword: Token) {}
-
-    accept<R>(visitor: Visitor<R>): R {
-        return visitor.visitM(this);
     }
 }
 


### PR DESCRIPTION
I added a few types of expressions but then never uesd them!  No need to keep them around anymore.