### PR TITLE
feat(parse): Allow assignment operators in set statements

### DIFF
--- a/test/e2e/Iterables.test.js
+++ b/test/e2e/Iterables.test.js
@@ -24,7 +24,8 @@ describe("end to end iterables", () => {
             ).toEqual([
                 "1", "4", "9", // squared values, via for-each
                 "27",          // two-dimensional index
-                "16"           // 2 ^ 4
+                "16",          // 2 ^ 4
+                "foo bar"      // oneDimensional[0] += " bar"
             ]);
         });
     });
@@ -43,7 +44,10 @@ describe("end to end iterables", () => {
                 "2",
 
                 // after adding a third layer, twoDimensional.secondLayer.thirdLayer.level
-                "3"
+                "3",
+
+                // modify twoDimensional.secondLayer.level to sanity-check *= and friends
+                "6"
             ]);
         });
     });

--- a/test/e2e/resources/arrays.brs
+++ b/test/e2e/resources/arrays.brs
@@ -17,3 +17,7 @@ print twoDimensional[3][2]
 twoDimensional[4] = [ 1, 16, 81 ]
 
 print twoDimensional[4][1]
+
+' modify oneDimensional[0]
+oneDimensional[0] += " bar"
+print oneDimensional[0]

--- a/test/e2e/resources/associative-arrays.brs
+++ b/test/e2e/resources/associative-arrays.brs
@@ -19,3 +19,6 @@ twoDimensional.secondLayer.thirdLayer = { level: 3 }
 
 print twoDimensional.secondLayer.thirdLayer.level
 
+' modify the top for an as
+twoDimensional.secondLayer.level *= 3
+print twoDimensional.secondLayer.level

--- a/test/parser/statement/Set.test.js
+++ b/test/parser/statement/Set.test.js
@@ -39,7 +39,6 @@ describe("parser indexed assignment", () => {
                token(Lexeme.StarEqual, "*="),
                token(Lexeme.Integer, "5", new Int32(5)),
                token(Lexeme.Newline, "\\n"),
-               token(Lexeme.EndFunction, "end function"),
                EOF
            ]);
 
@@ -78,12 +77,8 @@ describe("parser indexed assignment", () => {
                 token(Lexeme.LeftSquare, "["),
                 token(Lexeme.Integer, "0", new Int32(0)),
                 token(Lexeme.RightSquare, "]"),
-                token(Lexeme.Equal, "="),
-                token(Lexeme.Function, "function"),
-                token(Lexeme.LeftParen, "("),
-                token(Lexeme.RightParen, ")"),
-                token(Lexeme.Newline, "\\n"),
-                token(Lexeme.EndFunction, "end function"),
+                token(Lexeme.StarEqual, "*="),
+                token(Lexeme.Integer, "3", new Int32(3)),
                 EOF
             ]);
 

--- a/test/parser/statement/Set.test.js
+++ b/test/parser/statement/Set.test.js
@@ -10,45 +10,88 @@ describe("parser indexed assignment", () => {
         parser = new brs.parser.Parser();
     });
 
