### PR TITLE
feat(stdlib): Implement createObject("roRegex")

### DIFF
--- a/src/brsTypes/components/BrsObjects.ts
+++ b/src/brsTypes/components/BrsObjects.ts
@@ -9,5 +9,5 @@ export const BrsObjects = new Map<string, Function>([
     [ "roassociativearray", () => new AssociativeArray([]) ],
     [ "roarray", () => new BrsArray([]) ],
     [ "rotimespan", () => new Timespan() ],
-    [ "roRegex", () => new Regex(new BrsString(""), new BrsString("")) ],
+    [ "roRegex", (expression: BrsString, flags: BrsString) => new Regex(expression, flags) ],
 ]);

--- a/src/brsTypes/components/BrsObjects.ts
+++ b/src/brsTypes/components/BrsObjects.ts
@@ -9,5 +9,5 @@ export const BrsObjects = new Map<string, Function>([
     [ "roassociativearray", () => new AssociativeArray([]) ],
     [ "roarray", () => new BrsArray([]) ],
     [ "rotimespan", () => new Timespan() ],
-    [ "roRegex", (expression: BrsString, flags: BrsString) => new Regex(expression, flags) ],
+    [ "roregex", (expression: BrsString, flags: BrsString) => new Regex(expression, flags) ],
 ]);

--- a/src/brsTypes/components/BrsObjects.ts
+++ b/src/brsTypes/components/BrsObjects.ts
@@ -1,10 +1,13 @@
 import { AssociativeArray } from "./AssociativeArray";
 import { BrsArray } from "./BrsArray";
 import { Timespan } from "./Timespan";
+import { Regex } from "./Regex";
+import { BrsString } from "../BrsType";
 
 /** Map containing a list of brightscript components that can be created. */
 export const BrsObjects = new Map<string, Function>([
     [ "roassociativearray", () => new AssociativeArray([]) ],
     [ "roarray", () => new BrsArray([]) ],
-    [ "rotimespan", () => new Timespan() ]
+    [ "rotimespan", () => new Timespan() ],
+    [ "roRegex", () => new Regex(new BrsString(""), new BrsString("")) ],
 ]);

--- a/src/brsTypes/components/Regex.ts
+++ b/src/brsTypes/components/Regex.ts
@@ -108,11 +108,15 @@ export class Regex extends BrsComponent implements BrsValue {
         "split",
         {
             signature: {
-                args: [],
-                returns: ValueKind.Boolean
+                args: [
+                    new StdlibArgument("str", ValueKind.String)
+                ],
+                returns: ValueKind.Object
             },
             impl: (interpreter: Interpreter, str: BrsString) => {
-                return BrsBoolean.False;
+                let items = this.jsRegex[Symbol.split](str.value);
+                let brsItems = items.map( item => new BrsString(item));
+                return new BrsArray(brsItems);
             }
         }
     );

--- a/src/brsTypes/components/Regex.ts
+++ b/src/brsTypes/components/Regex.ts
@@ -1,8 +1,9 @@
-import { BrsValue, ValueKind, BrsString, BrsBoolean } from "../BrsType";
+import { BrsBoolean, BrsInvalid, BrsString, BrsValue, ValueKind } from "../BrsType";
 import { BrsComponent } from "./BrsComponent";
 import { BrsType } from "..";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
