### PR TITLE
Parser support type designators

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -503,8 +503,13 @@ export class Lexer {
                 }
             }
 
-            // TODO: support type designators:
-            // https://sdkdocs.roku.com/display/sdkdoc/Expressions%2C+Variables%2C+and+Types
+            //look for a type designator character ($ % ! #). vars may have them, but functions
+            //may not. Let the parser figure that part out.
+            let nextChar = peek();
+            if (["$", "%", "!", "#"].indexOf(nextChar) > -1) {
+                text += nextChar;
+                advance();
+            }
 
             let tokenType = KeyWords[text.toLowerCase()] || Lexeme.Identifier;
             if (tokenType === KeyWords.rem) {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -174,6 +174,17 @@ export class Parser {
             } else {
                 name = consume(`Expected ${functionType.text} name after '${functionType.text}'`, Lexeme.Identifier) as Identifier;
                 leftParen = consume(`Expected '(' after ${functionType.text} name`, Lexeme.LeftParen);
+
+                //prevent functions from ending with type designators
+                let lastChar = name.text[name.text.length - 1];
+                if (["$", "%", "!", "#"].indexOf(lastChar) > -1) {
+                    //Since function type is first word, force the first char to upper case to match style of other error messages
+                    let properFunctionName = functionType.text[0].toUpperCase() + functionType.text.substring(1);
+                    //this error should not prevent parsing, but should still show up in the list of errors
+                    try {
+                        addError(new ParseError(name, `${properFunctionName} name cannot end with type designator '${lastChar}'`));
+                    } catch (e) { }
+                }
             }
 
             let args: Argument[] = [];
@@ -244,7 +255,7 @@ export class Parser {
             } else {
                 // only consume trailing newlines in the statement context; expressions
                 // expect to handle their own trailing whitespace
-                while(match(Lexeme.Newline));
+                while (match(Lexeme.Newline));
                 return new Stmt.Function(name!, func);
             }
         }
@@ -373,7 +384,7 @@ export class Parser {
         function exitWhile(): Stmt.ExitWhile {
             let keyword = advance();
             consume("Expected newline after 'exit while'", Lexeme.Newline);
-            while (match(Lexeme.Newline)) {}
+            while (match(Lexeme.Newline)) { }
             return new Stmt.ExitWhile({ exitWhile: keyword });
         }
 
@@ -392,7 +403,7 @@ export class Parser {
                 // BrightScript for/to/step loops default to a step of 1 if no `step` is provided
                 increment = new Expr.Literal(new Int32(1), peek().location);
             }
-            while(match(Lexeme.Newline));
+            while (match(Lexeme.Newline));
 
             let body = block(Lexeme.EndFor, Lexeme.Next);
             if (!body) {
@@ -401,7 +412,7 @@ export class Parser {
                 );
             }
             let endFor = advance();
-            while(match(Lexeme.Newline));
+            while (match(Lexeme.Newline));
 
             // WARNING: BrightScript doesn't delete the loop initial value after a for/to loop! It just
             // stays around in scope with whatever value it was when the loop exited.

--- a/test/parser/statement/Function.test.js
+++ b/test/parser/statement/Function.test.js
@@ -199,47 +199,7 @@ describe("parser", () => {
             `);
             const { statements, errors } = parser.parse(tokens);
             expect(errors.length).toEqual(4);
-            expect(errors[0].location).toMatchObject({
-                start: {
-                    line: 2,
-                    column: 25
-                },
-                end: {
-                    line: 2,
-                    column: 36
-                }
-            });
-            expect(errors[1].location).toMatchObject({
-                start: {
-                    line: 6,
-                    column: 25
-                },
-                end: {
-                    line: 6,
-                    column: 37
-                }
-            });
-            expect(errors[2].location).toMatchObject({
-                start: {
-                    line: 10,
-                    column: 25
-                },
-                end: {
-                    line: 10,
-                    column: 35
-                }
-            });
-            expect(errors[3].location).toMatchObject({
-                start: {
-                    line: 14,
-                    column: 25
-                },
-                end: {
-                    line: 14,
-                    column: 36
-                }
-            });
-            expect(statements).toMatchSnapshot();
+            expect({ errors, statements }).toMatchSnapshot();
         });
     });
 
@@ -424,47 +384,7 @@ describe("parser", () => {
             `);
             const { statements, errors } = parser.parse(tokens);
             expect(errors.length).toEqual(4);
-            expect(errors[0].location).toMatchObject({
-                start: {
-                    line: 2,
-                    column: 20
-                },
-                end: {
-                    line: 2,
-                    column: 30
-                }
-            });
-            expect(errors[1].location).toMatchObject({
-                start: {
-                    line: 5,
-                    column: 20
-                },
-                end: {
-                    line: 5,
-                    column: 31
-                }
-            });
-            expect(errors[2].location).toMatchObject({
-                start: {
-                    line: 8,
-                    column: 20
-                },
-                end: {
-                    line: 8,
-                    column: 29
-                }
-            });
-            expect(errors[3].location).toMatchObject({
-                start: {
-                    line: 11,
-                    column: 20
-                },
-                end: {
-                    line: 11,
-                    column: 30
-                }
-            });
-            expect(statements).toMatchSnapshot();
+            expect({ errors, statements }).toMatchSnapshot();
         });
     });
 });

