### PR TITLE
Use `name.text` for argument error messages.

### DIFF
--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -767,7 +767,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 let messageParts = [];
 
                 let args = sig.args.map(a => {
-                    let requiredArg = `${a.name} as ${ValueKind.toString(a.type.kind)}`;
+                    let requiredArg = `${a.name.text} as ${ValueKind.toString(a.type.kind)}`;
                     if (a.defaultValue) {
                         return `[${requiredArg}]`;
                     } else {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -218,7 +218,7 @@ export class Parser {
                     return addError(
                         new ParseError(
                             { kind: Lexeme.Identifier, text: arg.name.text, isReserved: ReservedWords.has(arg.name.text), location: arg.location },
-                            `Argument '${arg.name}' has no default value, but comes after arguments with default values`
+                            `Argument '${arg.name.text}' has no default value, but comes after arguments with default values`
                         )
                     );
                 }


### PR DESCRIPTION
When the function arguments had their `name` property converted to an object containing location, these spots were missed, causing the error messages to contain `'[object Object]'` instead of the actual argument name

Fixes #196 
