### PR TITLE
Better single line recovery

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -706,14 +706,20 @@ export class Parser {
 
             const statements: Statement[] = [];
             while (!check(...terminators) && !isAtEnd()) {
-                const dec = declaration();
+                //grab the location of the current token
+                let loopCurrent = current;
+                let dec = declaration();
+
                 if (dec) {
                     statements.push(dec);
                 } else {
-                    // //couldn't find a declaration. Try discarding the line entirely for now
-                    // while (!check(Lexeme.Newline) && !isAtEnd()) {
-                    //     advance();
-                    // }
+                    //something went wrong. reset to the top of the loop
+                    current = loopCurrent;
+
+                    //scrap the entire line
+                    consumeUntil(Lexeme.Colon, Lexeme.Newline, Lexeme.Eof);
+                    //trash the newline character so we start the next iteraion on the next line
+                    advance();
                 }
             }
 
@@ -983,6 +989,20 @@ export class Parser {
             }
 
             return false;
+        }
+
+        /**
+         * Consume tokens until one of the `stopLexemes` is encountered
+         * @param lexemes 
+         * @return - the list of tokens consumed, EXCLUDING the `stopLexeme` (you can use `peek()` to see which one it was)
+         */
+        function consumeUntil(...stopLexemes: Lexeme[]) {
+            let result = [] as Token[];
+            //take tokens until we encounter one of the stopLexemes
+            while (stopLexemes.indexOf(peek().kind) === -1) {
+                result.push(advance());
+            }
+            return result;
         }
 
         function consume(message: string, ...lexemes: Lexeme[]): Token {

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -723,6 +723,11 @@ export class Parser {
                 const dec = declaration();
                 if (dec) {
                     statements.push(dec);
+                } else {
+                    // //couldn't find a declaration. Try discarding the line entirely for now
+                    // while (!check(Lexeme.Newline) && !isAtEnd()) {
+                    //     advance();
+                    // }
                 }
             }
 

--- a/test/parser/expression/Call.test.js
+++ b/test/parser/expression/Call.test.js
@@ -14,7 +14,7 @@ describe("parser call expressions", () => {
     it("parses named function calls", () => {
         const { statements, errors } = parser.parse([
             identifier("RebootSystem"),
-            { kind: Lexeme.LeftParen,  text: "(", line: 1 },
+            { kind: Lexeme.LeftParen, text: "(", line: 1 },
             token(Lexeme.RightParen, ")"),
             EOF
         ]);
@@ -25,10 +25,30 @@ describe("parser call expressions", () => {
         expect(statements).toMatchSnapshot();
     });
 
+    it('does not invalidate the rest of the file on incomplete statement', () => {
+        const { tokens } = brs.lexer.Lexer.scan(`
+            sub DoThingOne()
+                DoThin
+            end sub
+            sub DoThingTwo()
+            end sub 
+        `);
+        const { statements, errors } = parser.parse(tokens);
+        //there should only be at least one error, on the `DoThin` line
+        expect(errors.length).toBeGreaterThan(0);
+
+        //ALL of the errors should be on the `DoThin` line
+        let lineNumbers = errors.map(x => x.location.start.line);
+        for (let lineNumber of lineNumbers) {
+            expect(lineNumber).toEqual(3);
+        }
+        expect(statements).toMatchSnapshot();
+    });
+
     it("allows closing parentheses on separate line", () => {
         const { statements, errors } = parser.parse([
             identifier("RebootSystem"),
-            { kind: Lexeme.LeftParen,  text: "(", line: 1 },
+            { kind: Lexeme.LeftParen, text: "(", line: 1 },
             token(Lexeme.Newline, "\\n"),
             token(Lexeme.Newline, "\\n"),
             token(Lexeme.RightParen, ")"),
@@ -44,9 +64,9 @@ describe("parser call expressions", () => {
     it("accepts arguments", () => {
         const { statements, errors } = parser.parse([
             identifier("add"),
-            { kind: Lexeme.LeftParen,  text: "(", line: 1 },
+            { kind: Lexeme.LeftParen, text: "(", line: 1 },
             token(Lexeme.Integer, "1", new Int32(1)),
-            { kind: Lexeme.Comma,  text: ",", line: 1 },
+            { kind: Lexeme.Comma, text: ",", line: 1 },
             token(Lexeme.Integer, "2", new Int32(2)),
             token(Lexeme.RightParen, ")"),
             EOF

--- a/test/parser/expression/Call.test.js
+++ b/test/parser/expression/Call.test.js
@@ -34,7 +34,6 @@ describe("parser call expressions", () => {
             end sub 
         `);
         const { statements, errors } = parser.parse(tokens);
-        //there should only be at least one error, on the `DoThin` line
         expect(errors.length).toBeGreaterThan(0);
 
         //ALL of the errors should be on the `DoThin` line
@@ -42,6 +41,22 @@ describe("parser call expressions", () => {
         for (let lineNumber of lineNumbers) {
             expect(lineNumber).toEqual(3);
         }
+        expect(statements).toMatchSnapshot();
+    });
+
+    it('does not invalidate the next statement on a multi-statement line', () => {
+        const { tokens } = brs.lexer.Lexer.scan(`
+            sub DoThingOne()
+                DoThin:name = "bob"
+            end sub
+            sub DoThingTwo()
+            end sub 
+        `);
+        const { statements, errors } = parser.parse(tokens);
+        //there should only be 1 error
+        expect(errors.length).toEqual(1);
+        //the error should be BEFORE the `name = "bob"` statement
+        expect(errors[0].location.end.column).toBeLessThan(24);
         expect(statements).toMatchSnapshot();
     });
 

--- a/test/parser/expression/__snapshots__/Call.test.js.snap
+++ b/test/parser/expression/__snapshots__/Call.test.js.snap
@@ -121,6 +121,356 @@ Array [
 ]
 `;
 
+exports[`parser call expressions does not invalidate the next statement on a multi-statement line 1`] = `
+Array [
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 22,
+            "line": 3,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 3,
+          },
+        },
+        "statements": Array [
+          Assignment {
+            "name": Object {
+              "isReserved": false,
+              "kind": 28,
+              "literal": undefined,
+              "location": Object {
+                "end": Object {
+                  "column": 27,
+                  "line": 3,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 23,
+                  "line": 3,
+                },
+              },
+              "text": "name",
+            },
+            "tokens": Object {
+              "equals": Object {
+                "isReserved": false,
+                "kind": 26,
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 29,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 28,
+                    "line": 3,
+                  },
+                },
+                "text": "=",
+              },
+            },
+            "value": Literal {
+              "_location": Object {
+                "end": Object {
+                  "column": 35,
+                  "line": 3,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 30,
+                  "line": 3,
+                },
+              },
+              "value": BrsString {
+                "kind": 2,
+                "value": "bob",
+              },
+            },
+          },
+        ],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 55,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 19,
+            "line": 4,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 4,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 82,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 15,
+            "line": 2,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 2,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 26,
+          "line": 2,
+        },
+        "file": "",
+        "start": Object {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "text": "DoThingOne",
+    },
+  },
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 19,
+            "line": 6,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 6,
+          },
+        },
+        "statements": Array [],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 55,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 19,
+            "line": 6,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 6,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 82,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 15,
+            "line": 5,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 5,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 26,
+          "line": 5,
+        },
+        "file": "",
+        "start": Object {
+          "column": 16,
+          "line": 5,
+        },
+      },
+      "text": "DoThingTwo",
+    },
+  },
+]
+`;
+
+exports[`parser call expressions does not invalidate the rest of the file on incomplete statement 1`] = `
+Array [
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 22,
+            "line": 3,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 3,
+          },
+        },
+        "statements": Array [],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 55,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 19,
+            "line": 4,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 4,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 82,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 15,
+            "line": 2,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 2,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 26,
+          "line": 2,
+        },
+        "file": "",
+        "start": Object {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "text": "DoThingOne",
+    },
+  },
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 19,
+            "line": 6,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 6,
+          },
+        },
+        "statements": Array [],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 55,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 19,
+            "line": 6,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 6,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 82,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 15,
+            "line": 5,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 5,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 26,
+          "line": 5,
+        },
+        "file": "",
+        "start": Object {
+          "column": 16,
+          "line": 5,
+        },
+      },
+      "text": "DoThingTwo",
+    },
+  },
+]
+`;
+
 exports[`parser call expressions parses named function calls 1`] = `
 Array [
   Expression {


### PR DESCRIPTION
Sometimes a parse error causes the `block` function to consume all of the remaining tokens. This PR fixes that issue by discarding the line, which should drastically improve parse error recovery.

Fixes #157 