### PR TITLE
fix(parser): Allow function expressions as primary expressions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
         let parseResults = parser.parse(preprocessResults.processedTokens);
         if (parseResults.errors.length > 0) {
             return Promise.reject({
-                message: "Error occurred during pre-processing"
+                message: "Error occurred parsing"
             });
         }
 

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -837,6 +837,8 @@ export class Parser {
                 case match(Lexeme.Pos, Lexeme.Tab):
                     let token = Object.assign(previous(), { kind: Lexeme.Identifier }) as Identifier;
                     return new Expr.Variable(token);
+                case check(Lexeme.Function, Lexeme.Sub):
+                    return anonymousFunction();
                 default:
                     return addError(
                         new ParseError(peek(), `Found unexpected token '${peek().text}'`)

--- a/test/parser/statement/Set.test.js
+++ b/test/parser/statement/Set.test.js
@@ -16,7 +16,11 @@ describe("parser indexed assignment", () => {
             { kind: Lexeme.Dot, text: ".", line: 1 },
             { kind: Lexeme.Identifier, text: "bar", line: 1 },
             { kind: Lexeme.Equal, text: "=", line: 1 },
-            { kind: Lexeme.String, text: "baz", line: 1, literal: new BrsString("baz") },
+            { kind: Lexeme.Function, text: "function", line: 1 },
+            { kind: Lexeme.LeftParen, text: "(", line: 1 },
+            { kind: Lexeme.RightParen, text: ")", line: 1 },
+            { kind: Lexeme.Newline, text: "\\n", line: 1 },
+            { kind: Lexeme.EndFunction, text: "end function", line: 2 },
             EOF
         ]);
 
@@ -33,7 +37,11 @@ describe("parser indexed assignment", () => {
             { kind: Lexeme.Integer, text: "0", line: 1, literal: new Int32(0) },
             { kind: Lexeme.RightSquare, text: "]", line: 1 },
             { kind: Lexeme.Equal, text: "=", line: 1 },
-            { kind: Lexeme.String, text: "baz", line: 1, literal: new BrsString("baz") },
+            { kind: Lexeme.Function, text: "function", line: 1 },
+            { kind: Lexeme.LeftParen, text: "(", line: 1 },
+            { kind: Lexeme.RightParen, text: ")", line: 1 },
+            { kind: Lexeme.Newline, text: "\\n", line: 1 },
+            { kind: Lexeme.EndFunction, text: "end function", line: 2 },
             EOF
         ]);
 

--- a/test/parser/statement/__snapshots__/Set.test.js.snap
+++ b/test/parser/statement/__snapshots__/Set.test.js.snap
@@ -21,11 +21,12 @@ Array [
         "text": "someArray",
       },
     },
-    "value": Literal {
-      "value": BrsString {
-        "kind": 2,
-        "value": "baz",
+    "value": Function {
+      "body": Block {
+        "statements": Array [],
       },
+      "parameters": Array [],
+      "returns": 9,
     },
   },
 ]
@@ -46,11 +47,12 @@ Array [
         "text": "foo",
       },
     },
-    "value": Literal {
-      "value": BrsString {
-        "kind": 2,
-        "value": "baz",
+    "value": Function {
+      "body": Block {
+        "statements": Array [],
       },
+      "parameters": Array [],
+      "returns": 9,
     },
   },
 ]


### PR DESCRIPTION
Before this change, function expressions weren't allowed on the right-hand side of a dotted or indexed set operation.  Now they are!

fixes #146