### PR TITLE
Support bitshift assignment operators in the lexer

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -215,7 +215,15 @@ export class Lexer {
                             break;
                         case "<":
                             advance();
-                            addToken(Lexeme.LeftShift);
+                            switch (peek()) {
+                                case "=":
+                                    advance();
+                                    addToken(Lexeme.LeftShiftEqual);
+                                    break;
+                                default:
+                                    addToken(Lexeme.LeftShift);
+                                    break;
+                            }
                             break;
                         case ">":
                             advance();
@@ -232,7 +240,15 @@ export class Lexer {
                             break;
                         case ">":
                             advance();
-                            addToken(Lexeme.RightShift);
+                            switch(peek()){
+                                case "=":
+                                    advance();
+                                    addToken(Lexeme.RightShiftEqual);
+                                    break;
+                                default:
+                                    addToken(Lexeme.RightShift);
+                                    break;
+                            }
                             break;
                         default: addToken(Lexeme.Greater); break;
                     }

--- a/test/lexer/Lexer.test.js
+++ b/test/lexer/Lexer.test.js
@@ -95,6 +95,16 @@ describe("lexer", () => {
             expect(tokens.filter(t => !!t.literal).length).toBe(0);
         });
 
+        it('reads bitshift assignment operators', () => {
+            let { tokens } = Lexer.scan("<<= >>=");
+            expect(tokens.map(t => t.kind)).toEqual([
+                Lexeme.LeftShiftEqual,
+                Lexeme.RightShiftEqual,
+                Lexeme.Eof
+            ]);
+            expect(tokens.filter(t => !!t.literal).length).toBe(0);
+        });
+
         it("reads comparators", () => {
             let { tokens } = Lexer.scan("< <= > >= = <>");
             expect(tokens.map(t => t.kind)).toEqual([


### PR DESCRIPTION
The lexer was not properly tokenizing bitshift assignment operators. However, the parser DOES support them, so the only change necessary was the lexer.

This does not implement the runtime functionality.

Fixes #172 