### PR TITLE
fix(parse): Consume newlines and `:`s after `++` and `--`

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -613,14 +613,18 @@ export class Parser {
             function _expressionStatement(): Stmt.Expression | Stmt.Increment {
                 let expressionStart = peek();
 
-                if (match(Lexeme.PlusPlus, Lexeme.MinusMinus)) {
+                if (check(Lexeme.PlusPlus, Lexeme.MinusMinus)) {
+                    let operator = advance();
+
                     if (check(Lexeme.PlusPlus, Lexeme.MinusMinus)) {
                         throw addError(peek(), "Consecutive increment/decrement operators are not allowed");
                     } else if (expr instanceof Expr.Call) {
                         throw addError(expressionStart, "Increment/decrement operators are not allowed on the result of a function call");
                     }
 
-                    return new Stmt.Increment(expr, previous());
+                    while (match(Lexeme.Newline, Lexeme.Colon));
+
+                    return new Stmt.Increment(expr, operator);
                 }
 
                 if (!check(...additionalTerminators)) {

--- a/test/parser/statement/Increment.test.js
+++ b/test/parser/statement/Increment.test.js
@@ -84,6 +84,26 @@ describe("parser postfix unary expressions", () => {
         });
     });
 
+    it("allows '++' at the end of a function", () => {
+        let { statements, errors } = parser.parse([
+            token(Lexeme.Sub, "sub"),
+            identifier("foo"),
+            token(Lexeme.LeftParen, "("),
+            token(Lexeme.RightParen, ")"),
+            token(Lexeme.Newline, "\n"),
+            identifier("someValue"),
+            token(Lexeme.PlusPlus, "++"),
+            token(Lexeme.Newline, "\n"),
+            token(Lexeme.EndSub, "end sub"),
+            EOF
+        ]);
+
+        expect(errors).toEqual([]);
+        expect(statements).toBeDefined();
+        expect(statements).not.toBeNull();
+        expect(statements).toMatchSnapshot();
+    });
+
     test("location tracking", () => {
         /**
          *    0   0   0   1

--- a/test/parser/statement/__snapshots__/Increment.test.js.snap
+++ b/test/parser/statement/__snapshots__/Increment.test.js.snap
@@ -1,5 +1,114 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parser postfix unary expressions allows '++' at the end of a function 1`] = `
+Array [
+  Function {
+    "func": Function {
+      "body": Block {
+        "startingLocation": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "statements": Array [
+          Increment {
+            "token": Object {
+              "isReserved": false,
+              "kind": 13,
+              "literal": undefined,
+              "location": Object {
+                "end": Object {
+                  "column": -9,
+                  "line": -9,
+                },
+                "start": Object {
+                  "column": -9,
+                  "line": -9,
+                },
+              },
+              "text": "++",
+            },
+            "value": Variable {
+              "name": Object {
+                "isReserved": false,
+                "kind": 30,
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": -9,
+                    "line": -9,
+                  },
+                  "start": Object {
+                    "column": -9,
+                    "line": -9,
+                  },
+                },
+                "text": "someValue",
+              },
+            },
+          },
+        ],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": 57,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": 84,
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": 30,
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "text": "foo",
+    },
+  },
+]
+`;
+
 exports[`parser postfix unary expressions parses postfix '++' for indexed get expressions 1`] = `
 Array [
   Increment {


### PR DESCRIPTION
Thanks for catching that, @TwitchBronBron!

fixes #223