### PR TITLE
Break out manifest parsing into own function

### DIFF
--- a/src/preprocessor/Manifest.ts
+++ b/src/preprocessor/Manifest.ts
@@ -37,7 +37,7 @@ export async function getManifest(rootDir: string): Promise<Manifest> {
  * @returns a Promise that resolves to a map of string to JavaScript number, string, or boolean,
  *          representing the manifest file's contents
  */
-export async function parseManifest(contents: string) {
+export function parseManifest(contents: string) {
     let keyValuePairs = contents
         // for each line
         .split("\n")

--- a/src/preprocessor/Manifest.ts
+++ b/src/preprocessor/Manifest.ts
@@ -27,7 +27,17 @@ export async function getManifest(rootDir: string): Promise<Manifest> {
     } catch (err) {
         return new Map();
     }
+    return parseManifest(contents);
+}
 
+/**
+ * Attempts to parse a `manifest` file's contents into a map of string to JavaScript
+ * number, string, or boolean.
+ * @param contents the text contents of a manifest file.
+ * @returns a Promise that resolves to a map of string to JavaScript number, string, or boolean,
+ *          representing the manifest file's contents
+ */
+export async function parseManifest(contents: string) {
     let keyValuePairs = contents
         // for each line
         .split("\n")


### PR DESCRIPTION
This allows any caller to pass in the manifest file's contents, rather than depending on its physical location. This will help my languageserver because the manifest file changes are loaded into memory and are not always saved to disk right away...but we want to reflect those changes instantly. 