--- a/test/parser/statement/Function.test.js
+++ b/test/parser/statement/Function.test.js
@@ -128,7 +128,7 @@ describe("parser", () => {
         });
 
         it("parses functions with typed arguments and default expressions", () => {
-             let { statements, errors } = parser.parse([
+            let { statements, errors } = parser.parse([
                 token(Lexeme.Function, "function"),
                 identifier("add"),
                 token(Lexeme.LeftParen, "("),
@@ -176,6 +176,69 @@ describe("parser", () => {
             expect(errors).toEqual([]);
             expect(statements).toBeDefined();
             expect(statements).not.toBeNull();
+            expect(statements).toMatchSnapshot();
+        });
+
+        it('does not allow type designators at end of name', () => {
+            const { tokens } = brs.lexer.Lexer.scan(`
+                function StringFunc#()
+                    return 1
+                end function
+
+                function IntegerFunc%()
+                    return 1
+                end function
+
+                function FloatFunc!()
+                    return 1
+                end function
+
+                function DoubleFunc#()
+                    return 1
+                end function
+            `);
+            const { statements, errors } = parser.parse(tokens);
+            expect(errors.length).toEqual(4);
+            expect(errors[0].location).toMatchObject({
+                start: {
+                    line: 2,
+                    column: 25
+                },
+                end: {
+                    line: 2,
+                    column: 36
+                }
+            });
+            expect(errors[1].location).toMatchObject({
+                start: {
+                    line: 6,
+                    column: 25
+                },
+                end: {
+                    line: 6,
+                    column: 37
+                }
+            });
+            expect(errors[2].location).toMatchObject({
+                start: {
+                    line: 10,
+                    column: 25
+                },
+                end: {
+                    line: 10,
+                    column: 35
+                }
+            });
+            expect(errors[3].location).toMatchObject({
+                start: {
+                    line: 14,
+                    column: 25
+                },
+                end: {
+                    line: 14,
+                    column: 36
+                }
+            });
             expect(statements).toMatchSnapshot();
         });
     });
@@ -297,7 +360,7 @@ describe("parser", () => {
         });
 
         it("parses subs with typed arguments and default expressions", () => {
-             let { statements, errors } = parser.parse([
+            let { statements, errors } = parser.parse([
                 token(Lexeme.Sub, "sub"),
                 identifier("add"),
                 token(Lexeme.LeftParen, "("),
@@ -343,6 +406,65 @@ describe("parser", () => {
             ]);
 
             expect(errors.length).not.toBe(0);
+        });
+
+        it('does not allow type designators at end of name', () => {
+            const { tokens } = brs.lexer.Lexer.scan(`
+                sub StringSub#()
+                end sub
+
+                sub IntegerSub%()
+                end sub
+
+                sub FloatSub!()
+                end sub
+
+                sub DoubleSub#()
+                end sub
+            `);
+            const { statements, errors } = parser.parse(tokens);
+            expect(errors.length).toEqual(4);
+            expect(errors[0].location).toMatchObject({
+                start: {
+                    line: 2,
+                    column: 20
+                },
+                end: {
+                    line: 2,
+                    column: 30
+                }
+            });
+            expect(errors[1].location).toMatchObject({
+                start: {
+                    line: 5,
+                    column: 20
+                },
+                end: {
+                    line: 5,
+                    column: 31
+                }
+            });
+            expect(errors[2].location).toMatchObject({
+                start: {
+                    line: 8,
+                    column: 20
+                },
+                end: {
+                    line: 8,
+                    column: 29
+                }
+            });
+            expect(errors[3].location).toMatchObject({
+                start: {
+                    line: 11,
+                    column: 20
+                },
+                end: {
+                    line: 11,
+                    column: 30
+                }
+            });
+            expect(statements).toMatchSnapshot();
         });
     });
 });

--- a/test/parser/statement/__snapshots__/Function.test.js.snap
+++ b/test/parser/statement/__snapshots__/Function.test.js.snap
@@ -1,5 +1,450 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parser function declarations does not allow type designators at end of name 1`] = `
+Array [
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 26,
+            "line": 3,
+          },
+          "file": "",
+          "start": Object {
+            "column": 20,
+            "line": 3,
+          },
+        },
+        "statements": Array [
+          Return {
+            "tokens": Object {
+              "return": Object {
+                "isReserved": true,
+                "kind": 80,
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 26,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 20,
+                    "line": 3,
+                  },
+                },
+                "text": "return",
+              },
+            },
+            "value": Literal {
+              "_location": Object {
+                "end": Object {
+                  "column": 28,
+                  "line": 3,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 27,
+                  "line": 3,
+                },
+              },
+              "value": Int32 {
+                "kind": 3,
+                "value": 1,
+              },
+            },
+          },
+        ],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 52,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 28,
+            "line": 4,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 4,
+          },
+        },
+        "text": "end function",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 64,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 24,
+            "line": 2,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 2,
+          },
+        },
+        "text": "function",
+      },
+      "parameters": Array [],
+      "returns": 9,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 36,
+          "line": 2,
+        },
+        "file": "",
+        "start": Object {
+          "column": 25,
+          "line": 2,
+        },
+      },
+      "text": "StringFunc#",
+    },
+  },
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 26,
+            "line": 7,
+          },
+          "file": "",
+          "start": Object {
+            "column": 20,
+            "line": 7,
+          },
+        },
+        "statements": Array [
+          Return {
+            "tokens": Object {
+              "return": Object {
+                "isReserved": true,
+                "kind": 80,
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 26,
+                    "line": 7,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 20,
+                    "line": 7,
+                  },
+                },
+                "text": "return",
+              },
+            },
+            "value": Literal {
+              "_location": Object {
+                "end": Object {
+                  "column": 28,
+                  "line": 7,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 27,
+                  "line": 7,
+                },
+              },
+              "value": Int32 {
+                "kind": 3,
+                "value": 1,
+              },
+            },
+          },
+        ],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 52,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 28,
+            "line": 8,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 8,
+          },
+        },
+        "text": "end function",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 64,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 24,
+            "line": 6,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 6,
+          },
+        },
+        "text": "function",
+      },
+      "parameters": Array [],
+      "returns": 9,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 37,
+          "line": 6,
+        },
+        "file": "",
+        "start": Object {
+          "column": 25,
+          "line": 6,
+        },
+      },
+      "text": "IntegerFunc%",
+    },
+  },
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 26,
+            "line": 11,
+          },
+          "file": "",
+          "start": Object {
+            "column": 20,
+            "line": 11,
+          },
+        },
+        "statements": Array [
+          Return {
+            "tokens": Object {
+              "return": Object {
+                "isReserved": true,
+                "kind": 80,
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 26,
+                    "line": 11,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 20,
+                    "line": 11,
+                  },
+                },
+                "text": "return",
+              },
+            },
+            "value": Literal {
+              "_location": Object {
+                "end": Object {
+                  "column": 28,
+                  "line": 11,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 27,
+                  "line": 11,
+                },
+              },
+              "value": Int32 {
+                "kind": 3,
+                "value": 1,
+              },
+            },
+          },
+        ],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 52,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 28,
+            "line": 12,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 12,
+          },
+        },
+        "text": "end function",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 64,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 24,
+            "line": 10,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 10,
+          },
+        },
+        "text": "function",
+      },
+      "parameters": Array [],
+      "returns": 9,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 35,
+          "line": 10,
+        },
+        "file": "",
+        "start": Object {
+          "column": 25,
+          "line": 10,
+        },
+      },
+      "text": "FloatFunc!",
+    },
+  },
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 26,
+            "line": 15,
+          },
+          "file": "",
+          "start": Object {
+            "column": 20,
+            "line": 15,
+          },
+        },
+        "statements": Array [
+          Return {
+            "tokens": Object {
+              "return": Object {
+                "isReserved": true,
+                "kind": 80,
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 26,
+                    "line": 15,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 20,
+                    "line": 15,
+                  },
+                },
+                "text": "return",
+              },
+            },
+            "value": Literal {
+              "_location": Object {
+                "end": Object {
+                  "column": 28,
+                  "line": 15,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 27,
+                  "line": 15,
+                },
+              },
+              "value": Int32 {
+                "kind": 3,
+                "value": 1,
+              },
+            },
+          },
+        ],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 52,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 28,
+            "line": 16,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 16,
+          },
+        },
+        "text": "end function",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 64,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 24,
+            "line": 14,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 14,
+          },
+        },
+        "text": "function",
+      },
+      "parameters": Array [],
+      "returns": 9,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 36,
+          "line": 14,
+        },
+        "file": "",
+        "start": Object {
+          "column": 25,
+          "line": 14,
+        },
+      },
+      "text": "DoubleFunc#",
+    },
+  },
+]
+`;
+
 exports[`parser function declarations parses functions with default argument expressions 1`] = `
 Array [
   Function {
@@ -1081,6 +1526,295 @@ Array [
         },
       },
       "text": "foo",
+    },
+  },
+]
+`;
+
+exports[`parser sub declarations does not allow type designators at end of name 1`] = `
+Array [
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 23,
+            "line": 3,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 3,
+          },
+        },
+        "statements": Array [],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 55,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 23,
+            "line": 3,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 3,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 82,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 19,
+            "line": 2,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 2,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 30,
+          "line": 2,
+        },
+        "file": "",
+        "start": Object {
+          "column": 20,
+          "line": 2,
+        },
+      },
+      "text": "StringSub#",
+    },
+  },
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 23,
+            "line": 6,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 6,
+          },
+        },
+        "statements": Array [],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 55,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 23,
+            "line": 6,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 6,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 82,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 19,
+            "line": 5,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 5,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 31,
+          "line": 5,
+        },
+        "file": "",
+        "start": Object {
+          "column": 20,
+          "line": 5,
+        },
+      },
+      "text": "IntegerSub%",
+    },
+  },
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 23,
+            "line": 9,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 9,
+          },
+        },
+        "statements": Array [],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 55,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 23,
+            "line": 9,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 9,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 82,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 19,
+            "line": 8,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 8,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 29,
+          "line": 8,
+        },
+        "file": "",
+        "start": Object {
+          "column": 20,
+          "line": 8,
+        },
+      },
+      "text": "FloatSub!",
+    },
+  },
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 23,
+            "line": 12,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 12,
+          },
+        },
+        "statements": Array [],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 55,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 23,
+            "line": 12,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 12,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 82,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 19,
+            "line": 11,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 11,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 30,
+          "line": 11,
+        },
+        "file": "",
+        "start": Object {
+          "column": 20,
+          "line": 11,
+        },
+      },
+      "text": "DoubleSub#",
     },
   },
 ]

