### PR TITLE
chore(infra): Upgrade to typescript@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^2.6.2",
     "tslint": "^5.11.0",
     "tslint-language-service": "^0.9.9",
-    "typescript": "^2.6.2"
+    "typescript": "3"
   },
   "repository": "https://github.com/sjbarag/brs",
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3625,10 +3625,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^2.6.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
+typescript@3:
+  version "3.2.4"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
+  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
TypeScript 2.x seems to have some weird behavior where a destructured import of a type alias results in `import("../../../../../../path/to/file")` appearing wherever that alias is used.  This caused some of my directory structure to leak into the exported type files.  Now everyone knows I have a `src/` directory :sob:.

Upgrading to TypeScript 3 seems to fix that, and I wanted to do that eventually anyway.

fixes #137