### PR TITLE
Make project installable directly from GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "brs": "./bin/cli.js"
   },
   "scripts": {
+    "prepare": "tsc",
     "build": "tsc",
     "clean": "rimraf ./lib ./types",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "prepublishOnly": "npm-run-all --serial clean build lint test"
   },
   "files": [
-    "./bin/",
-    "./lib/",
-    "./types/"
+    "bin/**/*",
+    "lib/**/*",
+    "types/**/*"
   ],
   "dependencies": {
     "commander": "^2.12.2",


### PR DESCRIPTION
Based on [this blog post](https://blog.jim-nielsen.com/2018/installing-and-building-an-npm-package-from-github/), you can install npm packages directly from GitHub, and have the sources built locally at install time. This would be very helpful for me right now, as I'm using the bleeding edge features in master. I tested, and this change does indeed enable me to npm install directly from github.

The change is subtle. You need a `prepare` script in your `package.json`. Also, your `files` array needed to be changed to a glob format, otherwise the local build will fail because the necessary files are missing due to not matching the patterns for some reason. 

I ran `npm publish --dry-run` before and after my changes, and the output is quite a bit different, but I'm not really sure how the npm publish was ever actually working previously, because it was including like no files at all. You may want to test publish once after this to make sure everything still works the same, but I think it should be fine. 

Here's the `npm publish --dry-run` output BEFORE my change.
```
npm notice
npm notice package: brs@0.13.0-beta.1
npm notice === Tarball Contents ===
npm notice 1.3kB  package.json
npm notice 1.1kB  LICENSE
npm notice 3.7kB  README.md
npm notice 12.0kB lib/index.js
npm notice === Tarball Details ===
npm notice name:          brs
npm notice version:       0.13.0-beta.1
npm notice package size:  6.7 kB
npm notice unpacked size: 18.0 kB
npm notice shasum:        d502f666dccb85ff7e00b64c52639c1d1a21e975
npm notice integrity:     sha512-u7Eo4e913DVWn[...]6otDRom/y/EAg==
npm notice total files:   4
npm notice
+ brs@0.13.0-beta.1
```

And here's the `npm publish --dry-run` after my change

```
npm notice
npm notice package: brs@0.13.0-beta.1
npm notice === Tarball Contents ===
npm notice 1.3kB  package.json
npm notice 1.1kB  LICENSE
npm notice 3.7kB  README.md
npm notice 1.2kB  bin/cli.js
npm notice 293B   lib/brsTypes/BrsNumber.js
npm notice 14.3kB lib/brsTypes/BrsType.js
npm notice 10.6kB lib/brsTypes/Callable.js
npm notice 15.6kB lib/brsTypes/components/AssociativeArray.js
npm notice 12.5kB lib/brsTypes/components/BrsArray.js
npm notice 1.5kB  lib/brsTypes/components/BrsComponent.js
npm notice 1.2kB  lib/brsTypes/components/BrsObjects.js
npm notice 6.3kB  lib/brsTypes/components/Timespan.js
npm notice 14.0kB lib/brsTypes/Double.js
npm notice 16.0kB lib/brsTypes/Float.js
npm notice 4.0kB  lib/brsTypes/index.js
npm notice 17.2kB lib/brsTypes/Int32.js
npm notice 16.9kB lib/brsTypes/Int64.js
npm notice 2.2kB  lib/Error.js
npm notice 12.0kB lib/index.js
npm notice 5.3kB  lib/interpreter/AstPrinter.js
npm notice 1.5kB  lib/interpreter/BrsFunction.js
npm notice 9.7kB  lib/interpreter/Environment.js
npm notice 71.2kB lib/interpreter/index.js
npm notice 2.9kB  lib/interpreter/OutputProxy.js
npm notice 2.8kB  lib/lexer/Characters.js
npm notice 603B   lib/lexer/index.js
npm notice 6.9kB  lib/lexer/Lexeme.js
npm notice 37.8kB lib/lexer/Lexer.js
npm notice 5.5kB  lib/lexer/ReservedWords.js
npm notice 277B   lib/lexer/Token.js
npm notice 2.1kB  lib/parser/BlockEndReason.js
npm notice 5.8kB  lib/parser/Expression.js
npm notice 1.1kB  lib/parser/index.js
npm notice 1.0kB  lib/parser/ParseError.js
npm notice 63.9kB lib/parser/Parser.js
npm notice 8.6kB  lib/parser/Statement.js
npm notice 3.2kB  lib/preprocessor/Chunk.js
npm notice 4.8kB  lib/preprocessor/index.js
npm notice 9.9kB  lib/preprocessor/Manifest.js
npm notice 13.3kB lib/preprocessor/Parser.js
npm notice 10.9kB lib/preprocessor/Preprocessor.js
npm notice 3.5kB  lib/stdlib/CreateObject.js
npm notice 17.1kB lib/stdlib/File.js
npm notice 1.6kB  lib/stdlib/index.js
npm notice 10.8kB lib/stdlib/Json.js
npm notice 13.5kB lib/stdlib/Math.js
npm notice 3.3kB  lib/stdlib/Print.js
npm notice 20.3kB lib/stdlib/String.js
npm notice 2.3kB  lib/stdlib/Type.js
npm notice 3.5kB  types/brsTypes/BrsNumber.d.ts
npm notice 5.1kB  types/brsTypes/BrsType.d.ts
npm notice 4.9kB  types/brsTypes/Callable.d.ts
npm notice 2.0kB  types/brsTypes/components/AssociativeArray.d.ts
npm notice 858B   types/brsTypes/components/BrsArray.d.ts
npm notice 1.2kB  types/brsTypes/components/BrsComponent.d.ts
npm notice 135B   types/brsTypes/components/BrsObjects.d.ts
npm notice 899B   types/brsTypes/components/Timespan.d.ts
npm notice 1.7kB  types/brsTypes/Double.d.ts
npm notice 1.7kB  types/brsTypes/Float.d.ts
npm notice 2.7kB  types/brsTypes/index.d.ts
npm notice 1.7kB  types/brsTypes/Int32.d.ts
npm notice 1.6kB  types/brsTypes/Int64.d.ts
npm notice 1.1kB  types/Error.d.ts
npm notice 1.2kB  types/index.d.ts
npm notice 1.4kB  types/interpreter/AstPrinter.d.ts
npm notice 479B   types/interpreter/BrsFunction.d.ts
npm notice 4.0kB  types/interpreter/Environment.d.ts
npm notice 4.6kB  types/interpreter/index.d.ts
npm notice 1.0kB  types/interpreter/OutputProxy.d.ts
npm notice 973B   types/lexer/Characters.d.ts
npm notice 121B   types/lexer/index.d.ts
npm notice 1.6kB  types/lexer/Lexeme.d.ts
npm notice 2.0kB  types/lexer/Lexer.d.ts
npm notice 623B   types/lexer/ReservedWords.d.ts
npm notice 763B   types/lexer/Token.d.ts
npm notice 1.5kB  types/parser/BlockEndReason.d.ts
npm notice 3.4kB  types/parser/Expression.d.ts
npm notice 206B   types/parser/index.d.ts
npm notice 177B   types/parser/ParseError.d.ts
npm notice 2.1kB  types/parser/Parser.d.ts
npm notice 5.5kB  types/parser/Statement.d.ts
npm notice 2.5kB  types/preprocessor/Chunk.d.ts
npm notice 1.7kB  types/preprocessor/index.d.ts
npm notice 1.1kB  types/preprocessor/Manifest.d.ts
npm notice 1.1kB  types/preprocessor/Parser.d.ts
npm notice 3.4kB  types/preprocessor/Preprocessor.d.ts
npm notice 178B   types/stdlib/CreateObject.d.ts
npm notice 1.2kB  types/stdlib/File.d.ts
npm notice 273B   types/stdlib/index.d.ts
npm notice 128B   types/stdlib/Json.d.ts
npm notice 1.9kB  types/stdlib/Math.d.ts
npm notice 598B   types/stdlib/Print.d.ts
npm notice 1.8kB  types/stdlib/String.d.ts
npm notice 79B    types/stdlib/Type.d.ts
npm notice === Tarball Details ===
npm notice name:          brs
npm notice version:       0.13.0-beta.1
npm notice package size:  111.9 kB
npm notice unpacked size: 570.2 kB
npm notice shasum:        644b57023091b0277b30d099629840f6a40bae3a
npm notice integrity:     sha512-FwS0hJFnZLF09[...]lv7Fka9B9XoDw==
npm notice total files:   94
npm notice
+ brs@0.13.0-beta.1
```