--- a/test/parser/statement/__snapshots__/Function.test.js.snap
+++ b/test/parser/statement/__snapshots__/Function.test.js.snap
@@ -1,448 +1,456 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`parser function declarations does not allow type designators at end of name 1`] = `
-Array [
-  Function {
-    "func": Function {
-      "body": Block {
-        "startingLocation": Object {
-          "end": Object {
-            "column": 26,
-            "line": 3,
+Object {
+  "errors": Array [
+    [Error: Function name 'StringFunc#' cannot end with type designator '#'],
+    [Error: Function name 'IntegerFunc%' cannot end with type designator '%'],
+    [Error: Function name 'FloatFunc!' cannot end with type designator '!'],
+    [Error: Function name 'DoubleFunc#' cannot end with type designator '#'],
+  ],
+  "statements": Array [
+    Function {
+      "func": Function {
+        "body": Block {
+          "startingLocation": Object {
+            "end": Object {
+              "column": 26,
+              "line": 3,
+            },
+            "file": "",
+            "start": Object {
+              "column": 20,
+              "line": 3,
+            },
           },
-          "file": "",
-          "start": Object {
-            "column": 20,
-            "line": 3,
-          },
-        },
-        "statements": Array [
-          Return {
-            "tokens": Object {
-              "return": Object {
-                "isReserved": true,
-                "kind": 80,
-                "literal": undefined,
-                "location": Object {
+          "statements": Array [
+            Return {
+              "tokens": Object {
+                "return": Object {
+                  "isReserved": true,
+                  "kind": 80,
+                  "literal": undefined,
+                  "location": Object {
+                    "end": Object {
+                      "column": 26,
+                      "line": 3,
+                    },
+                    "file": "",
+                    "start": Object {
+                      "column": 20,
+                      "line": 3,
+                    },
+                  },
+                  "text": "return",
+                },
+              },
+              "value": Literal {
+                "_location": Object {
                   "end": Object {
-                    "column": 26,
+                    "column": 28,
                     "line": 3,
                   },
                   "file": "",
                   "start": Object {
-                    "column": 20,
+                    "column": 27,
                     "line": 3,
                   },
                 },
-                "text": "return",
-              },
-            },
-            "value": Literal {
-              "_location": Object {
-                "end": Object {
-                  "column": 28,
-                  "line": 3,
-                },
-                "file": "",
-                "start": Object {
-                  "column": 27,
-                  "line": 3,
+                "value": Int32 {
+                  "kind": 3,
+                  "value": 1,
                 },
               },
-              "value": Int32 {
-                "kind": 3,
-                "value": 1,
-              },
             },
-          },
-        ],
-      },
-      "end": Object {
-        "isReserved": false,
-        "kind": 52,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": 28,
-            "line": 4,
-          },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 4,
-          },
+          ],
         },
-        "text": "end function",
+        "end": Object {
+          "isReserved": false,
+          "kind": 52,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 28,
+              "line": 4,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 4,
+            },
+          },
+          "text": "end function",
+        },
+        "keyword": Object {
+          "isReserved": true,
+          "kind": 64,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 24,
+              "line": 2,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 2,
+            },
+          },
+          "text": "function",
+        },
+        "parameters": Array [],
+        "returns": 9,
       },
-      "keyword": Object {
-        "isReserved": true,
-        "kind": 64,
+      "name": Object {
+        "isReserved": false,
+        "kind": 28,
         "literal": undefined,
         "location": Object {
           "end": Object {
-            "column": 24,
+            "column": 36,
             "line": 2,
           },
           "file": "",
           "start": Object {
-            "column": 16,
+            "column": 25,
             "line": 2,
           },
         },
-        "text": "function",
+        "text": "StringFunc#",
       },
-      "parameters": Array [],
-      "returns": 9,
     },
-    "name": Object {
-      "isReserved": false,
-      "kind": 28,
-      "literal": undefined,
-      "location": Object {
-        "end": Object {
-          "column": 36,
-          "line": 2,
-        },
-        "file": "",
-        "start": Object {
-          "column": 25,
-          "line": 2,
-        },
-      },
-      "text": "StringFunc#",
-    },
-  },
-  Function {
-    "func": Function {
-      "body": Block {
-        "startingLocation": Object {
-          "end": Object {
-            "column": 26,
-            "line": 7,
+    Function {
+      "func": Function {
+        "body": Block {
+          "startingLocation": Object {
+            "end": Object {
+              "column": 26,
+              "line": 7,
+            },
+            "file": "",
+            "start": Object {
+              "column": 20,
+              "line": 7,
+            },
           },
-          "file": "",
-          "start": Object {
-            "column": 20,
-            "line": 7,
-          },
-        },
-        "statements": Array [
-          Return {
-            "tokens": Object {
-              "return": Object {
-                "isReserved": true,
-                "kind": 80,
-                "literal": undefined,
-                "location": Object {
+          "statements": Array [
+            Return {
+              "tokens": Object {
+                "return": Object {
+                  "isReserved": true,
+                  "kind": 80,
+                  "literal": undefined,
+                  "location": Object {
+                    "end": Object {
+                      "column": 26,
+                      "line": 7,
+                    },
+                    "file": "",
+                    "start": Object {
+                      "column": 20,
+                      "line": 7,
+                    },
+                  },
+                  "text": "return",
+                },
+              },
+              "value": Literal {
+                "_location": Object {
                   "end": Object {
-                    "column": 26,
+                    "column": 28,
                     "line": 7,
                   },
                   "file": "",
                   "start": Object {
-                    "column": 20,
+                    "column": 27,
                     "line": 7,
                   },
                 },
-                "text": "return",
-              },
-            },
-            "value": Literal {
-              "_location": Object {
-                "end": Object {
-                  "column": 28,
-                  "line": 7,
-                },
-                "file": "",
-                "start": Object {
-                  "column": 27,
-                  "line": 7,
+                "value": Int32 {
+                  "kind": 3,
+                  "value": 1,
                 },
               },
-              "value": Int32 {
-                "kind": 3,
-                "value": 1,
-              },
             },
-          },
-        ],
-      },
-      "end": Object {
-        "isReserved": false,
-        "kind": 52,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": 28,
-            "line": 8,
-          },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 8,
-          },
+          ],
         },
-        "text": "end function",
+        "end": Object {
+          "isReserved": false,
+          "kind": 52,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 28,
+              "line": 8,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 8,
+            },
+          },
+          "text": "end function",
+        },
+        "keyword": Object {
+          "isReserved": true,
+          "kind": 64,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 24,
+              "line": 6,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 6,
+            },
+          },
+          "text": "function",
+        },
+        "parameters": Array [],
+        "returns": 9,
       },
-      "keyword": Object {
-        "isReserved": true,
-        "kind": 64,
+      "name": Object {
+        "isReserved": false,
+        "kind": 28,
         "literal": undefined,
         "location": Object {
           "end": Object {
-            "column": 24,
+            "column": 37,
             "line": 6,
           },
           "file": "",
           "start": Object {
-            "column": 16,
+            "column": 25,
             "line": 6,
           },
         },
-        "text": "function",
+        "text": "IntegerFunc%",
       },
-      "parameters": Array [],
-      "returns": 9,
     },
-    "name": Object {
-      "isReserved": false,
-      "kind": 28,
-      "literal": undefined,
-      "location": Object {
-        "end": Object {
-          "column": 37,
-          "line": 6,
-        },
-        "file": "",
-        "start": Object {
-          "column": 25,
-          "line": 6,
-        },
-      },
-      "text": "IntegerFunc%",
-    },
-  },
-  Function {
-    "func": Function {
-      "body": Block {
-        "startingLocation": Object {
-          "end": Object {
-            "column": 26,
-            "line": 11,
+    Function {
+      "func": Function {
+        "body": Block {
+          "startingLocation": Object {
+            "end": Object {
+              "column": 26,
+              "line": 11,
+            },
+            "file": "",
+            "start": Object {
+              "column": 20,
+              "line": 11,
+            },
           },
-          "file": "",
-          "start": Object {
-            "column": 20,
-            "line": 11,
-          },
-        },
-        "statements": Array [
-          Return {
-            "tokens": Object {
-              "return": Object {
-                "isReserved": true,
-                "kind": 80,
-                "literal": undefined,
-                "location": Object {
+          "statements": Array [
+            Return {
+              "tokens": Object {
+                "return": Object {
+                  "isReserved": true,
+                  "kind": 80,
+                  "literal": undefined,
+                  "location": Object {
+                    "end": Object {
+                      "column": 26,
+                      "line": 11,
+                    },
+                    "file": "",
+                    "start": Object {
+                      "column": 20,
+                      "line": 11,
+                    },
+                  },
+                  "text": "return",
+                },
+              },
+              "value": Literal {
+                "_location": Object {
                   "end": Object {
-                    "column": 26,
+                    "column": 28,
                     "line": 11,
                   },
                   "file": "",
                   "start": Object {
-                    "column": 20,
+                    "column": 27,
                     "line": 11,
                   },
                 },
-                "text": "return",
-              },
-            },
-            "value": Literal {
-              "_location": Object {
-                "end": Object {
-                  "column": 28,
-                  "line": 11,
-                },
-                "file": "",
-                "start": Object {
-                  "column": 27,
-                  "line": 11,
+                "value": Int32 {
+                  "kind": 3,
+                  "value": 1,
                 },
               },
-              "value": Int32 {
-                "kind": 3,
-                "value": 1,
-              },
             },
-          },
-        ],
-      },
-      "end": Object {
-        "isReserved": false,
-        "kind": 52,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": 28,
-            "line": 12,
-          },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 12,
-          },
+          ],
         },
-        "text": "end function",
-      },
-      "keyword": Object {
-        "isReserved": true,
-        "kind": 64,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": 24,
-            "line": 10,
-          },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 10,
-          },
-        },
-        "text": "function",
-      },
-      "parameters": Array [],
-      "returns": 9,
-    },
-    "name": Object {
-      "isReserved": false,
-      "kind": 28,
-      "literal": undefined,
-      "location": Object {
         "end": Object {
-          "column": 35,
-          "line": 10,
+          "isReserved": false,
+          "kind": 52,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 28,
+              "line": 12,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 12,
+            },
+          },
+          "text": "end function",
         },
-        "file": "",
-        "start": Object {
-          "column": 25,
-          "line": 10,
+        "keyword": Object {
+          "isReserved": true,
+          "kind": 64,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 24,
+              "line": 10,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 10,
+            },
+          },
+          "text": "function",
         },
+        "parameters": Array [],
+        "returns": 9,
       },
-      "text": "FloatFunc!",
-    },
-  },
-  Function {
-    "func": Function {
-      "body": Block {
-        "startingLocation": Object {
+      "name": Object {
+        "isReserved": false,
+        "kind": 28,
+        "literal": undefined,
+        "location": Object {
           "end": Object {
-            "column": 26,
-            "line": 15,
+            "column": 35,
+            "line": 10,
           },
           "file": "",
           "start": Object {
-            "column": 20,
-            "line": 15,
+            "column": 25,
+            "line": 10,
           },
         },
-        "statements": Array [
-          Return {
-            "tokens": Object {
-              "return": Object {
-                "isReserved": true,
-                "kind": 80,
-                "literal": undefined,
-                "location": Object {
+        "text": "FloatFunc!",
+      },
+    },
+    Function {
+      "func": Function {
+        "body": Block {
+          "startingLocation": Object {
+            "end": Object {
+              "column": 26,
+              "line": 15,
+            },
+            "file": "",
+            "start": Object {
+              "column": 20,
+              "line": 15,
+            },
+          },
+          "statements": Array [
+            Return {
+              "tokens": Object {
+                "return": Object {
+                  "isReserved": true,
+                  "kind": 80,
+                  "literal": undefined,
+                  "location": Object {
+                    "end": Object {
+                      "column": 26,
+                      "line": 15,
+                    },
+                    "file": "",
+                    "start": Object {
+                      "column": 20,
+                      "line": 15,
+                    },
+                  },
+                  "text": "return",
+                },
+              },
+              "value": Literal {
+                "_location": Object {
                   "end": Object {
-                    "column": 26,
+                    "column": 28,
                     "line": 15,
                   },
                   "file": "",
                   "start": Object {
-                    "column": 20,
+                    "column": 27,
                     "line": 15,
                   },
                 },
-                "text": "return",
-              },
-            },
-            "value": Literal {
-              "_location": Object {
-                "end": Object {
-                  "column": 28,
-                  "line": 15,
-                },
-                "file": "",
-                "start": Object {
-                  "column": 27,
-                  "line": 15,
+                "value": Int32 {
+                  "kind": 3,
+                  "value": 1,
                 },
               },
-              "value": Int32 {
-                "kind": 3,
-                "value": 1,
-              },
             },
-          },
-        ],
-      },
-      "end": Object {
-        "isReserved": false,
-        "kind": 52,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": 28,
-            "line": 16,
-          },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 16,
-          },
+          ],
         },
-        "text": "end function",
-      },
-      "keyword": Object {
-        "isReserved": true,
-        "kind": 64,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": 24,
-            "line": 14,
-          },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 14,
-          },
-        },
-        "text": "function",
-      },
-      "parameters": Array [],
-      "returns": 9,
-    },
-    "name": Object {
-      "isReserved": false,
-      "kind": 28,
-      "literal": undefined,
-      "location": Object {
         "end": Object {
-          "column": 36,
-          "line": 14,
+          "isReserved": false,
+          "kind": 52,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 28,
+              "line": 16,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 16,
+            },
+          },
+          "text": "end function",
         },
-        "file": "",
-        "start": Object {
-          "column": 25,
-          "line": 14,
+        "keyword": Object {
+          "isReserved": true,
+          "kind": 64,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 24,
+              "line": 14,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 14,
+            },
+          },
+          "text": "function",
         },
+        "parameters": Array [],
+        "returns": 9,
       },
-      "text": "DoubleFunc#",
+      "name": Object {
+        "isReserved": false,
+        "kind": 28,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 36,
+            "line": 14,
+          },
+          "file": "",
+          "start": Object {
+            "column": 25,
+            "line": 14,
+          },
+        },
+        "text": "DoubleFunc#",
+      },
     },
-  },
-]
+  ],
+}
 `;
 
 exports[`parser function declarations parses functions with default argument expressions 1`] = `
@@ -1532,292 +1540,300 @@ Array [
 `;
 
 exports[`parser sub declarations does not allow type designators at end of name 1`] = `
-Array [
-  Function {
-    "func": Function {
-      "body": Block {
-        "startingLocation": Object {
-          "end": Object {
-            "column": 23,
-            "line": 3,
+Object {
+  "errors": Array [
+    [Error: Function name 'StringSub#' cannot end with type designator '#'],
+    [Error: Function name 'IntegerSub%' cannot end with type designator '%'],
+    [Error: Function name 'FloatSub!' cannot end with type designator '!'],
+    [Error: Function name 'DoubleSub#' cannot end with type designator '#'],
+  ],
+  "statements": Array [
+    Function {
+      "func": Function {
+        "body": Block {
+          "startingLocation": Object {
+            "end": Object {
+              "column": 23,
+              "line": 3,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 3,
+            },
           },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 3,
-          },
+          "statements": Array [],
         },
-        "statements": Array [],
+        "end": Object {
+          "isReserved": false,
+          "kind": 55,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 23,
+              "line": 3,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 3,
+            },
+          },
+          "text": "end sub",
+        },
+        "keyword": Object {
+          "isReserved": true,
+          "kind": 82,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 19,
+              "line": 2,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 2,
+            },
+          },
+          "text": "sub",
+        },
+        "parameters": Array [],
+        "returns": 10,
       },
-      "end": Object {
+      "name": Object {
         "isReserved": false,
-        "kind": 55,
+        "kind": 28,
         "literal": undefined,
         "location": Object {
           "end": Object {
-            "column": 23,
-            "line": 3,
-          },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 3,
-          },
-        },
-        "text": "end sub",
-      },
-      "keyword": Object {
-        "isReserved": true,
-        "kind": 82,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": 19,
+            "column": 30,
             "line": 2,
           },
           "file": "",
           "start": Object {
-            "column": 16,
+            "column": 20,
             "line": 2,
           },
         },
-        "text": "sub",
+        "text": "StringSub#",
       },
-      "parameters": Array [],
-      "returns": 10,
     },
-    "name": Object {
-      "isReserved": false,
-      "kind": 28,
-      "literal": undefined,
-      "location": Object {
+    Function {
+      "func": Function {
+        "body": Block {
+          "startingLocation": Object {
+            "end": Object {
+              "column": 23,
+              "line": 6,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 6,
+            },
+          },
+          "statements": Array [],
+        },
         "end": Object {
-          "column": 30,
-          "line": 2,
-        },
-        "file": "",
-        "start": Object {
-          "column": 20,
-          "line": 2,
-        },
-      },
-      "text": "StringSub#",
-    },
-  },
-  Function {
-    "func": Function {
-      "body": Block {
-        "startingLocation": Object {
-          "end": Object {
-            "column": 23,
-            "line": 6,
+          "isReserved": false,
+          "kind": 55,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 23,
+              "line": 6,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 6,
+            },
           },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 6,
-          },
+          "text": "end sub",
         },
-        "statements": Array [],
+        "keyword": Object {
+          "isReserved": true,
+          "kind": 82,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 19,
+              "line": 5,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 5,
+            },
+          },
+          "text": "sub",
+        },
+        "parameters": Array [],
+        "returns": 10,
       },
-      "end": Object {
+      "name": Object {
         "isReserved": false,
-        "kind": 55,
+        "kind": 28,
         "literal": undefined,
         "location": Object {
           "end": Object {
-            "column": 23,
-            "line": 6,
-          },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 6,
-          },
-        },
-        "text": "end sub",
-      },
-      "keyword": Object {
-        "isReserved": true,
-        "kind": 82,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": 19,
+            "column": 31,
             "line": 5,
           },
           "file": "",
           "start": Object {
-            "column": 16,
+            "column": 20,
             "line": 5,
           },
         },
-        "text": "sub",
+        "text": "IntegerSub%",
       },
-      "parameters": Array [],
-      "returns": 10,
     },
-    "name": Object {
-      "isReserved": false,
-      "kind": 28,
-      "literal": undefined,
-      "location": Object {
+    Function {
+      "func": Function {
+        "body": Block {
+          "startingLocation": Object {
+            "end": Object {
+              "column": 23,
+              "line": 9,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 9,
+            },
+          },
+          "statements": Array [],
+        },
         "end": Object {
-          "column": 31,
-          "line": 5,
-        },
-        "file": "",
-        "start": Object {
-          "column": 20,
-          "line": 5,
-        },
-      },
-      "text": "IntegerSub%",
-    },
-  },
-  Function {
-    "func": Function {
-      "body": Block {
-        "startingLocation": Object {
-          "end": Object {
-            "column": 23,
-            "line": 9,
+          "isReserved": false,
+          "kind": 55,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 23,
+              "line": 9,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 9,
+            },
           },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 9,
-          },
+          "text": "end sub",
         },
-        "statements": Array [],
+        "keyword": Object {
+          "isReserved": true,
+          "kind": 82,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 19,
+              "line": 8,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 8,
+            },
+          },
+          "text": "sub",
+        },
+        "parameters": Array [],
+        "returns": 10,
       },
-      "end": Object {
+      "name": Object {
         "isReserved": false,
-        "kind": 55,
+        "kind": 28,
         "literal": undefined,
         "location": Object {
           "end": Object {
-            "column": 23,
-            "line": 9,
-          },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 9,
-          },
-        },
-        "text": "end sub",
-      },
-      "keyword": Object {
-        "isReserved": true,
-        "kind": 82,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": 19,
+            "column": 29,
             "line": 8,
           },
           "file": "",
           "start": Object {
-            "column": 16,
+            "column": 20,
             "line": 8,
           },
         },
-        "text": "sub",
+        "text": "FloatSub!",
       },
-      "parameters": Array [],
-      "returns": 10,
     },
-    "name": Object {
-      "isReserved": false,
-      "kind": 28,
-      "literal": undefined,
-      "location": Object {
+    Function {
+      "func": Function {
+        "body": Block {
+          "startingLocation": Object {
+            "end": Object {
+              "column": 23,
+              "line": 12,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 12,
+            },
+          },
+          "statements": Array [],
+        },
         "end": Object {
-          "column": 29,
-          "line": 8,
-        },
-        "file": "",
-        "start": Object {
-          "column": 20,
-          "line": 8,
-        },
-      },
-      "text": "FloatSub!",
-    },
-  },
-  Function {
-    "func": Function {
-      "body": Block {
-        "startingLocation": Object {
-          "end": Object {
-            "column": 23,
-            "line": 12,
+          "isReserved": false,
+          "kind": 55,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 23,
+              "line": 12,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 12,
+            },
           },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 12,
-          },
+          "text": "end sub",
         },
-        "statements": Array [],
+        "keyword": Object {
+          "isReserved": true,
+          "kind": 82,
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 19,
+              "line": 11,
+            },
+            "file": "",
+            "start": Object {
+              "column": 16,
+              "line": 11,
+            },
+          },
+          "text": "sub",
+        },
+        "parameters": Array [],
+        "returns": 10,
       },
-      "end": Object {
+      "name": Object {
         "isReserved": false,
-        "kind": 55,
+        "kind": 28,
         "literal": undefined,
         "location": Object {
           "end": Object {
-            "column": 23,
-            "line": 12,
-          },
-          "file": "",
-          "start": Object {
-            "column": 16,
-            "line": 12,
-          },
-        },
-        "text": "end sub",
-      },
-      "keyword": Object {
-        "isReserved": true,
-        "kind": 82,
-        "literal": undefined,
-        "location": Object {
-          "end": Object {
-            "column": 19,
+            "column": 30,
             "line": 11,
           },
           "file": "",
           "start": Object {
-            "column": 16,
+            "column": 20,
             "line": 11,
           },
         },
-        "text": "sub",
+        "text": "DoubleSub#",
       },
-      "parameters": Array [],
-      "returns": 10,
     },
-    "name": Object {
-      "isReserved": false,
-      "kind": 28,
-      "literal": undefined,
-      "location": Object {
-        "end": Object {
-          "column": 30,
-          "line": 11,
-        },
-        "file": "",
-        "start": Object {
-          "column": 20,
-          "line": 11,
-        },
-      },
-      "text": "DoubleSub#",
-    },
-  },
-]
+  ],
+}
 `;
 
 exports[`parser sub declarations parses minimal sub declarations 1`] = `


### PR DESCRIPTION
Adds parser support for type designators (i.e. a trailing `$` `%` `#` `!` after a variable identifier). This will still need to be implemented in the runtime at a later time. 

All function, variable, and parameter identifier tokens are permitted to end with a type designator. Then, in the parser, we enforce that function identifiers are NOT allowed to end with a type designator. 

Fixes #162  