### PR TITLE
fix(parse): Allow `next` keyword as synonym for `end for`

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -21,6 +21,7 @@ type BlockTerminator =
     Lexeme.ElseIf |
     Lexeme.Else |
     Lexeme.EndFor |
+    Lexeme.Next |
     Lexeme.EndIf |
     Lexeme.EndWhile |
     Lexeme.EndSub |
@@ -342,10 +343,10 @@ export class Parser {
             }
             while(match(Lexeme.Newline));
 
-            let body = block(Lexeme.EndFor);
+            let body = block(Lexeme.EndFor, Lexeme.Next);
             if (!body) {
                 return addError(
-                    new ParseError(peek(), "Expected 'end for' to terminate for-loop block")
+                    new ParseError(peek(), "Expected 'end for' or 'next' to terminate for-loop block")
                 );
             }
             advance();
@@ -377,10 +378,10 @@ export class Parser {
             advance();
             while(match(Lexeme.Newline));
 
-            let body = block(Lexeme.EndFor);
+            let body = block(Lexeme.EndFor, Lexeme.Next);
             if (!body) {
                 return addError(
-                    new ParseError(peek(), "Expected 'end for' to terminate for-each loop block")
+                    new ParseError(peek(), "Expected 'end for' or 'next' to terminate for-loop block")
                 );
             }
             advance();

--- a/test/parser/controlFlow/For.test.js
+++ b/test/parser/controlFlow/For.test.js
@@ -60,4 +60,24 @@ describe("parser for loops", () => {
 
         expect(statements).toMatchSnapshot();
     });
+
+    it("allows 'next' to terminate loop", () => {
+        let { statements, errors } = parser.parse([
+            { kind: Lexeme.For, text: "for", line: 1 },
+            { kind: Lexeme.Identifier, text: "i", line: 1 },
+            { kind: Lexeme.Equal, text: "=", line: 1 },
+            { kind: Lexeme.Integer, text: "0", literal: new Int32(0), line: 1 },
+            { kind: Lexeme.To, text: "to", line: 1 },
+            { kind: Lexeme.Integer, text: "5", literal: new Int32(5), line: 1 },
+            { kind: Lexeme.Newline, text: "\n", line: 1 },
+            // body would go here, but it's not necessary for this test
+            { kind: Lexeme.Next, text: "next", line: 2 },
+            { kind: Lexeme.Newline, text: "\n", line: 2 },
+            EOF
+        ]);
+
+        expect(errors).toEqual([]);
+        expect(statements).toBeDefined();
+        expect(statements).toMatchSnapshot();
+    });
 });

--- a/test/parser/controlFlow/ForEach.test.js
+++ b/test/parser/controlFlow/ForEach.test.js
@@ -41,4 +41,25 @@ describe("parser foreach loops", () => {
 
         expect(statements).toMatchSnapshot();
     });
+
+    it("allows 'next' to terminate loop", () => {
+        let { statements, errors } = parser.parse([
+            { kind: Lexeme.ForEach, text: "for each", line: 2 },
+            { kind: Lexeme.Identifier, text: "word", line: 2 },
+            { kind: Lexeme.Identifier, text: "in", line: 2 },
+            { kind: Lexeme.Identifier, text: "lipsum", line: 2 },
+            { kind: Lexeme.Newline, text: "\n", line: 2 },
+
+            // body would go here, but it's not necessary for this test
+            { kind: Lexeme.Next, text: "next", line: 3 },
+            { kind: Lexeme.Newline, text: "\n", line: 3 },
+            EOF
+        ]);
+
+        expect(errors).toEqual([])
+        expect(statements).toBeDefined();
+        expect(errors).toEqual([]);
+        expect(statements).toBeDefined();
+        expect(statements).toMatchSnapshot();
+    });
 });

--- a/test/parser/controlFlow/__snapshots__/For.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/For.test.js.snap
@@ -35,6 +35,41 @@ Array [
 ]
 `;
 
+exports[`parser for loops allows 'next' to terminate loop 1`] = `
+Array [
+  For {
+    "body": Block {
+      "statements": Array [],
+    },
+    "counterDeclaration": Assignment {
+      "name": Object {
+        "kind": 21,
+        "line": 1,
+        "text": "i",
+      },
+      "value": Literal {
+        "value": Int32 {
+          "kind": 3,
+          "value": 0,
+        },
+      },
+    },
+    "finalValue": Literal {
+      "value": Int32 {
+        "kind": 3,
+        "value": 5,
+      },
+    },
+    "increment": Literal {
+      "value": Int32 {
+        "kind": 3,
+        "value": 1,
+      },
+    },
+  },
+]
+`;
+
 exports[`parser for loops defaults a missing 'step' clause to '1' 1`] = `
 Array [
   For {

--- a/test/parser/controlFlow/__snapshots__/ForEach.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/ForEach.test.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parser foreach loops allows 'next' to terminate loop 1`] = `
+Array [
+  ForEach {
+    "body": Block {
+      "statements": Array [],
+    },
+    "item": Object {
+      "kind": 21,
+      "line": 2,
+      "text": "word",
+    },
+    "target": Variable {
+      "name": Object {
+        "kind": 21,
+        "line": 2,
+        "text": "lipsum",
+      },
+    },
+  },
+]
+`;
+
 exports[`parser foreach loops requires a name and target 1`] = `
 Array [
   ForEach {


### PR DESCRIPTION
While not specified anywhere in its public documentation, the Reference BrightScript Implementation (RBI) allows `next` to be used to terminate `for` and `for each` loops everywhere `end for` would normally be used.  Note that `next` can't be used like `continue` would in other languages (i.e. to stop execution of the loop's block for the current loop variable and move to the next value) - it's a strict synonym for `end for` in BrightScript.

fixes #145 