### PR TITLE
Fix for each space

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -486,13 +486,21 @@ export class Lexer {
             let text = source.slice(start, current).toLowerCase();
 
             // some identifiers can be split into two words, so check the "next" word and see what we get
-            if ((text === "end" || text === "else" || text === "exit" || text === "for") && peek() === " ") {
+            if ((text === "end" || text === "else" || text === "exit" || text === "for") && (peek() === " " || peek() === "\t")) {
                 let endOfFirstWord = current;
 
-                advance(); // skip past the space
+                // skip past any whitespace
+                let whitespace = "";
+                while (peek() === " " || peek() === "\t") {
+                    //keep the whitespace so we can replace it later
+                    whitespace += peek();
+                    advance();
+                }
                 while (isAlphaNumeric(peek())) { advance(); } // read the next word
 
                 let twoWords = source.slice(start, current);
+                //replace all of the whitespace with a single space character so we can properly match keyword token types
+                twoWords = twoWords.replace(whitespace, " ");
                 let maybeTokenType = KeyWords[twoWords.toLowerCase()];
                 if (maybeTokenType) {
                     addToken(maybeTokenType);

--- a/test/lexer/Lexer.test.js
+++ b/test/lexer/Lexer.test.js
@@ -342,8 +342,8 @@ describe("lexer", () => {
         });
     });
 
-    describe('for each loop', () => {
-        it('supports various types of spacing between the two keywords', () => {
+    describe('two word keywords', () => {
+        it('supports various spacing between for each', () => {
             var k = 2;
             let { tokens } = Lexer.scan('for each for  each for    each for\teach for\t each for \teach for \t each');
             console.log(tokens);
@@ -355,6 +355,21 @@ describe("lexer", () => {
                 Lexeme.ForEach,
                 Lexeme.ForEach,
                 Lexeme.ForEach,
+                Lexeme.Eof
+            ]);
+        });
+        it('supports various spacing between else if', () => {
+            var k = 2;
+            let { tokens } = Lexer.scan('else if else  if else    if else\tif else\t if else \tif else \t if');
+            console.log(tokens);
+            expect(tokens.map(t => t.kind)).toEqual([
+                Lexeme.ElseIf,
+                Lexeme.ElseIf,
+                Lexeme.ElseIf,
+                Lexeme.ElseIf,
+                Lexeme.ElseIf,
+                Lexeme.ElseIf,
+                Lexeme.ElseIf,
                 Lexeme.Eof
             ]);
         });

--- a/test/lexer/Lexer.test.js
+++ b/test/lexer/Lexer.test.js
@@ -345,7 +345,6 @@ describe("lexer", () => {
     describe('two word keywords', () => {
         it('supports various spacing between for each', () => {
             let { tokens } = Lexer.scan('for each for  each for    each for\teach for\t each for \teach for \t each');
-            console.log(tokens);
             expect(tokens.map(t => t.kind)).toEqual([
                 Lexeme.ForEach,
                 Lexeme.ForEach,
@@ -359,7 +358,6 @@ describe("lexer", () => {
         });
         it('supports various spacing between else if', () => {
             let { tokens } = Lexer.scan('else if else  if else    if else\tif else\t if else \tif else \t if');
-            console.log(tokens);
             expect(tokens.map(t => t.kind)).toEqual([
                 Lexeme.ElseIf,
                 Lexeme.ElseIf,

--- a/test/lexer/Lexer.test.js
+++ b/test/lexer/Lexer.test.js
@@ -341,4 +341,23 @@ describe("lexer", () => {
             ]);
         });
     });
+
+    describe('for each loop', () => {
+        it('supports various types of spacing between the two keywords', () => {
+            var k = 2;
+            let { tokens } = Lexer.scan('for each for  each for    each for\teach for\t each for \teach for \t each');
+            console.log(tokens);
+            expect(tokens.map(t => t.kind)).toEqual([
+                Lexeme.ForEach,
+                Lexeme.ForEach,
+                Lexeme.ForEach,
+                Lexeme.ForEach,
+                Lexeme.ForEach,
+                Lexeme.ForEach,
+                Lexeme.ForEach,
+                Lexeme.Eof
+            ]);
+        });
+    });
+
 }); // lexer

--- a/test/lexer/Lexer.test.js
+++ b/test/lexer/Lexer.test.js
@@ -344,7 +344,6 @@ describe("lexer", () => {
 
     describe('two word keywords', () => {
         it('supports various spacing between for each', () => {
-            var k = 2;
             let { tokens } = Lexer.scan('for each for  each for    each for\teach for\t each for \teach for \t each');
             console.log(tokens);
             expect(tokens.map(t => t.kind)).toEqual([
@@ -359,7 +358,6 @@ describe("lexer", () => {
             ]);
         });
         it('supports various spacing between else if', () => {
-            var k = 2;
             let { tokens } = Lexer.scan('else if else  if else    if else\tif else\t if else \tif else \t if');
             console.log(tokens);
             expect(tokens.map(t => t.kind)).toEqual([


### PR DESCRIPTION
Fix issues in the parser with multiple spaces between two-word keywords (like `for each`, `exit while`, etc). 

I also verified that tabs are treated the same as spaces, so I added support for tabs between these keywords as well. This program is an example (replace `\t\t` with actual tab chars):

```
sub SayHi(message as string)
    for \t\t each num in [1,2,3]
		print num
	end for
end sub
```

Fixes #202 
Fixes #201 

