### PR TITLE
fix(parse): Allow `sub` declarations with return-type specifications

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -203,11 +203,8 @@ export class Parser {
             rightParen = advance();
 
             let maybeAs = peek();
-            if (check(Lexeme.Identifier) && maybeAs.text && maybeAs.text.toLowerCase() === "as") {
+            if (check(Lexeme.Identifier) && maybeAs.text.toLowerCase() === "as") {
                 advance();
-                if (isSub) {
-                    throw addError(previous(), "'Sub' functions are always void returns, and can't have 'as' clauses");
-                }
 
                 let typeToken = advance();
                 let typeString = typeToken.text || "";

--- a/test/parser/expression/Function.test.js
+++ b/test/parser/expression/Function.test.js
@@ -369,23 +369,6 @@ describe("parser", () => {
             expect(statements).not.toBeNull();
             expect(statements).toMatchSnapshot();
         });
-
-        it("doesn't allow return types", () => {
-            let { statements, errors } = parser.parse([
-                identifier("_"),
-                token(Lexeme.Equal, "="),
-                token(Lexeme.Sub, "sub"),
-                token(Lexeme.LeftParen, "("),
-                token(Lexeme.RightParen, ")"),
-                identifier("as"),
-                identifier("integer"),
-                token(Lexeme.Newline, "\\n"),
-                token(Lexeme.EndSub, "end sub"),
-                EOF
-            ]);
-
-            expect(errors.length).not.toBe(0);
-        });
     });
 
     describe("usage", () => {

--- a/test/parser/statement/Function.test.js
+++ b/test/parser/statement/Function.test.js
@@ -17,10 +17,10 @@ describe("parser", () => {
                 function Main()
                     print "Hello world"
                 end sub
-                
+
                 sub DoSomething()
-                
-                end sub 
+
+                end sub
             `);
             let { statements, errors } = parser.parse(tokens);
             expect(errors.length).toBe(1);
@@ -226,10 +226,10 @@ describe("parser", () => {
                 sub Main()
                     print "Hello world"
                 end function
-                
+
                 sub DoSomething()
-                
-                end sub 
+
+                end sub
             `);
             let { statements, errors } = parser.parse(tokens);
             expect(errors.length).toBe(1);
@@ -384,22 +384,6 @@ describe("parser", () => {
             expect(statements).toBeDefined();
             expect(statements).not.toBeNull();
             expect(statements).toMatchSnapshot();
-        });
-
-        it("doesn't allow return types", () => {
-            let { statements, errors } = parser.parse([
-                token(Lexeme.Sub, "sub"),
-                identifier("foo"),
-                token(Lexeme.LeftParen, "("),
-                token(Lexeme.RightParen, ")"),
-                identifier("as"),
-                identifier("integer"),
-                token(Lexeme.Newline, "\\n"),
-                token(Lexeme.EndSub, "end sub"),
-                EOF
-            ]);
-
-            expect(errors.length).not.toBe(0);
         });
 
         it('does not allow type designators at end of name', () => {


### PR DESCRIPTION
While `sub` is conventionally used only for functions with `void` return types, the Reference BrightScript Implementation (RBI) allows non-void return types to be declared on `sub`s, e.g.:

```brightscript
sub main()
    print getFive()
end sub

sub getFive() as integer
'             ~~~~~~~~~~
'             This is valid in RBI!
    return five
end sub
```

fixes #220