### PR TITLE
On windows, spawn needs to call node in order to execute js files.

### DIFF
--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -2,32 +2,34 @@ const child_process = require("child_process");
 const path = require("path");
 const pify = require("pify");
 
-const execFile = pify(child_process.execFile);
+const exec = pify(child_process.exec);
 
 describe("cli", () => {
     it("accepts a root directory", () => {
         let rootDir = path.join(__dirname, "resources");
 
-        return execFile(
-            'node', [
-                path.join(process.cwd(), "bin", "cli.js"),
-                "--root", rootDir,
-                path.join(rootDir, "requires-manifest.brs")
-            ]
-        ).then((stdout, stderr) => {
+        let command = [
+            "node",
+            path.join(process.cwd(), "bin", "cli.js"),
+            "--root", rootDir,
+            path.join(rootDir, "requires-manifest.brs")
+        ].join(" ");
+
+        return exec(command).then((stdout, stderr) => {
             expect(stdout.trim()).toEqual("hi from foo()");
         });
     });
 
     it("defaults --root to process.cwd()", () => {
-        return execFile(
-            'node',
-            [
-                path.join(process.cwd(), "bin", "cli.js"),
-                "requires-manifest.brs"
-            ],
-            { cwd: path.join(__dirname, "resources") }
-        ).then((stdout, stderr) => {
+        let command = [
+            "node",
+            path.join(process.cwd(), "bin", "cli.js"),
+            "requires-manifest.brs"
+        ].join(" ");
+
+        return exec(command, {
+            cwd: path.join(__dirname, "resources")
+        }).then((stdout, stderr) => {
             expect(stdout.trim()).toEqual("hi from foo()");
         });
     });

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -9,8 +9,8 @@ describe("cli", () => {
         let rootDir = path.join(__dirname, "resources");
 
         return execFile(
-            path.join(process.cwd(), "bin", "cli.js"),
-            [
+            'node', [
+                path.join(process.cwd(), "bin", "cli.js"),
                 "--root", rootDir,
                 path.join(rootDir, "requires-manifest.brs")
             ]
@@ -21,8 +21,11 @@ describe("cli", () => {
 
     it("defaults --root to process.cwd()", () => {
         return execFile(
-            path.join(process.cwd(), "bin", "cli.js"),
-            [ "requires-manifest.brs" ],
+            'node',
+            [
+                path.join(process.cwd(), "bin", "cli.js"),
+                "requires-manifest.brs"
+            ],
             { cwd: path.join(__dirname, "resources") }
         ).then((stdout, stderr) => {
             expect(stdout.trim()).toEqual("hi from foo()");


### PR DESCRIPTION
The cli tests fail when running on windows. I think it has to do with a js file not being executable on its own. This PR fixes that. 