### PR TITLE
fix(parse): Allow `sub` declarations with return-type specifications

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -343,9 +343,6 @@ export class Parser {
                 let maybeAs = peek();
                 if (check(Lexeme.Identifier) && maybeAs.text.toLowerCase() === "as") {
                     advance();
-                    if (isSub) {
-                        throw addError(previous(), "'Sub' functions are always void returns, and can't have 'as' clauses");
-                    }
 
                     let typeToken = advance();
                     let typeString = typeToken.text || "";


### PR DESCRIPTION
Re-remove the sub-declarations-with-as-type error.

duplicates #225 
fixes #220
fixes #237

(cherry picked from commit f397208ce642b033ab2b0e83b00d3dcffc4d198b)