-    it("assigns to dotted index", () => {
-        let { statements, errors } = parser.parse([
-            identifier("foo"),
-            token(Lexeme.Dot, "."),
-            identifier("bar"),
-            token(Lexeme.Equal, "="),
-            token(Lexeme.Function, "function"),
-            token(Lexeme.LeftParen, "("),
-            token(Lexeme.RightParen, ")"),
-            token(Lexeme.Newline, "\\n"),
-            token(Lexeme.EndFunction, "end function"),
-            EOF
-        ]);
+    describe("dotted", () => {
+        test("assignment", () => {
+            let { statements, errors } = parser.parse([
+                identifier("foo"),
+                token(Lexeme.Dot, "."),
+                identifier("bar"),
+                token(Lexeme.Equal, "="),
+                token(Lexeme.Function, "function"),
+                token(Lexeme.LeftParen, "("),
+                token(Lexeme.RightParen, ")"),
+                token(Lexeme.Newline, "\\n"),
+                token(Lexeme.EndFunction, "end function"),
+                EOF
+            ]);
 
-        expect(errors).toEqual([])
-        expect(statements).toBeDefined();
-        expect(statements).not.toBeNull();
-        expect(statements).toMatchSnapshot();
+            expect(errors).toEqual([])
+            expect(statements).toBeDefined();
+            expect(statements).not.toBeNull();
+            expect(statements).toMatchSnapshot();
+        });
+
+        test("assignment operator", () => {
+           let { statements, errors } = parser.parse([
+               identifier("foo"),
+               token(Lexeme.Dot, "."),
+               identifier("bar"),
+               token(Lexeme.StarEqual, "*="),
+               token(Lexeme.Integer, "5", new Int32(5)),
+               token(Lexeme.Newline, "\\n"),
+               token(Lexeme.EndFunction, "end function"),
+               EOF
+           ]);
+
+           expect(errors).toEqual([])
+           expect(statements).toBeDefined();
+           expect(statements).not.toBeNull();
+           expect(statements).toMatchSnapshot();
+        });
     });
 
-    it("assigns to bracketed index", () => {
-        let { statements, errors } = parser.parse([
-            identifier("someArray"),
-            token(Lexeme.LeftSquare, "["),
-            token(Lexeme.Integer, "0", new Int32(0)),
-            token(Lexeme.RightSquare, "]"),
-            token(Lexeme.Equal, "="),
-            token(Lexeme.Function, "function"),
-            token(Lexeme.LeftParen, "("),
-            token(Lexeme.RightParen, ")"),
-            token(Lexeme.Newline, "\\n"),
-            token(Lexeme.EndFunction, "end function"),
-            EOF
-        ]);
+    describe("bracketed", () => {
+        it("assignment", () => {
+            let { statements, errors } = parser.parse([
+                identifier("someArray"),
+                token(Lexeme.LeftSquare, "["),
+                token(Lexeme.Integer, "0", new Int32(0)),
+                token(Lexeme.RightSquare, "]"),
+                token(Lexeme.Equal, "="),
+                token(Lexeme.Function, "function"),
+                token(Lexeme.LeftParen, "("),
+                token(Lexeme.RightParen, ")"),
+                token(Lexeme.Newline, "\\n"),
+                token(Lexeme.EndFunction, "end function"),
+                EOF
+            ]);
 
-        expect(errors).toEqual([])
-        expect(statements).toBeDefined();
-        expect(statements).not.toBeNull();
-        expect(statements).toMatchSnapshot();
+            expect(errors).toEqual([])
+            expect(statements).toBeDefined();
+            expect(statements).not.toBeNull();
+            expect(statements).toMatchSnapshot();
+        });
+
+        it("assignment operator", () => {
+            let { statements, errors } = parser.parse([
+                identifier("someArray"),
+                token(Lexeme.LeftSquare, "["),
+                token(Lexeme.Integer, "0", new Int32(0)),
+                token(Lexeme.RightSquare, "]"),
+                token(Lexeme.Equal, "="),
+                token(Lexeme.Function, "function"),
+                token(Lexeme.LeftParen, "("),
+                token(Lexeme.RightParen, ")"),
+                token(Lexeme.Newline, "\\n"),
+                token(Lexeme.EndFunction, "end function"),
+                EOF
+            ]);
+
+            expect(errors).toEqual([])
+            expect(statements).toBeDefined();
+            expect(statements).not.toBeNull();
+            expect(statements).toMatchSnapshot();
+        });
     });
 
     test("location tracking", () => {

--- a/test/parser/statement/__snapshots__/Set.test.js.snap
+++ b/test/parser/statement/__snapshots__/Set.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`parser indexed assignment assigns to bracketed index 1`] = `
+exports[`parser indexed assignment bracketed assignment 1`] = `
 Array [
   IndexedSet {
     "closingSquare": Object {
@@ -106,7 +106,7 @@ Array [
 ]
 `;
 
-exports[`parser indexed assignment assigns to dotted index 1`] = `
+exports[`parser indexed assignment dotted assignment 1`] = `
 Array [
   DottedSet {
     "name": Object {

--- a/test/parser/statement/__snapshots__/Set.test.js.snap
+++ b/test/parser/statement/__snapshots__/Set.test.js.snap
@@ -106,6 +106,149 @@ Array [
 ]
 `;
 
+exports[`parser indexed assignment bracketed assignment operator 1`] = `
+Array [
+  IndexedSet {
+    "closingSquare": Object {
+      "isReserved": false,
+      "kind": 3,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "text": "]",
+    },
+    "index": Literal {
+      "_location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "value": Int32 {
+        "kind": 3,
+        "value": 0,
+      },
+    },
+    "obj": Variable {
+      "name": Object {
+        "isReserved": false,
+        "kind": 28,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "someArray",
+      },
+    },
+    "value": Binary {
+      "left": IndexedGet {
+        "closingSquare": Object {
+          "isReserved": false,
+          "kind": 3,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": -9,
+              "line": -9,
+            },
+            "start": Object {
+              "column": -9,
+              "line": -9,
+            },
+          },
+          "text": "]",
+        },
+        "index": Literal {
+          "_location": Object {
+            "end": Object {
+              "column": -9,
+              "line": -9,
+            },
+            "start": Object {
+              "column": -9,
+              "line": -9,
+            },
+          },
+          "value": Int32 {
+            "kind": 3,
+            "value": 0,
+          },
+        },
+        "obj": Variable {
+          "name": Object {
+            "isReserved": false,
+            "kind": 28,
+            "literal": undefined,
+            "location": Object {
+              "end": Object {
+                "column": -9,
+                "line": -9,
+              },
+              "start": Object {
+                "column": -9,
+                "line": -9,
+              },
+            },
+            "text": "someArray",
+          },
+        },
+      },
+      "right": Literal {
+        "_location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "value": Int32 {
+          "kind": 3,
+          "value": 3,
+        },
+      },
+      "token": Object {
+        "isReserved": false,
+        "kind": 17,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "*=",
+      },
+    },
+  },
+]
+`;
+
 exports[`parser indexed assignment dotted assignment 1`] = `
 Array [
   DottedSet {
@@ -191,6 +334,117 @@ Array [
       },
       "parameters": Array [],
       "returns": 9,
+    },
+  },
+]
+`;
+
+exports[`parser indexed assignment dotted assignment operator 1`] = `
+Array [
+  DottedSet {
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "text": "bar",
+    },
+    "obj": Variable {
+      "name": Object {
+        "isReserved": false,
+        "kind": 28,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "foo",
+      },
+    },
+    "value": Binary {
+      "left": DottedGet {
+        "name": Object {
+          "isReserved": false,
+          "kind": 28,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": -9,
+              "line": -9,
+            },
+            "start": Object {
+              "column": -9,
+              "line": -9,
+            },
+          },
+          "text": "bar",
+        },
+        "obj": Variable {
+          "name": Object {
+            "isReserved": false,
+            "kind": 28,
+            "literal": undefined,
+            "location": Object {
+              "end": Object {
+                "column": -9,
+                "line": -9,
+              },
+              "start": Object {
+                "column": -9,
+                "line": -9,
+              },
+            },
+            "text": "foo",
+          },
+        },
+      },
+      "right": Literal {
+        "_location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "value": Int32 {
+          "kind": 3,
+          "value": 5,
+        },
+      },
+      "token": Object {
+        "isReserved": false,
+        "kind": 17,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "*=",
+      },
     },
   },
 ]


### PR DESCRIPTION
Due to the fact that the `=` token is ambiguous without context (i.e. "is it an assignment or comparison?"), assignments get parsed as binary operations and transformed into assignments after the binary operation's been completely parsed.  Dotted and indexed "set" statements (e.g. `foo.bar = "baz"`) required a bit of additional parsing logic when they were added.  Since assignment operators like `+=` are unambiguously used in statements only, there was yet more parsing logic required to handle assignment operators when the left-hand side is a dotted or indexed set.

This should take care of it though!

fixes #173 