### PR TITLE
fix(parse): Allow ':'-separated function expressions

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -136,7 +136,7 @@ function functionDeclaration(isAnonymous: boolean) {
         return haveFoundOptional || !!arg.defaultValue;
     }, false);
 
-    consume(`Expected newline after ${functionType} signature`, Lexeme.Newline);
+    consume(`Expected newline or ':' after ${functionType} signature`, Lexeme.Newline, Lexeme.Colon);
     let body = block(isSub ? Lexeme.EndSub : Lexeme.EndFunction);
     if (!body) {
         throw ParseError.make(peek(), `Expected 'end ${functionType}' to terminate ${functionType} block`);

--- a/test/parser/expression/Function.test.js
+++ b/test/parser/expression/Function.test.js
@@ -26,6 +26,27 @@ describe("parser", () => {
             expect(parsed).toMatchSnapshot();
         });
 
+        it("parses colon-separated function declarations", () => {
+            let parsed = Parser.parse([
+                { kind: Lexeme.Identifier, text: "_", line: 1 },
+                { kind: Lexeme.Equal, text: "=", line: 1 },
+                { kind: Lexeme.Function, text: "function", line: 1 },
+                { kind: Lexeme.LeftParen, text: "(", line: 1 },
+                { kind: Lexeme.RightParen, text: ")", line: 1 },
+                { kind: Lexeme.Colon, text: ":", line: 1 },
+                { kind: Lexeme.Print, text: "print", line: 2 },
+                { kind: Lexeme.String, text: "Lorem ipsum", line: 2, literal: new BrsString("Lorem ipsum") },
+                { kind: Lexeme.Colon, text: ":", line: 2 },
+                { kind: Lexeme.EndFunction, text: "end function", line: 3 },
+                EOF
+            ]);
+
+            expect(BrsError.found()).toBeFalsy();
+            expect(parsed).toBeDefined();
+            expect(parsed).not.toBeNull();
+            expect(parsed).toMatchSnapshot();
+        });
+
         it("parses non-empty function expressions", () => {
             let parsed = Parser.parse([
                 { kind: Lexeme.Identifier, text: "_", line: 1 },

--- a/test/parser/expression/__snapshots__/Function.test.js.snap
+++ b/test/parser/expression/__snapshots__/Function.test.js.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parser function expressions parses colon-separated function declarations 1`] = `
+Array [
+  Assignment {
+    "name": Object {
+      "kind": 21,
+      "line": 1,
+      "text": "_",
+    },
+    "value": Function {
+      "body": Block {
+        "statements": Array [
+          Print {
+            "expressions": Array [
+              Literal {
+                "value": BrsString {
+                  "kind": 2,
+                  "value": "Lorem ipsum",
+                },
+              },
+            ],
+          },
+        ],
+      },
+      "parameters": Array [],
+      "returns": 9,
+    },
+  },
+]
+`;
+
 exports[`parser function expressions parses functions with default argument expressions 1`] = `
 Array [
   Assignment {


### PR DESCRIPTION
[rodash](https://github.com/Tubitv/rodash) currently causes a parse
failure for its oneliner anonymous function form:

```brightscript
fn = Function(x): return x: End FUnction
```

I forgot to allow `:` in function declarations instead of newlines!

fixes #133