### PR TITLE
fix(build): Use npmjs.com as registry instead of yarnpkg.com

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry = "https://registry.yarnpkg.com/"
+registry = "https://registry.npmjs.com/"


### PR DESCRIPTION
This package is actually published to npmjs.com and mirrored to
yarnpkg.com instead of directly to yarnpkg.com.