### PR TITLE
test(e2e): Re-enable scoping end-to-end test

### DIFF
--- a/test/e2e/Functions.test.js
+++ b/test/e2e/Functions.test.js
@@ -69,8 +69,7 @@ describe("end to end functions", () => {
         });
     });
 
-    test.skip("function/scoping.brs", () => {
-        // TODO: fix this test once `type` has been implemented
+    test("function/scoping.brs", () => {
         return execute([ resourceFile("function", "scoping.brs") ], outputStreams).then(() => {
             expect(
                 allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")

--- a/test/e2e/resources/function/scoping.brs
+++ b/test/e2e/resources/function/scoping.brs
@@ -2,9 +2,9 @@ sub Main()
     functionScoped = "I'm function scoped"
 
     _ = (sub()
-        print "Global: " RebootSystem <> "<UNINITIALIZED>"
-        print "Module: " ModuleDefined <> "<UNINITIALIZED>"
-        print "Function: " functionScoped <> "<UNINITIALIZED>"
+        print "Global: " type(RebootSystem) <> "<UNINITIALIZED>"
+        print "Module: " type(ModuleDefined) <> "<UNINITIALIZED>"
+        print "Function: " type(functionScoped) <> "<UNINITIALIZED>"
     end sub)()
 end sub
 


### PR DESCRIPTION
I forgot to re-enable it once `type()` was implemented!