### PR TITLE
feat(cli): Add --stop-after CLI argument

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,6 +13,9 @@ const packageJson = JSON.parse(
     )
 );
 
+/** Set of phases valid for the `--stop-after` argument. */
+const stopPhases = [ "lexer", "preprocessor", "parser" ];
+
 program
     .description("Off-Roku BrightScript interpreter")
     .arguments("brs [brsFiles...]")
@@ -21,15 +24,26 @@ program
         "The root directory from which `pkg:` paths will be resolved.",
         process.cwd()
     )
+    .option(
+        "--stop-after <lex|preprocess|parse>",
+        "Stops processing after the provided phase, printing the results of the final phase to the console."
+    )
     .action((brsFiles, program) => {
+        if (program.stopAfter && stopPhases.indexOf(program.stopAfter) === -1) {
+            console.error(`ERROR: Unexpected '--stop-after' phase ${program.stopAfter}. Expected one of ${stopPhases.join(", ")}.`);
+            process.exitCode = 1;
+            return;
+        }
+
         if (brsFiles.length > 0) {
-            brs.execute(brsFiles, { root: program.root }).catch(err => {
+            brs.execute(brsFiles, { root: program.root, stopAfter: program.stopAfter }).catch(err => {
                 if (err.messages && err.messages.length) {
                     err.messages.forEach(message => console.error(message));
                 } else {
                     console.error(err.message);
                 }
-                process.exit(1);
+                process.exitCode = 1;
+                return;
             });
         } else {
             brs.repl();

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,11 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
             return Promise.reject({
                 message: "Error occurred during lexing"
             });
+        } else if (options.stopAfter === "lexer") {
+            console.log(JSON.stringify(scanResults.tokens, null, 2));
+            return Promise.reject({
+                message: "Execution stopped early because of `--stop-after` argument."
+            });
         }
 
         let preprocessResults = preprocessor.preprocess(scanResults.tokens, manifest);
@@ -63,13 +68,22 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
             return Promise.reject({
                 message: "Error occurred during pre-processing"
             });
+        } else if (options.stopAfter === "preprocessor") {
+            console.log(JSON.stringify(preprocessResults.processedTokens, null ,2));
+            return Promise.reject({
+                message: "Execution stopped early because of `--stop-after` argument."
+            });
         }
-
 
         let parseResults = parser.parse(preprocessResults.processedTokens);
         if (parseResults.errors.length > 0) {
             return Promise.reject({
                 message: "Error occurred parsing"
+            });
+        } else if (options.stopAfter === "parser") {
+            console.log(JSON.stringify(parseResults.statements, null, 2));
+            return Promise.reject({
+                message: "Execution stopped early because of `--stop-after` argument."
             });
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
         let parseResults = parser.parse(preprocessResults.processedTokens);
         if (parseResults.errors.length > 0) {
             return Promise.reject({
-                message: "Error occurred parsing"
+                message: "Error occurred during parsing"
             });
         } else if (options.stopAfter === "parser") {
             console.log(JSON.stringify(parseResults.statements, null, 2));

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -39,7 +39,8 @@ export interface ExecutionOptions {
     /** The base path for  */
     root: string,
     stdout: NodeJS.WriteStream,
-    stderr: NodeJS.WriteStream
+    stderr: NodeJS.WriteStream,
+    stopAfter?: "lexer" | "preprocessor" | "parser"
 }
 
 /** The default set of execution options.  Includes the `stdout`/`stderr` pair from the process that invoked `brs`. */


### PR DESCRIPTION
Adds a new CLI argument that stops execution after the lexer, preprocessor, or parser.  I've built something like this directly into src/index.ts several times, but it's always been a one-off hack.  It's been consistently useful though, so it's time to support it long-term.