+import { BrsArray } from "./BrsArray";
 
 export class Regex extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -31,7 +32,7 @@ export class Regex extends BrsComponent implements BrsValue {
         {
             signature: {
                 args: [
-                    new StdlibArgument("str", ValueKind.String),
+                    new StdlibArgument("str", ValueKind.String)
                 ],
                 returns: ValueKind.Boolean
             },
@@ -45,11 +46,22 @@ export class Regex extends BrsComponent implements BrsValue {
         "match",
         {
             signature: {
-                args: [],
-                returns: ValueKind.Boolean
+                args: [
+                    new StdlibArgument("str", ValueKind.String)
+                ],
+                returns: ValueKind.Object
             },
             impl: (interpreter: Interpreter, str: BrsString) => {
-                return BrsBoolean.False;
+                const result = this.jsRegex.exec(str.value);
+                let arr = [];
+                if (result !== null) {
+                    for (let i = 0; i < result.length; i++) {
+                        let item = result[i] ? new BrsString(result[i]) : BrsInvalid.Instance;
+                        arr.push(item);
+                    }
+                }
+
+                return new BrsArray(arr);
             }
         }
     );

--- a/src/brsTypes/components/Regex.ts
+++ b/src/brsTypes/components/Regex.ts
@@ -7,11 +7,12 @@ import { BrsArray } from "./BrsArray";
 
 export class Regex extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
+    readonly supportedFlags = "ims";
     private jsRegex : RegExp;
 
     constructor(expression: BrsString, flags = new BrsString("")) {
         super("roRegex");
-        this.jsRegex = new RegExp(expression.value, flags.value);
+        this.jsRegex = new RegExp(expression.value, this.parseFlags(flags.value));
 
         this.registerMethods([
             this.isMatch,
@@ -25,6 +26,25 @@ export class Regex extends BrsComponent implements BrsValue {
 
     toString(parent?: BrsType): string {
         return "<Component: roRegex>";
+    }
+
+    private parseFlags(inputFlags: string): string {
+        let parsedFlags = "";
+        if (inputFlags.length === 0) {
+            return parsedFlags;
+        }
+
+        for (const flag of inputFlags) {
+            if (flag === "x") {
+                console.warn("'x' flag is not implemented yet, ignoring flag.");
+            } else if(this.supportedFlags.indexOf(flag) === -1) {
+                throw new Error(`${flag} is not supported.`);
+            } else {
+                parsedFlags += flag;
+            }
+        }
+
+        return parsedFlags;
     }
 
     private parseReplacementPattern(pattern: string): string {

--- a/src/brsTypes/components/Regex.ts
+++ b/src/brsTypes/components/Regex.ts
@@ -1,0 +1,108 @@
+import { BrsValue, ValueKind, BrsString, BrsBoolean } from "../BrsType";
+import { BrsComponent } from "./BrsComponent";
+import { BrsType } from "..";
+import { Callable, StdlibArgument } from "../Callable";
+import { Interpreter } from "../../interpreter";
+
+export class Regex extends BrsComponent implements BrsValue {
+    readonly kind = ValueKind.Object;
+    private jsRegex : RegExp;
+
+    constructor(expression: BrsString, flags = new BrsString("")) {
+        super("roRegex");
+        this.jsRegex = new RegExp(expression.value, flags.value);
+
+        this.registerMethods([
+            this.isMatch,
+            this.match,
+            this.replace,
+            this.replaceAll,
+            this.split,
+            this.matchAll
+        ]);
+    }
+
+    toString(parent?: BrsType): string {
+        return "<Component: roRegex>";
+    }
+
+    private isMatch = new Callable(
+        "ismatch",
+        {
+            signature: {
+                args: [
+                    new StdlibArgument("str", ValueKind.String),
+                ],
+                returns: ValueKind.Boolean
+            },
+            impl: (interpreter: Interpreter, str: BrsString) => {
+                return this.jsRegex.test(str.value) ? BrsBoolean.True : BrsBoolean.False;
+            }
+        }
+    );
+
+    private match = new Callable(
+        "match",
+        {
+            signature: {
+                args: [],
+                returns: ValueKind.Boolean
+            },
+            impl: (interpreter: Interpreter, str: BrsString) => {
+                return BrsBoolean.False;
+            }
+        }
+    );
+
+    private replace = new Callable(
+        "replace",
+        {
+            signature: {
+                args: [],
+                returns: ValueKind.Boolean
+            },
+            impl: (interpreter: Interpreter, str: BrsString) => {
+                return BrsBoolean.False;
+            }
+        }
+    );
+
+    private replaceAll = new Callable(
+        "replaceall",
+        {
+            signature: {
+                args: [],
+                returns: ValueKind.Boolean
+            },
+            impl: (interpreter: Interpreter, str: BrsString) => {
+                return BrsBoolean.False;
+            }
+        }
+    );
+
+    private split = new Callable(
+        "split",
+        {
+            signature: {
+                args: [],
+                returns: ValueKind.Boolean
+            },
+            impl: (interpreter: Interpreter, str: BrsString) => {
+                return BrsBoolean.False;
+            }
+        }
+    );
+
+    private matchAll = new Callable(
+        "matchall",
+        {
+            signature: {
+                args: [],
+                returns: ValueKind.Boolean
+            },
+            impl: (interpreter: Interpreter, str: BrsString) => {
+                return BrsBoolean.False;
+            }
+        }
+    );
+}

--- a/src/brsTypes/components/Regex.ts
+++ b/src/brsTypes/components/Regex.ts
@@ -70,11 +70,15 @@ export class Regex extends BrsComponent implements BrsValue {
         "replace",
         {
             signature: {
-                args: [],
-                returns: ValueKind.Boolean
+                args: [
+                    new StdlibArgument("str", ValueKind.String),
+                    new StdlibArgument("str", ValueKind.String)
+                ],
+                returns: ValueKind.String
             },
-            impl: (interpreter: Interpreter, str: BrsString) => {
-                return BrsBoolean.False;
+            impl: (interpreter: Interpreter, str: BrsString, replacement: BrsString) => {
+                const newStr = this.jsRegex[Symbol.replace](str.value, replacement.value);
+                return new BrsString(newStr);
             }
         }
     );
@@ -83,11 +87,19 @@ export class Regex extends BrsComponent implements BrsValue {
         "replaceall",
         {
             signature: {
-                args: [],
-                returns: ValueKind.Boolean
+                args: [
+                    new StdlibArgument("str", ValueKind.String),
+                    new StdlibArgument("str", ValueKind.String)
+                ],
+                returns: ValueKind.String
             },
-            impl: (interpreter: Interpreter, str: BrsString) => {
-                return BrsBoolean.False;
+            impl: (interpreter: Interpreter, str: BrsString, replacement: BrsString) => {
+                const source = this.jsRegex.source;
+                const flags = this.jsRegex.flags + "g";
+                this.jsRegex = new RegExp(source, flags);
+                const newStr = this.jsRegex[Symbol.replace](str.value, replacement.value);
+
+                return new BrsString(newStr);
             }
         }
     );

--- a/src/brsTypes/index.ts
+++ b/src/brsTypes/index.ts
@@ -17,6 +17,7 @@ export * from "./components/BrsArray";
 export * from "./components/AssociativeArray";
 export * from "./components/Timespan";
 export * from "./components/BrsObjects";
+export * from "./components/Regex";
 export * from "./Callable";
 
 /**

--- a/test/brsTypes/components/Regex.test.js
+++ b/test/brsTypes/components/Regex.test.js
@@ -38,6 +38,7 @@ describe("Regex", () => {
             expect(str2).toBe(BrsBoolean.False);
         });
     });
+
     describe("match", () => {
         it("doesn't match string", () => {
             let rgx = new Regex(new BrsString("(a|(z))(bc)"));
@@ -67,8 +68,42 @@ describe("Regex", () => {
             expect(result.get(new Int32(3)).value).toBe("bc");
         });
     });
-    // describe("replace");
-    // describe("replaceAll");
-    // describe("split");
+
+    describe("replace", () => {
+        it("replaces first matched instance from string", () => {
+            let rgx = new Regex(new BrsString("-"));
+            let replace = rgx.getMethod("replace");
+            expect(replace).toBeTruthy();
+
+            let result = replace.call(interpreter, new BrsString("2010-01-01"), new BrsString("."));
+            expect(result.kind).toBe(ValueKind.String);
+            expect(result.value).toBe("2010.01-01");
+        })
+    });
+
+    describe("replaceAll", () => {
+        it("replaces all matched instances from string", () => {
+            let rgx = new Regex(new BrsString("-"));
+            let replaceAll = rgx.getMethod("replaceall");
+            expect(replaceAll).toBeTruthy();
+
+            let result = replaceAll.call(interpreter, new BrsString("2010-01-01"), new BrsString("."));
+            expect(result.kind).toBe(ValueKind.String);
+            expect(result.value).toBe("2010.01.01");
+        })
+    });
+
+    describe("split", () => {
+        it("splits in the correct number of items", () => {
+            let rgx = new Regex(new BrsString(","));
+            let split = rgx.getMethod("split");
+            expect(split).toBeTruthy();
+
+            let result = split.call(interpreter, new BrsString("one, two, three, four"));
+            let count = result.getMethod("count").call(interpreter);
+            expect(result.kind).toBe(ValueKind.Object);
+            expect(count.value).toBe(4);
+        })
+    });
     // describe("matchAll");
 });

--- a/test/brsTypes/components/Regex.test.js
+++ b/test/brsTypes/components/Regex.test.js
@@ -10,7 +10,7 @@ describe("Regex", () => {
     });
 
     describe("isMatch", () => {
-        it("tests strings with case sensitive flag", () => {
+        it("matches strings with case sensitive flag", () => {
             let regx = new Regex(new BrsString("hello_[0-9]*_world"));
             let isMatch = regx.getMethod("isMatch");
             expect(isMatch).toBeTruthy();
@@ -24,7 +24,7 @@ describe("Regex", () => {
             expect(str2).toBe(BrsBoolean.False);
         });
 
-        it("tests strings with case insensitive flag", () => {
+        it("matches strings with case insensitive flag", () => {
             let regx = new Regex(new BrsString("hello_[0-9]*_world"), new BrsString("i"));
             let isMatch = regx.getMethod("isMatch");
             expect(isMatch).toBeTruthy();
@@ -36,6 +36,20 @@ describe("Regex", () => {
             let str2 = isMatch.call(interpreter, new BrsString("HeLlO_XXX_WoRlD"));
             expect(str2.kind).toBe(ValueKind.Boolean);
             expect(str2).toBe(BrsBoolean.False);
+        });
+
+        it("matches a string in ISO8601 format", () => {
+            let regx = new Regex(new BrsString("P(\\d+Y)?(\\d+M)?(\\d+D)?T(\\d+H)?(\\d+M)?(\\d+(.\\d+)?S)?"));
+            let isMatch = regx.getMethod("isMatch");
+            expect(isMatch).toBeTruthy();
+
+            let str1 = isMatch.call(interpreter, new BrsString("P3Y6M4DT12H30M5S"));
+            expect(str1.kind).toBe(ValueKind.Boolean);
+            expect(str1).toBe(BrsBoolean.True);
+
+            let str2 = isMatch.call(interpreter, new BrsString("P4Y5M2DT10H15M5.6S"));
+            expect(str2.kind).toBe(ValueKind.Boolean);
+            expect(str2).toBe(BrsBoolean.True);
         });
     });
 
@@ -67,6 +81,42 @@ describe("Regex", () => {
             expect(result.get(new Int32(2))).toEqual(BrsInvalid.Instance);
             expect(result.get(new Int32(3)).value).toBe("bc");
         });
+
+        it("matches string in hh:mm:ss.ms date format", () => {
+            let regx = new Regex(new BrsString("(([0-9]{2}):)?(([0-9]{2}):)?([0-9]{2})\\.([0-9]{3})"));
+            let match = regx.getMethod("match");
+            expect(match).toBeTruthy();
+
+            let result = match.call(interpreter, new BrsString("10:35:15.123"));
+            let count = result.getMethod("count").call(interpreter);
+            expect(result.kind).toBe(ValueKind.Object);
+            expect(result.getComponentName()).toBe("roArray");
+            expect(count.value).toBe(7);
+        });
+
+        it("matches strings using beginning and end of input", () => {
+            let regx = new Regex(new BrsString("^(.*:)\\/\\/([A-Za-z0-9\\-\\.]+)?(:[0-9]+)?\\/?(.*)$"));
+            let match = regx.getMethod("match");
+            expect(match).toBeTruthy();
+
+            let result = match.call(interpreter, new BrsString("http://regex101.com"));
+            let count = result.getMethod("count").call(interpreter);
+            expect(result.kind).toBe(ValueKind.Object);
+            expect(result.getComponentName()).toBe("roArray");
+            expect(count.value).toBe(5);
+            expect(result.get(new Int32(2)).value).toBe("regex101.com"); //Domain name
+
+            result = match.call(interpreter, new BrsString("https://regex101.com"));
+            expect(result.kind).toBe(ValueKind.Object);
+            expect(result.getComponentName()).toBe("roArray");
+            expect(result.get(new Int32(1)).value).toBe("https:"); //Protocol
+
+            result = match.call(interpreter, new BrsString("https:/regex101.com")); //Missing slash
+            count = result.getMethod("count").call(interpreter);
+            expect(result.kind).toBe(ValueKind.Object);
+            expect(result.getComponentName()).toBe("roArray");
+            expect(count.value).toBe(0); //No matches
+        });
     });
 
     describe("replace", () => {
@@ -78,7 +128,17 @@ describe("Regex", () => {
             let result = replace.call(interpreter, new BrsString("2010-01-01"), new BrsString("."));
             expect(result.kind).toBe(ValueKind.String);
             expect(result.value).toBe("2010.01-01");
-        })
+        });
+
+        it("replaces string by using positional replacement patterns", () => {
+            let rgx = new Regex(new BrsString("S([0-9]+) E([0-9]+)"), new BrsString("i"));
+            let replace = rgx.getMethod("replace");
+            expect(replace).toBeTruthy();
+
+            let result = replace.call(interpreter, new BrsString("S6 E9"), new BrsString("Season \\1 Episode \\2"));
+            expect(result.kind).toBe(ValueKind.String);
+            expect(result.value).toBe("Season 6 Episode 9");
+        });
     });
 
     describe("replaceAll", () => {
@@ -90,7 +150,7 @@ describe("Regex", () => {
             let result = replaceAll.call(interpreter, new BrsString("2010-01-01"), new BrsString("."));
             expect(result.kind).toBe(ValueKind.String);
             expect(result.value).toBe("2010.01.01");
-        })
+        });
     });
 
     describe("split", () => {
@@ -103,7 +163,30 @@ describe("Regex", () => {
             let count = result.getMethod("count").call(interpreter);
             expect(result.kind).toBe(ValueKind.Object);
             expect(count.value).toBe(4);
-        })
+        });
     });
-    // describe("matchAll");
+
+    describe("matchAll", () => {
+        it("matches all patterns in the string", () => {
+            let rgx = new Regex(new BrsString("\\d+"));
+            let matchAll = rgx.getMethod("matchall");
+            expect(matchAll).toBeTruthy();
+
+            let result = matchAll.call(interpreter, new BrsString("123 456 789"));
+            let count = result.getMethod("count").call(interpreter);
+            let firstElement = result.get(new Int32(0));
+            let secondElement = result.get(new Int32(1));
+            let thirdElement = result.get(new Int32(2));
+
+            expect(result.kind).toBe(ValueKind.Object);
+            expect(result.getComponentName()).toBe("roArray");
+            expect(count.value).toBe(3);
+            expect(firstElement.getComponentName()).toBe("roArray");
+            expect(secondElement.getComponentName()).toBe("roArray");
+            expect(thirdElement.getComponentName()).toBe("roArray");
+            expect(firstElement.get(new Int32(0)).value).toBe("123");
+            expect(secondElement.get(new Int32(0)).value).toBe("456");
+            expect(thirdElement.get(new Int32(0)).value).toBe("789");
+        });
+    });
 });

--- a/test/brsTypes/components/Regex.test.js
+++ b/test/brsTypes/components/Regex.test.js
@@ -1,0 +1,46 @@
+const brs = require("brs");
+const { BrsBoolean, BrsString, Regex, ValueKind } = brs.types;
+const { Interpreter } = require("../../../lib/interpreter");
+
+describe("Regex", () => {
+    let interpreter;
+
+    beforeEach(() => {
+        interpreter = new Interpreter;
+    });
+
+    describe("isMatch", () => {
+        it("tests strings case sensitive", () => {
+            let regx = new Regex(new BrsString("hello_[0-9]*_world"));
+            let isMatch = regx.getMethod("isMatch");
+            expect(isMatch).toBeTruthy();
+
+            let str1 = isMatch.call(interpreter, new BrsString("hello_123_world"));
+            expect(str1.kind).toBe(ValueKind.Boolean);
+            expect(str1).toBe(BrsBoolean.True);
+
+            let str2 = isMatch.call(interpreter, new BrsString("HeLlO_123_WoRlD"));
+            expect(str2.kind).toBe(ValueKind.Boolean);
+            expect(str2).toBe(BrsBoolean.False);
+        });
+
+        it("tests strings case insensitive", () => {
+            let regx = new Regex(new BrsString("hello_[0-9]*_world"), new BrsString("i"));
+            let isMatch = regx.getMethod("isMatch");
+            expect(isMatch).toBeTruthy();
+
+            let str1 = isMatch.call(interpreter, new BrsString("HeLlO_123_WoRlD"));
+            expect(str1.kind).toBe(ValueKind.Boolean);
+            expect(str1).toBe(BrsBoolean.True);
+
+            let str2 = isMatch.call(interpreter, new BrsString("HeLlO_XXX_WoRlD"));
+            expect(str2.kind).toBe(ValueKind.Boolean);
+            expect(str2).toBe(BrsBoolean.False);
+        });
+    });
+    // describe("match");
+    // describe("replace");
+    // describe("replaceAll");
+    // describe("split");
+    // describe("matchAll");
+});

--- a/test/brsTypes/components/Regex.test.js
+++ b/test/brsTypes/components/Regex.test.js
@@ -1,5 +1,5 @@
 const brs = require("brs");
-const { BrsBoolean, BrsString, Regex, ValueKind } = brs.types;
+const { BrsBoolean, BrsInvalid, BrsString, Int32, Regex, ValueKind } = brs.types;
 const { Interpreter } = require("../../../lib/interpreter");
 
 describe("Regex", () => {
@@ -10,7 +10,7 @@ describe("Regex", () => {
     });
 
     describe("isMatch", () => {
-        it("tests strings case sensitive", () => {
+        it("tests strings with case sensitive flag", () => {
             let regx = new Regex(new BrsString("hello_[0-9]*_world"));
             let isMatch = regx.getMethod("isMatch");
             expect(isMatch).toBeTruthy();
@@ -24,7 +24,7 @@ describe("Regex", () => {
             expect(str2).toBe(BrsBoolean.False);
         });
 
-        it("tests strings case insensitive", () => {
+        it("tests strings with case insensitive flag", () => {
             let regx = new Regex(new BrsString("hello_[0-9]*_world"), new BrsString("i"));
             let isMatch = regx.getMethod("isMatch");
             expect(isMatch).toBeTruthy();
@@ -38,7 +38,35 @@ describe("Regex", () => {
             expect(str2).toBe(BrsBoolean.False);
         });
     });
-    // describe("match");
+    describe("match", () => {
+        it("doesn't match string", () => {
+            let rgx = new Regex(new BrsString("(a|(z))(bc)"));
+            let match = rgx.getMethod("match");
+            expect(match).toBeTruthy();
+
+            let result = match.call(interpreter, new BrsString(""));
+            let count = result.getMethod("count").call(interpreter);
+            expect(result.kind).toBe(ValueKind.Object);
+            expect(result.getComponentName()).toBe("roArray");
+            expect(count.value).toBe(0);
+        });
+
+        it("matches groups in string", () => {
+            let rgx = new Regex(new BrsString("(a|(z))(bc)"));
+            let match = rgx.getMethod("match");
+            expect(match).toBeTruthy();
+
+            let result = match.call(interpreter, new BrsString("abcd"));
+            let count = result.getMethod("count").call(interpreter);
+            expect(result.kind).toBe(ValueKind.Object);
+            expect(result.getComponentName()).toBe("roArray");
+            expect(count.value).toBe(4);
+            expect(result.get(new Int32(0)).value).toBe("abc"); //Entire match
+            expect(result.get(new Int32(1)).value).toBe("a");
+            expect(result.get(new Int32(2))).toEqual(BrsInvalid.Instance);
+            expect(result.get(new Int32(3)).value).toBe("bc");
+        });
+    });
     // describe("replace");
     // describe("replaceAll");
     // describe("split");

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -60,4 +60,24 @@ describe("end to end brightscript functions", () => {
             ]);
         });
     });
+
+    test("components/roRegex.brs", () => {
+        return execute([ resourceFile("components", "roRegex.brs") ], outputStreams).then(() => {
+            expect(
+                allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")
+            ).toEqual([
+                "HeLlO_123_WoRlD is match of hello_[0-9]*_world: ", "true",
+                "goodbye_123_WoRlD isn't match of hello_[0-9]*_world: ",  "true",
+                "Replacing ',' in 2019,03,26 by '-' on first occurrence: ", "2019-03,26",
+                "Replacing ',' in 2019,03,26 by '-' on all occurrences: ", "2019-03-26",
+                "Split by ',': [ ", "2019", " ", "03", " ", "26", " ]",
+                "First match: [ ", "123", " ]",
+                "All matches: [ ",
+                "[ ", "123", " ]",
+                "[ ", "456", " ]",
+                "[ ", "789", " ]",
+                " ]"
+            ]);
+        });
+    });
 });

--- a/test/e2e/resources/components/roRegex.brs
+++ b/test/e2e/resources/components/roRegex.brs
@@ -1,0 +1,21 @@
+sub main()
+    regex = createObject("roRegex", "hello_[0-9]*_world", "i")
+
+    print "HeLlO_123_WoRlD is match of hello_[0-9]*_world: " regex.ismatch("HeLlO_123_WoRlD")
+    print "goodbye_123_WoRlD isn't match of hello_[0-9]*_world: " regex.ismatch("HeLlO_123_WoRlD")
+
+    regex = createObject("roRegex", ",", "i")
+
+    print "Replacing ',' in 2019,03,26 by '-' on first occurrence: " regex.replace("2019,03,26", "-")
+    print "Replacing ',' in 2019,03,26 by '-' on all occurrences: " regex.replaceall("2019,03,26", "-")
+    print "Split by ','" regex.split("2019,03,26")
+
+    regex = createObject("roRegex", "\d+", "i")
+
+    print "First match" regex.match("123 456 789")
+    matches = regex.matchall("123 456 789")
+    print "All matches: "
+    print matches[0]
+    print matches[1]
+    print matches[2]
+end sub

--- a/test/e2e/resources/components/roRegex.brs
+++ b/test/e2e/resources/components/roRegex.brs
@@ -8,14 +8,18 @@ sub main()
 
     print "Replacing ',' in 2019,03,26 by '-' on first occurrence: " regex.replace("2019,03,26", "-")
     print "Replacing ',' in 2019,03,26 by '-' on all occurrences: " regex.replaceall("2019,03,26", "-")
-    print "Split by ','" regex.split("2019,03,26")
+    parts = regex.split("2019,03,26")
+    print "Split by ',': [ " parts[0] " " parts[1] " " parts[2] " ]"
 
     regex = createObject("roRegex", "\d+", "i")
 
-    print "First match" regex.match("123 456 789")
+    matches = regex.match("123 456 789")
+    print "First match: [ " matches[0] " ]" 
+
     matches = regex.matchall("123 456 789")
-    print "All matches: "
-    print matches[0]
-    print matches[1]
-    print matches[2]
+    print "All matches: [ "
+    print "[ " matches[0][0] " ]"
+    print "[ " matches[1][0] " ]"
+    print "[ " matches[2][0] " ]"
+    print " ]"
 end sub


### PR DESCRIPTION
This feature implements all methods of the [ifRegex](https://sdkdocs.roku.com/display/sdkdoc/ifRegex) interface. 
Although javascript's `RegExp` doesn't fully support PCRE, as Brightscript does, it gives `brs` the ability to support most of the common regex use cases.

All flags in [roRegex](https://sdkdocs.roku.com/display/sdkdoc/roRegex) but "x" should be supported.