### PR TITLE
fix(lex): Allow single-word #elseif and #endif

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -694,6 +694,12 @@ export class Lexer {
                 case "#else":
                     addToken(Lexeme.HashElse);
                     return;
+                case "#elseif":
+                    addToken(Lexeme.HashElseIf);
+                    return;
+                case "#endif":
+                    addToken(Lexeme.HashEndIf);
+                    return;
                 case "#const":
                     addToken(Lexeme.HashConst);
                     return;

--- a/test/lexer/Lexer.test.js
+++ b/test/lexer/Lexer.test.js
@@ -336,11 +336,13 @@ describe("lexer", () => {
         });
 
         it("reads conditional directives", () => {
-            let { tokens } = Lexer.scan("#if #else if #else #end if");
+            let { tokens } = Lexer.scan("#if #else if #elseif #else #end if #endif");
             expect(tokens.map(t => t.kind)).toEqual([
                 Lexeme.HashIf,
                 Lexeme.HashElseIf,
+                Lexeme.HashElseIf,
                 Lexeme.HashElse,
+                Lexeme.HashEndIf,
                 Lexeme.HashEndIf,
                 Lexeme.Eof,
             ]);


### PR DESCRIPTION
The two-word variants `#else if` and `#end if` were already supported, but I didn't realize the single-word versions were valid in RBI!  Now they're valid here too.