### PR TITLE
Support colons as separators for AA properties

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -940,8 +940,8 @@ export class Parser {
                             value: expression()
                         });
 
-                        while (match(Lexeme.Comma, Lexeme.Newline)) {
-                            while (match(Lexeme.Newline));
+                        while (match(Lexeme.Comma, Lexeme.Newline, Lexeme.Colon)) {
+                            while (match(Lexeme.Newline, Lexeme.Colon));
 
                             if (check(Lexeme.RightBrace)) {
                                 break;

--- a/test/parser/expression/AssociativeArrayLiterals.test.js
+++ b/test/parser/expression/AssociativeArrayLiterals.test.js
@@ -135,6 +135,17 @@ describe("parser associative array literals", () => {
         });
     });
 
+    it('allows separating properties with colons', ()=>{
+        const { tokens } = brs.lexer.Lexer.scan(`
+            sub Main()
+                person = {name: "Bob":::::age:50}
+            end sub 
+        `);
+        let { statements, errors } = parser.parse(tokens);
+        expect(errors.length).toEqual(0);
+        expect(statements).toMatchSnapshot();
+    });
+
     it("allows a mix of quoted and unquoted keys", () => {
         let { statements, errors } = parser.parse([
             identifier("_"),

--- a/test/parser/expression/AssociativeArrayLiterals.test.js
+++ b/test/parser/expression/AssociativeArrayLiterals.test.js
@@ -135,13 +135,32 @@ describe("parser associative array literals", () => {
         });
     });
 
-    it('allows separating properties with colons', ()=>{
-        const { tokens } = brs.lexer.Lexer.scan(`
-            sub Main()
-                person = {name: "Bob":::::age:50}
-            end sub 
-        `);
-        let { statements, errors } = parser.parse(tokens);
+    it('allows separating properties with colons', () => {
+        let { statements, errors } = parser.parse([
+            token(Lexeme.Sub, 'sub'),
+            identifier('main'),
+            token(Lexeme.LeftParen, '('),
+            token(Lexeme.RightParen, ')'),
+            token(Lexeme.Newline, '\n'),
+            identifier('person'),
+            token(Lexeme.Equal, '='),
+            token(Lexeme.LeftBrace, '{'),
+            identifier('name'),
+            token(Lexeme.Colon, ':'),
+            token(Lexeme.String, "Bob", new BrsString("Bob")),
+            token(Lexeme.Colon, ':'),
+            token(Lexeme.Colon, ':'),
+            token(Lexeme.Colon, ':'),
+            token(Lexeme.Colon, ':'),
+            token(Lexeme.Colon, ':'),
+            identifier('age'),
+            token(Lexeme.Colon, ':'),
+            token(Lexeme.Integer, "50", new Int32(3)),
+            token(Lexeme.RightBrace, '}'),
+            token(Lexeme.Newline, '\n'),
+            token(Lexeme.EndSub, 'end sub'),
+            EOF
+        ]);
         expect(errors.length).toEqual(0);
         expect(statements).toMatchSnapshot();
     });

--- a/test/parser/expression/__snapshots__/AssociativeArrayLiterals.test.js.snap
+++ b/test/parser/expression/__snapshots__/AssociativeArrayLiterals.test.js.snap
@@ -143,6 +143,205 @@ Array [
 ]
 `;
 
+exports[`parser associative array literals allows separating properties with colons 1`] = `
+Array [
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": 22,
+            "line": 3,
+          },
+          "file": "",
+          "start": Object {
+            "column": 16,
+            "line": 3,
+          },
+        },
+        "statements": Array [
+          Assignment {
+            "name": Object {
+              "isReserved": false,
+              "kind": 28,
+              "literal": undefined,
+              "location": Object {
+                "end": Object {
+                  "column": 22,
+                  "line": 3,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 16,
+                  "line": 3,
+                },
+              },
+              "text": "person",
+            },
+            "tokens": Object {
+              "equals": Object {
+                "isReserved": false,
+                "kind": 26,
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 24,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 23,
+                    "line": 3,
+                  },
+                },
+                "text": "=",
+              },
+            },
+            "value": AALiteral {
+              "close": Object {
+                "isReserved": false,
+                "kind": 5,
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 49,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 48,
+                    "line": 3,
+                  },
+                },
+                "text": "}",
+              },
+              "elements": Array [
+                Object {
+                  "name": BrsString {
+                    "kind": 2,
+                    "value": "name",
+                  },
+                  "value": Literal {
+                    "_location": Object {
+                      "end": Object {
+                        "column": 37,
+                        "line": 3,
+                      },
+                      "file": "",
+                      "start": Object {
+                        "column": 32,
+                        "line": 3,
+                      },
+                    },
+                    "value": BrsString {
+                      "kind": 2,
+                      "value": "Bob",
+                    },
+                  },
+                },
+                Object {
+                  "name": BrsString {
+                    "kind": 2,
+                    "value": "age",
+                  },
+                  "value": Literal {
+                    "_location": Object {
+                      "end": Object {
+                        "column": 48,
+                        "line": 3,
+                      },
+                      "file": "",
+                      "start": Object {
+                        "column": 46,
+                        "line": 3,
+                      },
+                    },
+                    "value": Int32 {
+                      "kind": 3,
+                      "value": 50,
+                    },
+                  },
+                },
+              ],
+              "open": Object {
+                "isReserved": false,
+                "kind": 4,
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 26,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 25,
+                    "line": 3,
+                  },
+                },
+                "text": "{",
+              },
+            },
+          },
+        ],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 55,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 19,
+            "line": 4,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 4,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 82,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 15,
+            "line": 2,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 2,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 28,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 20,
+          "line": 2,
+        },
+        "file": "",
+        "start": Object {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "text": "Main",
+    },
+  },
+]
+`;
+
 exports[`parser associative array literals empty associative arrays on multiple lines 1`] = `
 Array [
   Assignment {

--- a/test/parser/expression/__snapshots__/AssociativeArrayLiterals.test.js.snap
+++ b/test/parser/expression/__snapshots__/AssociativeArrayLiterals.test.js.snap
@@ -150,13 +150,12 @@ Array [
       "body": Block {
         "startingLocation": Object {
           "end": Object {
-            "column": 22,
-            "line": 3,
+            "column": -9,
+            "line": -9,
           },
-          "file": "",
           "start": Object {
-            "column": 16,
-            "line": 3,
+            "column": -9,
+            "line": -9,
           },
         },
         "statements": Array [
@@ -167,13 +166,12 @@ Array [
               "literal": undefined,
               "location": Object {
                 "end": Object {
-                  "column": 22,
-                  "line": 3,
+                  "column": -9,
+                  "line": -9,
                 },
-                "file": "",
                 "start": Object {
-                  "column": 16,
-                  "line": 3,
+                  "column": -9,
+                  "line": -9,
                 },
               },
               "text": "person",
@@ -185,13 +183,12 @@ Array [
                 "literal": undefined,
                 "location": Object {
                   "end": Object {
-                    "column": 24,
-                    "line": 3,
+                    "column": -9,
+                    "line": -9,
                   },
-                  "file": "",
                   "start": Object {
-                    "column": 23,
-                    "line": 3,
+                    "column": -9,
+                    "line": -9,
                   },
                 },
                 "text": "=",
@@ -204,13 +201,12 @@ Array [
                 "literal": undefined,
                 "location": Object {
                   "end": Object {
-                    "column": 49,
-                    "line": 3,
+                    "column": -9,
+                    "line": -9,
                   },
-                  "file": "",
                   "start": Object {
-                    "column": 48,
-                    "line": 3,
+                    "column": -9,
+                    "line": -9,
                   },
                 },
                 "text": "}",
@@ -224,13 +220,12 @@ Array [
                   "value": Literal {
                     "_location": Object {
                       "end": Object {
-                        "column": 37,
-                        "line": 3,
+                        "column": -9,
+                        "line": -9,
                       },
-                      "file": "",
                       "start": Object {
-                        "column": 32,
-                        "line": 3,
+                        "column": -9,
+                        "line": -9,
                       },
                     },
                     "value": BrsString {
@@ -247,18 +242,17 @@ Array [
                   "value": Literal {
                     "_location": Object {
                       "end": Object {
-                        "column": 48,
-                        "line": 3,
+                        "column": -9,
+                        "line": -9,
                       },
-                      "file": "",
                       "start": Object {
-                        "column": 46,
-                        "line": 3,
+                        "column": -9,
+                        "line": -9,
                       },
                     },
                     "value": Int32 {
                       "kind": 3,
-                      "value": 50,
+                      "value": 3,
                     },
                   },
                 },
@@ -269,13 +263,12 @@ Array [
                 "literal": undefined,
                 "location": Object {
                   "end": Object {
-                    "column": 26,
-                    "line": 3,
+                    "column": -9,
+                    "line": -9,
                   },
-                  "file": "",
                   "start": Object {
-                    "column": 25,
-                    "line": 3,
+                    "column": -9,
+                    "line": -9,
                   },
                 },
                 "text": "{",
@@ -290,13 +283,12 @@ Array [
         "literal": undefined,
         "location": Object {
           "end": Object {
-            "column": 19,
-            "line": 4,
+            "column": -9,
+            "line": -9,
           },
-          "file": "",
           "start": Object {
-            "column": 12,
-            "line": 4,
+            "column": -9,
+            "line": -9,
           },
         },
         "text": "end sub",
@@ -307,13 +299,12 @@ Array [
         "literal": undefined,
         "location": Object {
           "end": Object {
-            "column": 15,
-            "line": 2,
+            "column": -9,
+            "line": -9,
           },
-          "file": "",
           "start": Object {
-            "column": 12,
-            "line": 2,
+            "column": -9,
+            "line": -9,
           },
         },
         "text": "sub",
@@ -327,16 +318,15 @@ Array [
       "literal": undefined,
       "location": Object {
         "end": Object {
-          "column": 20,
-          "line": 2,
+          "column": -9,
+          "line": -9,
         },
-        "file": "",
         "start": Object {
-          "column": 16,
-          "line": 2,
+          "column": -9,
+          "line": -9,
         },
       },
-      "text": "Main",
+      "text": "main",
     },
   },
 ]


### PR DESCRIPTION
The parser does not properly parse objects with properties separate by colons: `obj = {x:0 : y: 1}`. This PR resolves that issue.

Fixes #195 
