### PR TITLE
fix(parser): Allow complex expressions on RHS of set statements

### DIFF
--- a/test/e2e/Iterables.test.js
+++ b/test/e2e/Iterables.test.js
@@ -47,7 +47,10 @@ describe("end to end iterables", () => {
                 "3",
 
                 // modify twoDimensional.secondLayer.level to sanity-check *= and friends
-                "6"
+                "6",
+
+                // add `false` via expression to `empty`
+                "false"
             ]);
         });
     });

--- a/test/e2e/resources/associative-arrays.brs
+++ b/test/e2e/resources/associative-arrays.brs
@@ -19,6 +19,10 @@ twoDimensional.secondLayer.thirdLayer = { level: 3 }
 
 print twoDimensional.secondLayer.thirdLayer.level
 
-' modify the top for an as
+' modify the top for a silly example
 twoDimensional.secondLayer.level *= 3
 print twoDimensional.secondLayer.level
+
+' add property to `empty` to be really silly
+empty.isEmpty = oneDimensional.isOneDimensional and false
+print empty.isEmpty

--- a/test/parser/expression/Function.test.js
+++ b/test/parser/expression/Function.test.js
@@ -392,7 +392,7 @@ describe("parser", () => {
         it("allows sub expressions in call arguments", () => {
             const { statements, errors } = parser.parse([
                 identifier("acceptsCallback"),
-                { kind: Lexeme.LeftParen,  text: "(", line: 1 },
+                token(Lexeme.LeftParen, "("),
                 token(Lexeme.Newline, "\\n"),
 
                 token(Lexeme.Function, "function"),

--- a/test/parser/statement/Set.test.js
+++ b/test/parser/statement/Set.test.js
@@ -11,7 +11,7 @@ describe("parser indexed assignment", () => {
     });
 
     describe("dotted", () => {
-        test("assignment", () => {
+        it("assigns anonymous functions", () => {
             let { statements, errors } = parser.parse([
                 identifier("foo"),
                 token(Lexeme.Dot, "."),
@@ -22,6 +22,25 @@ describe("parser indexed assignment", () => {
                 token(Lexeme.RightParen, ")"),
                 token(Lexeme.Newline, "\\n"),
                 token(Lexeme.EndFunction, "end function"),
+                EOF
+            ]);
+
+            expect(errors).toEqual([])
+            expect(statements).toBeDefined();
+            expect(statements).not.toBeNull();
+            expect(statements).toMatchSnapshot();
+        });
+
+        it("assigns boolean expressions", () => {
+            let { statements, errors } = parser.parse([
+                identifier("foo"),
+                token(Lexeme.Dot, "."),
+                identifier("bar"),
+                token(Lexeme.Equal, "="),
+                token(Lexeme.True, "true"),
+                token(Lexeme.And, "and"),
+                token(Lexeme.False, "false"),
+                token(Lexeme.Newline, "\\n"),
                 EOF
             ]);
 
@@ -50,7 +69,7 @@ describe("parser indexed assignment", () => {
     });
 
     describe("bracketed", () => {
-        it("assignment", () => {
+        it("assigns anonymous functions", () => {
             let { statements, errors } = parser.parse([
                 identifier("someArray"),
                 token(Lexeme.LeftSquare, "["),
@@ -62,6 +81,26 @@ describe("parser indexed assignment", () => {
                 token(Lexeme.RightParen, ")"),
                 token(Lexeme.Newline, "\\n"),
                 token(Lexeme.EndFunction, "end function"),
+                EOF
+            ]);
+
+            expect(errors).toEqual([])
+            expect(statements).toBeDefined();
+            expect(statements).not.toBeNull();
+            expect(statements).toMatchSnapshot();
+        });
+
+        it("assigns boolean expressions", () => {
+            let { statements, errors } = parser.parse([
+                identifier("someArray"),
+                token(Lexeme.LeftSquare, "["),
+                token(Lexeme.Integer, "0", new Int32(0)),
+                token(Lexeme.RightSquare, "]"),
+                token(Lexeme.Equal, "="),
+                token(Lexeme.True, "true"),
+                token(Lexeme.And, "and"),
+                token(Lexeme.False, "false"),
+                token(Lexeme.Newline, "\\n"),
                 EOF
             ]);
 

--- a/test/parser/statement/__snapshots__/Set.test.js.snap
+++ b/test/parser/statement/__snapshots__/Set.test.js.snap
@@ -1,111 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`parser indexed assignment bracketed assignment 1`] = `
-Array [
-  IndexedSet {
-    "closingSquare": Object {
-      "isReserved": false,
-      "kind": 3,
-      "literal": undefined,
-      "location": Object {
-        "end": Object {
-          "column": -9,
-          "line": -9,
-        },
-        "start": Object {
-          "column": -9,
-          "line": -9,
-        },
-      },
-      "text": "]",
-    },
-    "index": Literal {
-      "_location": Object {
-        "end": Object {
-          "column": -9,
-          "line": -9,
-        },
-        "start": Object {
-          "column": -9,
-          "line": -9,
-        },
-      },
-      "value": Int32 {
-        "kind": 3,
-        "value": 0,
-      },
-    },
-    "obj": Variable {
-      "name": Object {
-        "isReserved": false,
-        "kind": 28,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": -9,
-            "line": -9,
-          },
-          "start": Object {
-            "column": -9,
-            "line": -9,
-          },
-        },
-        "text": "someArray",
-      },
-    },
-    "value": Function {
-      "body": Block {
-        "startingLocation": Object {
-          "end": Object {
-            "column": -9,
-            "line": -9,
-          },
-          "start": Object {
-            "column": -9,
-            "line": -9,
-          },
-        },
-        "statements": Array [],
-      },
-      "end": Object {
-        "isReserved": false,
-        "kind": 52,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": -9,
-            "line": -9,
-          },
-          "start": Object {
-            "column": -9,
-            "line": -9,
-          },
-        },
-        "text": "end function",
-      },
-      "keyword": Object {
-        "isReserved": true,
-        "kind": 64,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": -9,
-            "line": -9,
-          },
-          "start": Object {
-            "column": -9,
-            "line": -9,
-          },
-        },
-        "text": "function",
-      },
-      "parameters": Array [],
-      "returns": 9,
-    },
-  },
-]
-`;
-
 exports[`parser indexed assignment bracketed assignment operator 1`] = `
 Array [
   IndexedSet {
@@ -249,12 +143,12 @@ Array [
 ]
 `;
 
-exports[`parser indexed assignment dotted assignment 1`] = `
+exports[`parser indexed assignment bracketed assigns anonymous functions 1`] = `
 Array [
-  DottedSet {
-    "name": Object {
+  IndexedSet {
+    "closingSquare": Object {
       "isReserved": false,
-      "kind": 28,
+      "kind": 3,
       "literal": undefined,
       "location": Object {
         "end": Object {
@@ -266,7 +160,23 @@ Array [
           "line": -9,
         },
       },
-      "text": "bar",
+      "text": "]",
+    },
+    "index": Literal {
+      "_location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "value": Int32 {
+        "kind": 3,
+        "value": 0,
+      },
     },
     "obj": Variable {
       "name": Object {
@@ -283,7 +193,7 @@ Array [
             "line": -9,
           },
         },
-        "text": "foo",
+        "text": "someArray",
       },
     },
     "value": Function {
@@ -334,6 +244,113 @@ Array [
       },
       "parameters": Array [],
       "returns": 9,
+    },
+  },
+]
+`;
+
+exports[`parser indexed assignment bracketed assigns boolean expressions 1`] = `
+Array [
+  IndexedSet {
+    "closingSquare": Object {
+      "isReserved": false,
+      "kind": 3,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "text": "]",
+    },
+    "index": Literal {
+      "_location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "value": Int32 {
+        "kind": 3,
+        "value": 0,
+      },
+    },
+    "obj": Variable {
+      "name": Object {
+        "isReserved": false,
+        "kind": 28,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "someArray",
+      },
+    },
+    "value": Binary {
+      "left": Literal {
+        "_location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "value": BrsBoolean {
+          "kind": 1,
+          "value": true,
+        },
+      },
+      "right": Literal {
+        "_location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "value": BrsBoolean {
+          "kind": 1,
+          "value": false,
+        },
+      },
+      "token": Object {
+        "isReserved": true,
+        "kind": 45,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "and",
+      },
     },
   },
 ]
@@ -444,6 +461,187 @@ Array [
           },
         },
         "text": "*=",
+      },
+    },
+  },
+]
+`;
+
+exports[`parser indexed assignment dotted assigns anonymous functions 1`] = `
+Array [
+  DottedSet {
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "text": "bar",
+    },
+    "obj": Variable {
+      "name": Object {
+        "isReserved": false,
+        "kind": 28,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "foo",
+      },
+    },
+    "value": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "statements": Array [],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 52,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "end function",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 64,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "function",
+      },
+      "parameters": Array [],
+      "returns": 9,
+    },
+  },
+]
+`;
+
+exports[`parser indexed assignment dotted assigns boolean expressions 1`] = `
+Array [
+  DottedSet {
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "text": "bar",
+    },
+    "obj": Variable {
+      "name": Object {
+        "isReserved": false,
+        "kind": 28,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "foo",
+      },
+    },
+    "value": Binary {
+      "left": Literal {
+        "_location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "value": BrsBoolean {
+          "kind": 1,
+          "value": true,
+        },
+      },
+      "right": Literal {
+        "_location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "value": BrsBoolean {
+          "kind": 1,
+          "value": false,
+        },
+      },
+      "token": Object {
+        "isReserved": true,
+        "kind": 45,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "and",
       },
     },
   },


### PR DESCRIPTION
The parser was a little bit too greedy when attempting to detect set statements, which I should have noticed with the weird workarounds in that function.  Now that we're _not_ trying to read an entire expression as the left-hand side of a set statement (e.g.  `foo + bar *= 3`), that complication can be removed.

Arbitrarily complex expressions are now supported on the right-hand side of a set statement, e.g. `foo.bar = true and false or 3 > 4`

fixes #156