### PR TITLE
feat(stdlib,interp): Implement autoboxing and roString (ifStringOps only)

### DIFF
--- a/src/brsTypes/Boxing.ts
+++ b/src/brsTypes/Boxing.ts
@@ -11,12 +11,7 @@ export interface Unboxable {
 }
 
 export function isBoxable(value: BrsType): value is BrsType & Boxable {
-    switch (value.kind) {
-        case ValueKind.String:
-            return true;
-        default:
-            return false;
-    }
+    return "box" in value;
 }
 
 export function isUnboxable(value: BrsType): value is BrsType & Unboxable {

--- a/src/brsTypes/Boxing.ts
+++ b/src/brsTypes/Boxing.ts
@@ -15,5 +15,5 @@ export function isBoxable(value: BrsType): value is BrsType & Boxable {
 }
 
 export function isUnboxable(value: BrsType): value is BrsType & Unboxable {
-    return value instanceof BrsComponent && value.hasOwnProperty("unbox");
+    return "unbox" in value;
 }

--- a/src/brsTypes/Boxing.ts
+++ b/src/brsTypes/Boxing.ts
@@ -1,0 +1,24 @@
+import { BrsComponent } from "./components/BrsComponent";
+import { BrsValue, BrsType, ValueKind } from "./";
+import { RoString } from "./components/RoString";
+
+export interface Boxable {
+    box(): BrsComponent;
+}
+
+export interface Unboxable {
+    unbox(): BrsValue;
+}
+
+export function isBoxable(value: BrsType): value is BrsType & Boxable {
+    switch (value.kind) {
+        case ValueKind.String:
+            return true;
+        default:
+            return false;
+    }
+}
+
+export function isUnboxable(value: BrsType): value is BrsType & Unboxable {
+    return value instanceof BrsComponent && value.hasOwnProperty("unbox");
+}

--- a/src/brsTypes/BrsType.ts
+++ b/src/brsTypes/BrsType.ts
@@ -137,20 +137,28 @@ export class BrsString implements BrsValue, Comparable, Boxable {
     lessThan(other: BrsType): BrsBoolean {
         if (other.kind === ValueKind.String) {
             return BrsBoolean.from(this.value < other.value);
+        } else if (other instanceof RoString) {
+            return this.lessThan(other.unbox());
         }
+
         return BrsBoolean.False;
     }
 
     greaterThan(other: BrsType): BrsBoolean {
         if (other.kind === ValueKind.String) {
             return BrsBoolean.from(this.value > other.value);
+        } else if (other instanceof RoString) {
+            return this.greaterThan(other.unbox());
         }
+
         return BrsBoolean.False;
     }
 
     equalTo(other: BrsType): BrsBoolean {
         if (other.kind === ValueKind.String) {
             return BrsBoolean.from(this.value === other.value);
+        } else if (other instanceof RoString) {
+            return this.equalTo(other.unbox());
         }
         return BrsBoolean.False;
     }

--- a/src/brsTypes/BrsType.ts
+++ b/src/brsTypes/BrsType.ts
@@ -1,4 +1,6 @@
 import { BrsType } from ".";
+import { Boxable } from "./Boxing";
+import { RoString } from "./components/RoString";
 
 /** Set of values supported in BrightScript. */
 export enum ValueKind {
@@ -101,6 +103,13 @@ export interface BrsValue {
      * @returns A human-readable representation of this value.
      */
     toString(parent?: BrsType): string;
+
+    /**
+     * Determines whether or not this value is equal to some `other` value.
+     * @param other The value to compare this value to.
+     * @returns `true` if this value is strictly equal to the `other` value, otherwise `false`.
+     */
+    equalTo(other: BrsType): BrsBoolean;
 }
 
 /** The set of operations required for a BrightScript datatype to be compared to another. */
@@ -118,17 +127,10 @@ export interface Comparable {
      * @returns `true` if this value is greater than the `other` value, otherwise `false`.
      */
     greaterThan(other: BrsType): BrsBoolean;
-
-    /**
-     * Determines whether or not this value is equal to some `other` value.
-     * @param other The value to compare this value to.
-     * @returns `true` if this value is strictly equal to the `other` value, otherwise `false`.
-     */
-    equalTo(other: BrsType): BrsBoolean;
 }
 
 /** Internal representation of a string in BrightScript. */
-export class BrsString implements BrsValue, Comparable {
+export class BrsString implements BrsValue, Comparable, Boxable {
     readonly kind = ValueKind.String;
     constructor(readonly value: string) {}
 
@@ -159,6 +161,10 @@ export class BrsString implements BrsValue, Comparable {
 
     concat(other: BrsString) {
         return new BrsString(this.value + other.value);
+    }
+
+    box() {
+        return new RoString(this);
     }
 }
 

--- a/src/brsTypes/components/BrsComponent.ts
+++ b/src/brsTypes/components/BrsComponent.ts
@@ -6,8 +6,11 @@ export class BrsComponent {
     private methods: Map<string, Callable> = new Map();
     private readonly componentName: string;
 
-    constructor(name: string) {
+    readonly interfaces: Set<string>;
+
+    constructor(name: string, interfaces: string[] = []) {
         this.componentName = name;
+        this.interfaces = new Set(interfaces);
     }
 
     /**
@@ -19,7 +22,9 @@ export class BrsComponent {
     }
 
     protected registerMethods(methods: Callable[]) {
-        this.methods = new Map(methods.map(m => [m.name!, m] as [string, Callable]));
+        this.methods = new Map(
+            methods.map(m => [(m.name || "").toLowerCase(), m] as [string, Callable])
+        );
     }
 
     getMethod(index: string): Callable | undefined {

--- a/src/brsTypes/components/BrsObjects.ts
+++ b/src/brsTypes/components/BrsObjects.ts
@@ -5,9 +5,9 @@ import { RoRegex } from "./RoRegex";
 import { BrsString } from "../BrsType";
 
 /** Map containing a list of brightscript components that can be created. */
-export const BrsObjects = new Map<string, Function>([
-    ["roassociativearray", () => new RoAssociativeArray([])],
-    ["roarray", () => new RoArray([])],
-    ["rotimespan", () => new Timespan()],
-    ["roregex", (expression: BrsString, flags: BrsString) => new RoRegex(expression, flags)],
-]);
+export const BrsObjects = {
+    roassociativearray: () => new RoAssociativeArray([]),
+    roarray: () => new RoArray([]),
+    rotimespan: () => new Timespan(),
+    roregex: (expression: BrsString, flags: BrsString) => new RoRegex(expression, flags),
+};

--- a/src/brsTypes/components/BrsObjects.ts
+++ b/src/brsTypes/components/BrsObjects.ts
@@ -5,9 +5,9 @@ import { RoRegex } from "./RoRegex";
 import { BrsString } from "../BrsType";
 
 /** Map containing a list of brightscript components that can be created. */
-export const BrsObjects = {
-    roassociativearray: () => new RoAssociativeArray([]),
-    roarray: () => new RoArray([]),
-    rotimespan: () => new Timespan(),
-    roregex: (expression: BrsString, flags: BrsString) => new RoRegex(expression, flags),
-};
+export const BrsObjects = new Map<string, Function>([
+    ["roassociativearray", () => new RoAssociativeArray([])],
+    ["roarray", () => new RoArray([])],
+    ["rotimespan", () => new Timespan()],
+    ["roregex", (expression: BrsString, flags: BrsString) => new RoRegex(expression, flags)],
+]);

--- a/src/brsTypes/components/BrsObjects.ts
+++ b/src/brsTypes/components/BrsObjects.ts
@@ -3,6 +3,7 @@ import { RoArray } from "./RoArray";
 import { Timespan } from "./Timespan";
 import { RoRegex } from "./RoRegex";
 import { BrsString } from "../BrsType";
+import { RoString } from "./RoString";
 
 /** Map containing a list of brightscript components that can be created. */
 export const BrsObjects = new Map<string, Function>([
@@ -10,4 +11,5 @@ export const BrsObjects = new Map<string, Function>([
     ["roarray", () => new RoArray([])],
     ["rotimespan", () => new Timespan()],
     ["roregex", (expression: BrsString, flags: BrsString) => new RoRegex(expression, flags)],
+    ["rostring", (literal: BrsString) => new RoString(literal)],
 ]);

--- a/src/brsTypes/components/RoArray.ts
+++ b/src/brsTypes/components/RoArray.ts
@@ -38,14 +38,6 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
         ].join("\n");
     }
 
-    lessThan(other: BrsType) {
-        return BrsBoolean.False;
-    }
-
-    greaterThan(other: BrsType) {
-        return BrsBoolean.False;
-    }
-
     equalTo(other: BrsType) {
         return BrsBoolean.False;
     }

--- a/src/brsTypes/components/RoAssociativeArray.ts
+++ b/src/brsTypes/components/RoAssociativeArray.ts
@@ -52,14 +52,6 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
         ].join("\n");
     }
 
-    lessThan(other: BrsType) {
-        return BrsBoolean.False;
-    }
-
-    greaterThan(other: BrsType) {
-        return BrsBoolean.False;
-    }
-
     equalTo(other: BrsType) {
         return BrsBoolean.False;
     }

--- a/src/brsTypes/components/RoRegex.ts
+++ b/src/brsTypes/components/RoRegex.ts
@@ -24,8 +24,12 @@ export class RoRegex extends BrsComponent implements BrsValue {
         ]);
     }
 
-    toString(parent?: BrsType): string {
+    toString(parent?: BrsType) {
         return "<Component: roRegex>";
+    }
+
+    equalTo(other: BrsType) {
+        return BrsBoolean.False;
     }
 
     /**

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -1,0 +1,36 @@
+import { BrsComponent } from "./BrsComponent";
+import { RoArray } from "./RoArray";
+import { BrsValue, ValueKind, BrsString } from "../BrsType";
+import { Callable, StdlibArgument } from "../Callable";
+import { Interpreter } from "../../interpreter";
+import { BrsType } from "..";
+
+export class RoString extends BrsComponent implements BrsValue {
+    readonly kind = ValueKind.Object;
+    readonly value: string;
+
+    public getValue(): string {
+        return this.value;
+    }
+
+    constructor(initialValue: BrsString) {
+        super("roString");
+
+        this.value = initialValue.value;
+        this.registerMethods([this.split]);
+    }
+
+    toString(_parent?: BrsType): string {
+        return this.value;
+    }
+
+    private split = new Callable("split", {
+        signature: {
+            args: [new StdlibArgument("s", ValueKind.String)],
+            returns: ValueKind.Object,
+        },
+        impl: (_interpreter: Interpreter, s: BrsString) => {
+            return new RoArray(this.value.split(s.value).map(section => new BrsString(section)));
+        },
+    });
+}

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -43,12 +43,12 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
 
     private split = new Callable("split", {
         signature: {
-            args: [new StdlibArgument("s", ValueKind.String)],
+            args: [new StdlibArgument("separator", ValueKind.String)],
             returns: ValueKind.Object,
         },
-        impl: (_interpreter: Interpreter, s: BrsString) => {
+        impl: (_interpreter: Interpreter, separator: BrsString) => {
             return new RoArray(
-                this.intrinsic.value.split(s.value).map(section => new BrsString(section))
+                this.intrinsic.value.split(separator.value).map(section => new BrsString(section))
             );
         },
     });

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -6,6 +6,7 @@ import { Interpreter } from "../../interpreter";
 import { BrsType } from "..";
 import { Unboxable } from "../Boxing";
 import { Int32 } from "../Int32";
+import { Float } from "../Float";
 
 export class RoString extends BrsComponent implements BrsValue, Unboxable {
     readonly kind = ValueKind.Object;
@@ -28,6 +29,9 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
             this.mid,
             this.instr,
             this.replace,
+            this.trim,
+            this.toInt,
+            this.toFloat,
             this.split,
         ]);
     }
@@ -204,6 +208,42 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
             return new BrsString(
                 this.intrinsic.value.replace(new RegExp(from.value, "g"), to.value)
             );
+        },
+    });
+
+    /**
+     * Returns the string with any leading and trailing whitespace characters (space, TAB, LF, CR,
+     * VT, FF, NO-BREAK SPACE, et al) removed.
+     */
+    private trim = new Callable("Trim", {
+        signature: {
+            args: [],
+            returns: ValueKind.String,
+        },
+        impl: _interpreter => {
+            return new BrsString(this.intrinsic.value.trim());
+        },
+    });
+
+    /** Returns the value of the string interpreted as a decimal number. */
+    private toInt = new Callable("ToInt", {
+        signature: {
+            args: [],
+            returns: ValueKind.Int32,
+        },
+        impl: _interpreter => {
+            return Int32.fromString(this.intrinsic.value);
+        },
+    });
+
+    /** Returns the value of the string interpreted as a floating point number. */
+    private toFloat = new Callable("ToFloat", {
+        signature: {
+            args: [],
+            returns: ValueKind.Float,
+        },
+        impl: _interpreter => {
+            return Float.fromString(this.intrinsic.value);
         },
     });
 

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -339,7 +339,12 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
                 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#Description
                 encodeURIComponent(this.intrinsic.value).replace(
                     /[!'()*]/g,
-                    c => "%" + c.charCodeAt(0).toString(16)
+                    c =>
+                        "%" +
+                        c
+                            .charCodeAt(0)
+                            .toString(16)
+                            .toUpperCase()
                 )
             );
         },

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -213,6 +213,10 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
             returns: ValueKind.String,
         },
         impl: (_interpreter, from: BrsString, to: BrsString) => {
+            if (from.value === "") {
+                return this.intrinsic;
+            }
+
             return new BrsString(
                 this.intrinsic.value.replace(new RegExp(from.value, "g"), to.value)
             );

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -1,6 +1,6 @@
 import { BrsComponent } from "./BrsComponent";
 import { RoArray } from "./RoArray";
-import { BrsValue, ValueKind, BrsString, BrsBoolean, BrsInvalid } from "../BrsType";
+import { BrsValue, ValueKind, BrsString, BrsBoolean, BrsInvalid, Comparable } from "../BrsType";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { BrsType } from "..";
@@ -8,7 +8,7 @@ import { Unboxable } from "../Boxing";
 import { Int32 } from "../Int32";
 import { Float } from "../Float";
 
-export class RoString extends BrsComponent implements BrsValue, Unboxable {
+export class RoString extends BrsComponent implements BrsValue, Comparable, Unboxable {
     readonly kind = ValueKind.Object;
     private intrinsic: BrsString;
 
@@ -51,6 +51,30 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
 
         if (other instanceof RoString) {
             return BrsBoolean.from(other.intrinsic.value === this.intrinsic.value);
+        }
+
+        return BrsBoolean.False;
+    }
+
+    lessThan(other: BrsType): BrsBoolean {
+        if (other.kind === ValueKind.String) {
+            return this.unbox().lessThan(other);
+        }
+
+        if (other instanceof RoString) {
+            return this.unbox().lessThan(other.unbox());
+        }
+
+        return BrsBoolean.False;
+    }
+
+    greaterThan(other: BrsType): BrsBoolean {
+        if (other.kind === ValueKind.String) {
+            return this.unbox().greaterThan(other);
+        }
+
+        if (other instanceof RoString) {
+            return this.unbox().greaterThan(other.unbox());
         }
 
         return BrsBoolean.False;

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -74,7 +74,7 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
             ],
             returns: ValueKind.Void,
         },
-        impl: (_interpreter, Interpreter, s: BrsString, len: Int32) => {
+        impl: (_interpreter, s: BrsString, len: Int32) => {
             this.intrinsic = new BrsString(s.value.substr(0, len.getValue()));
             return BrsInvalid.Instance;
         },
@@ -89,7 +89,7 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
             ],
             returns: ValueKind.Void,
         },
-        impl: (_interpreter, Interpreter, s: BrsString, len: Int32) => {
+        impl: (_interpreter, s: BrsString, len: Int32) => {
             this.intrinsic = this.intrinsic.concat(
                 new BrsString(s.value.substr(0, len.getValue()))
             );
@@ -114,7 +114,7 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
             args: [new StdlibArgument("len", ValueKind.Int32)],
             returns: ValueKind.String,
         },
-        impl: (_interpreter: Interpreter, len: Int32) => {
+        impl: (_interpreter, len: Int32) => {
             return new BrsString(this.intrinsic.value.substr(0, len.getValue()));
         },
     });
@@ -125,7 +125,7 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
             args: [new StdlibArgument("len", ValueKind.Int32)],
             returns: ValueKind.String,
         },
-        impl: (_interpreter: Interpreter, len: Int32) => {
+        impl: (_interpreter, len: Int32) => {
             let source = this.intrinsic.value;
             return new BrsString(source.substr(source.length - len.getValue()));
         },
@@ -142,7 +142,7 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
                 args: [new StdlibArgument("start_index", ValueKind.Int32)],
                 returns: ValueKind.String,
             },
-            impl: (_interpreter: Interpreter, startIndex: Int32) => {
+            impl: (_interpreter, startIndex: Int32) => {
                 return new BrsString(this.intrinsic.value.substr(startIndex.getValue()));
             },
         },
@@ -159,7 +159,7 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
                 ],
                 returns: ValueKind.String,
             },
-            impl: (_interpreter: Interpreter, startIndex: Int32, numChars: Int32) => {
+            impl: (_interpreter, startIndex: Int32, numChars: Int32) => {
                 let source = this.intrinsic.value;
                 return new BrsString(
                     this.intrinsic.value.substr(startIndex.getValue(), numChars.getValue())
@@ -176,7 +176,7 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
                 args: [new StdlibArgument("substring", ValueKind.String)],
                 returns: ValueKind.Int32,
             },
-            impl: (_interpreter: Interpreter, substring: BrsString) => {
+            impl: (_interpreter, substring: BrsString) => {
                 return new Int32(this.intrinsic.value.indexOf(substring.value));
             },
         },
@@ -192,7 +192,7 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
                 ],
                 returns: ValueKind.Int32,
             },
-            impl: (_interpreter: Interpreter, startIndex: Int32, substring: BrsString) => {
+            impl: (_interpreter, startIndex: Int32, substring: BrsString) => {
                 return new Int32(
                     this.intrinsic.value.indexOf(substring.value, startIndex.getValue())
                 );
@@ -282,7 +282,7 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
             args: [new StdlibArgument("separator", ValueKind.String)],
             returns: ValueKind.Object,
         },
-        impl: (_interpreter: Interpreter, separator: BrsString) => {
+        impl: (_interpreter, separator: BrsString) => {
             return new RoArray(
                 this.intrinsic.value.split(separator.value).map(section => new BrsString(section))
             );

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -244,7 +244,14 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
             returns: ValueKind.Int32,
         },
         impl: _interpreter => {
-            return Int32.fromString(this.intrinsic.value);
+            let int = Math.trunc(Number.parseFloat(this.intrinsic.value));
+
+            if (Number.isNaN(int)) {
+                // non-integers are returned as "0"
+                return new Int32(0);
+            }
+
+            return new Int32(int);
         },
     });
 
@@ -255,7 +262,14 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
             returns: ValueKind.Float,
         },
         impl: _interpreter => {
-            return Float.fromString(this.intrinsic.value);
+            let float = Number.parseFloat(this.intrinsic.value);
+
+            if (Number.isNaN(float)) {
+                // non-integers are returned as "0"
+                return new Float(0);
+            }
+
+            return new Float(float);
         },
     });
 

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -1,24 +1,35 @@
 import { BrsComponent } from "./BrsComponent";
 import { RoArray } from "./RoArray";
-import { BrsValue, ValueKind, BrsString, BrsBoolean } from "../BrsType";
+import { BrsValue, ValueKind, BrsString, BrsBoolean, BrsInvalid } from "../BrsType";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { BrsType } from "..";
 import { Unboxable } from "../Boxing";
+import { Int32 } from "../Int32";
 
 export class RoString extends BrsComponent implements BrsValue, Unboxable {
     readonly kind = ValueKind.Object;
-    readonly intrinsic: BrsString;
+    private intrinsic: BrsString;
 
     public getValue(): string {
         return this.intrinsic.value;
     }
 
     constructor(initialValue: BrsString) {
-        super("roString");
+        super("roString", ["ifStringOps"]);
 
         this.intrinsic = initialValue;
-        this.registerMethods([this.split]);
+        this.registerMethods([
+            this.setString,
+            this.appendString,
+            this.len,
+            this.left,
+            this.right,
+            this.mid,
+            this.instr,
+            this.replace,
+            this.split,
+        ]);
     }
 
     equalTo(other: BrsType): BrsBoolean {
@@ -41,7 +52,167 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
         return this.intrinsic.toString();
     }
 
-    private split = new Callable("split", {
+    // ---------- ifStringOps ----------
+    /** Sets the string to the first len characters of s. */
+    private setString = new Callable("SetString", {
+        signature: {
+            args: [
+                new StdlibArgument("s", ValueKind.String),
+                new StdlibArgument("len", ValueKind.Int32),
+            ],
+            returns: ValueKind.Void,
+        },
+        impl: (_interpreter, Interpreter, s: BrsString, len: Int32) => {
+            this.intrinsic = new BrsString(s.value.substr(0, len.getValue()));
+            return BrsInvalid.Instance;
+        },
+    });
+
+    /** Appends the first len characters of s to the end of the string. */
+    private appendString = new Callable("AppendString", {
+        signature: {
+            args: [
+                new StdlibArgument("s", ValueKind.String),
+                new StdlibArgument("len", ValueKind.Int32),
+            ],
+            returns: ValueKind.Void,
+        },
+        impl: (_interpreter, Interpreter, s: BrsString, len: Int32) => {
+            this.intrinsic = this.intrinsic.concat(
+                new BrsString(s.value.substr(0, len.getValue()))
+            );
+            return BrsInvalid.Instance;
+        },
+    });
+
+    /** Returns the number of characters in the string. */
+    private len = new Callable("Len", {
+        signature: {
+            args: [],
+            returns: ValueKind.Int32,
+        },
+        impl: _interpreter => {
+            return new Int32(this.intrinsic.value.length);
+        },
+    });
+
+    /** Returns a string consisting of the first len characters of the string. */
+    private left = new Callable("Left", {
+        signature: {
+            args: [new StdlibArgument("len", ValueKind.Int32)],
+            returns: ValueKind.String,
+        },
+        impl: (_interpreter: Interpreter, len: Int32) => {
+            return new BrsString(this.intrinsic.value.substr(0, len.getValue()));
+        },
+    });
+
+    /** Returns a string consisting of the last len characters of the string. */
+    private right = new Callable("Right", {
+        signature: {
+            args: [new StdlibArgument("len", ValueKind.Int32)],
+            returns: ValueKind.String,
+        },
+        impl: (_interpreter: Interpreter, len: Int32) => {
+            let source = this.intrinsic.value;
+            return new BrsString(source.substr(source.length - len.getValue()));
+        },
+    });
+
+    private mid = new Callable(
+        "Mid",
+        /**
+         * Returns a string consisting of the last characters of the string, starting at the
+         * zero-based start_index.
+         */
+        {
+            signature: {
+                args: [new StdlibArgument("start_index", ValueKind.Int32)],
+                returns: ValueKind.String,
+            },
+            impl: (_interpreter: Interpreter, startIndex: Int32) => {
+                return new BrsString(this.intrinsic.value.substr(startIndex.getValue()));
+            },
+        },
+
+        /**
+         * Returns a string consisting of num_chars characters of the string, starting at the
+         * zero-based start_index.
+         */
+        {
+            signature: {
+                args: [
+                    new StdlibArgument("start_index", ValueKind.Int32),
+                    new StdlibArgument("num_chars", ValueKind.Int32),
+                ],
+                returns: ValueKind.String,
+            },
+            impl: (_interpreter: Interpreter, startIndex: Int32, numChars: Int32) => {
+                let source = this.intrinsic.value;
+                return new BrsString(
+                    this.intrinsic.value.substr(startIndex.getValue(), numChars.getValue())
+                );
+            },
+        }
+    );
+
+    private instr = new Callable(
+        "Instr",
+        /** Returns the zero-based index of the first occurrence of substring in the string. */
+        {
+            signature: {
+                args: [new StdlibArgument("substring", ValueKind.String)],
+                returns: ValueKind.Int32,
+            },
+            impl: (_interpreter: Interpreter, substring: BrsString) => {
+                return new Int32(this.intrinsic.value.indexOf(substring.value));
+            },
+        },
+        /**
+         * Returns the zero-based index of the first occurrence of substring in the string, starting
+         * at the specified zero-based start_index.
+         */
+        {
+            signature: {
+                args: [
+                    new StdlibArgument("start_index", ValueKind.Int32),
+                    new StdlibArgument("substring", ValueKind.String),
+                ],
+                returns: ValueKind.Int32,
+            },
+            impl: (_interpreter: Interpreter, startIndex: Int32, substring: BrsString) => {
+                return new Int32(
+                    this.intrinsic.value.indexOf(substring.value, startIndex.getValue())
+                );
+            },
+        }
+    );
+
+    /**
+     * Returns a copy of the string with all instances of fromStr replaced with toStr. If fromStr is
+     * empty the return value is the same as the source string.
+     */
+    private replace = new Callable("Replace", {
+        signature: {
+            args: [
+                new StdlibArgument("from", ValueKind.String),
+                new StdlibArgument("to", ValueKind.String),
+            ],
+            returns: ValueKind.String,
+        },
+        impl: (_interpreter, from: BrsString, to: BrsString) => {
+            return new BrsString(
+                this.intrinsic.value.replace(new RegExp(from.value, "g"), to.value)
+            );
+        },
+    });
+
+    /**
+     * Splits the input string using the separator string as a delimiter, and returns an array of
+     * the split token strings (not including the delimiter). An empty separator string indicates
+     * to split the string by character.
+     */
+    private split = new Callable("Split", {
         signature: {
             args: [new StdlibArgument("separator", ValueKind.String)],
             returns: ValueKind.Object,

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -1,27 +1,44 @@
 import { BrsComponent } from "./BrsComponent";
 import { RoArray } from "./RoArray";
-import { BrsValue, ValueKind, BrsString } from "../BrsType";
+import { BrsValue, ValueKind, BrsString, BrsBoolean } from "../BrsType";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { BrsType } from "..";
+import { Unboxable } from "../Boxing";
 
-export class RoString extends BrsComponent implements BrsValue {
+export class RoString extends BrsComponent implements BrsValue, Unboxable {
     readonly kind = ValueKind.Object;
-    readonly value: string;
+    readonly intrinsic: BrsString;
 
     public getValue(): string {
-        return this.value;
+        return this.intrinsic.value;
     }
 
     constructor(initialValue: BrsString) {
         super("roString");
 
-        this.value = initialValue.value;
+        this.intrinsic = initialValue;
         this.registerMethods([this.split]);
     }
 
+    equalTo(other: BrsType): BrsBoolean {
+        if (other.kind === ValueKind.String) {
+            return BrsBoolean.from(other.box().intrinsic === this.intrinsic);
+        }
+
+        if (other instanceof RoString) {
+            return BrsBoolean.from(other.intrinsic === this.intrinsic);
+        }
+
+        return BrsBoolean.False;
+    }
+
+    unbox() {
+        return this.intrinsic;
+    }
+
     toString(_parent?: BrsType): string {
-        return this.value;
+        return this.intrinsic.toString();
     }
 
     private split = new Callable("split", {
@@ -30,7 +47,9 @@ export class RoString extends BrsComponent implements BrsValue {
             returns: ValueKind.Object,
         },
         impl: (_interpreter: Interpreter, s: BrsString) => {
-            return new RoArray(this.value.split(s.value).map(section => new BrsString(section)));
+            return new RoArray(
+                this.intrinsic.value.split(s.value).map(section => new BrsString(section))
+            );
         },
     });
 }

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -284,7 +284,7 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
         },
         impl: _interpreter => {
             _interpreter.stderr.write(
-                "WARNING: tokenize not yet implemented.  Returning `invalid`."
+                "WARNING: tokenize not yet implemented, because it returns an RoList.  Returning `invalid`."
             );
             return BrsInvalid.Instance;
         },
@@ -301,9 +301,15 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
             returns: ValueKind.Object,
         },
         impl: (_interpreter, separator: BrsString) => {
-            return new RoArray(
-                this.intrinsic.value.split(separator.value).map(section => new BrsString(section))
-            );
+            let parts;
+            if (separator.value === "") {
+                // split characters apart, preserving multi-character unicode structures
+                parts = Array.from(this.intrinsic.value);
+            } else {
+                parts = this.intrinsic.value.split(separator.value);
+            }
+
+            return new RoArray(parts.map(part => new BrsString(part)));
         },
     });
 

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -8,17 +8,6 @@ import { Unboxable } from "../Boxing";
 import { Int32 } from "../Int32";
 import { Float } from "../Float";
 
-function isRfc3986Unreserved(char: string) {
-    return (
-        (char >= "a" && char <= "z") ||
-        (char >= "A" && char <= "Z") ||
-        char === "-" ||
-        char === "." ||
-        char === "_" ||
-        char === "~"
-    );
-}
-
 export class RoString extends BrsComponent implements BrsValue, Unboxable {
     readonly kind = ValueKind.Object;
     private intrinsic: BrsString;
@@ -57,11 +46,11 @@ export class RoString extends BrsComponent implements BrsValue, Unboxable {
 
     equalTo(other: BrsType): BrsBoolean {
         if (other.kind === ValueKind.String) {
-            return BrsBoolean.from(other.box().intrinsic === this.intrinsic);
+            return BrsBoolean.from(other.value === this.intrinsic.value);
         }
 
         if (other instanceof RoString) {
-            return BrsBoolean.from(other.intrinsic === this.intrinsic);
+            return BrsBoolean.from(other.intrinsic.value === this.intrinsic.value);
         }
 
         return BrsBoolean.False;

--- a/src/brsTypes/components/Timespan.ts
+++ b/src/brsTypes/components/Timespan.ts
@@ -1,4 +1,4 @@
-import { BrsValue, ValueKind, BrsString, BrsInvalid } from "../BrsType";
+import { BrsValue, ValueKind, BrsString, BrsInvalid, BrsBoolean } from "../BrsType";
 import { BrsComponent } from "./BrsComponent";
 import { BrsType } from "..";
 import { Callable, StdlibArgument } from "../Callable";
@@ -28,6 +28,10 @@ export class Timespan extends BrsComponent implements BrsValue {
 
     toString(parent?: BrsType): string {
         return "<Component: roTimespan>";
+    }
+
+    equalTo(other: BrsType) {
+        return BrsBoolean.False;
     }
 
     /** Sets timespan object to the current time */

--- a/src/brsTypes/components/index.ts
+++ b/src/brsTypes/components/index.ts
@@ -1,5 +1,0 @@
-import { RoArray } from "./RoArray";
-import { RoAssociativeArray } from "./RoAssociativeArray";
-import { RoRegex } from "./RoRegex";
-
-export type BrsObject = RoArray | RoAssociativeArray | RoRegex;

--- a/src/brsTypes/components/index.ts
+++ b/src/brsTypes/components/index.ts
@@ -1,0 +1,5 @@
+import { RoArray } from "./RoArray";
+import { RoAssociativeArray } from "./RoAssociativeArray";
+import { RoRegex } from "./RoRegex";
+
+export type BrsObject = RoArray | RoAssociativeArray | RoRegex;

--- a/src/brsTypes/index.ts
+++ b/src/brsTypes/index.ts
@@ -7,7 +7,6 @@ import {
     Comparable,
     BrsValue,
 } from "./BrsType";
-import { BrsObject } from "./components";
 import { RoArray } from "./components/RoArray";
 import { RoAssociativeArray } from "./components/RoAssociativeArray";
 import { Int32 } from "./Int32";

--- a/src/brsTypes/index.ts
+++ b/src/brsTypes/index.ts
@@ -15,6 +15,7 @@ import { Float } from "./Float";
 import { Double } from "./Double";
 import { Callable } from "./Callable";
 import { BrsComponent } from "./components/BrsComponent";
+import { RoString } from "./components/RoString";
 
 export * from "./BrsType";
 export * from "./Int32";
@@ -52,7 +53,7 @@ export function isBrsNumber(value: BrsType): value is BrsNumber {
  * @returns `true` if `value` is a string, otherwise `false`.
  */
 export function isBrsString(value: BrsType): value is BrsString {
-    return value.kind === ValueKind.String;
+    return value.kind === ValueKind.String || value instanceof RoString;
 }
 
 /**

--- a/src/brsTypes/index.ts
+++ b/src/brsTypes/index.ts
@@ -1,12 +1,21 @@
-import { ValueKind, BrsInvalid, BrsBoolean, BrsString, Uninitialized, Comparable } from "./BrsType";
+import {
+    ValueKind,
+    BrsInvalid,
+    BrsBoolean,
+    BrsString,
+    Uninitialized,
+    Comparable,
+    BrsValue,
+} from "./BrsType";
+import { BrsObject } from "./components";
 import { RoArray } from "./components/RoArray";
 import { RoAssociativeArray } from "./components/RoAssociativeArray";
 import { Int32 } from "./Int32";
 import { Int64 } from "./Int64";
 import { Float } from "./Float";
 import { Double } from "./Double";
-import { Callable, CallableImplementation } from "./Callable";
-import { Lexeme } from "../lexer";
+import { Callable } from "./Callable";
+import { BrsComponent } from "./components/BrsComponent";
 
 export * from "./BrsType";
 export * from "./Int32";
@@ -18,6 +27,7 @@ export * from "./components/RoAssociativeArray";
 export * from "./components/Timespan";
 export * from "./components/BrsObjects";
 export * from "./components/RoRegex";
+export * from "./components/RoString";
 export * from "./Callable";
 
 /**
@@ -70,11 +80,7 @@ export function isBrsCallable(value: BrsType): value is Callable {
  * @returns `true` if `value` can be iterated across, otherwise `false`.
  */
 export function isIterable(value: BrsType): value is Iterable {
-    if (value.kind !== ValueKind.Object) {
-        return false;
-    }
-
-    return value.getElements != null;
+    return value instanceof RoArray || value instanceof RoAssociativeArray;
 }
 
 /** The set of BrightScript numeric types. */
@@ -89,5 +95,8 @@ export type BrsPrimitive = BrsInvalid | BrsBoolean | BrsString | BrsNumber;
 /** The set of BrightScript iterable types. */
 export type Iterable = RoArray | RoAssociativeArray;
 
+// this is getting weird - we need a lesThan and greaterThan function?!
+export type AllComponents = { kind: ValueKind.Object } & BrsComponent & BrsValue;
+
 /** The set of all supported types in BrightScript. */
-export type BrsType = BrsPrimitive | Iterable | Callable | Uninitialized;
+export type BrsType = BrsPrimitive | Iterable | Callable | AllComponents | Uninitialized;

--- a/src/interpreter/AutoBox.ts
+++ b/src/interpreter/AutoBox.ts
@@ -1,0 +1,10 @@
+import { BrsType, ValueKind, RoString } from "../brsTypes";
+
+export function autobox(maybeIntrinsic: BrsType) {
+    switch (maybeIntrinsic.kind) {
+        case ValueKind.String:
+            return new RoString(maybeIntrinsic);
+        default:
+            return maybeIntrinsic;
+    }
+}

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -323,11 +323,10 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 return operator === Lexeme.Equal || operator === Lexeme.LessGreater;
             }
 
-            return isComparable(left) && isComparable(right);
-        }
-
-        function isComparable(value: BrsType): value is BrsType & Comparable {
-            return value.kind < ValueKind.Dynamic || isUnboxable(value);
+            return (
+                (left.kind < ValueKind.Dynamic || isUnboxable(left)) &&
+                (right.kind < ValueKind.Dynamic || isUnboxable(right))
+            );
         }
 
         switch (lexeme) {
@@ -464,7 +463,10 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                     );
                 }
             case Lexeme.Greater:
-                if (isComparable(left) && isComparable(right)) {
+                if (
+                    (isBrsNumber(left) || isBrsString(left)) &&
+                    (isBrsNumber(right) || isBrsString(right))
+                ) {
                     return left.greaterThan(right);
                 }
 
@@ -483,8 +485,13 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 );
 
             case Lexeme.GreaterEqual:
-                if (isComparable(left) && isComparable(right)) {
+                if (
+                    (isBrsNumber(left) || isBrsString(left)) &&
+                    (isBrsNumber(right) || isBrsString(right))
+                ) {
                     return left.greaterThan(right).or(left.equalTo(right));
+                } else if (canCheckEquality(left, lexeme, right)) {
+                    return left.equalTo(right);
                 }
 
                 return this.addError(
@@ -502,7 +509,10 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 );
 
             case Lexeme.Less:
-                if (isComparable(left) && isComparable(right)) {
+                if (
+                    (isBrsNumber(left) || isBrsString(left)) &&
+                    (isBrsNumber(right) || isBrsString(right))
+                ) {
                     return left.lessThan(right);
                 }
 
@@ -520,8 +530,13 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                     })
                 );
             case Lexeme.LessEqual:
-                if (isComparable(left) && isComparable(right)) {
+                if (
+                    (isBrsNumber(left) || isBrsString(left)) &&
+                    (isBrsNumber(right) || isBrsString(right))
+                ) {
                     return left.lessThan(right).or(left.equalTo(right));
+                } else if (canCheckEquality(left, lexeme, right)) {
+                    return left.equalTo(right);
                 }
 
                 return this.addError(

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -35,7 +35,7 @@ import { Runtime } from "../parser/Statement";
 import { RoAssociativeArray } from "../brsTypes/components/RoAssociativeArray";
 import MemoryFileSystem from "memory-fs";
 import { BrsComponent } from "../brsTypes/components/BrsComponent";
-import { isBoxable } from "../brsTypes/Boxing";
+import { isBoxable, isUnboxable } from "../brsTypes/Boxing";
 import { DottedGet } from "../parser/Expression";
 
 /** The set of options used to configure an interpreter's execution. */
@@ -323,11 +323,11 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 return operator === Lexeme.Equal || operator === Lexeme.LessGreater;
             }
 
-            return false;
+            return isComparable(left) && isComparable(right);
         }
 
         function isComparable(value: BrsType): value is BrsType & Comparable {
-            return value.kind < ValueKind.Dynamic;
+            return value.kind < ValueKind.Dynamic || isUnboxable(value);
         }
 
         switch (lexeme) {

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -36,6 +36,7 @@ import { RoAssociativeArray } from "../brsTypes/components/RoAssociativeArray";
 import MemoryFileSystem from "memory-fs";
 import { BrsComponent } from "../brsTypes/components/BrsComponent";
 import { isBoxable } from "../brsTypes/Boxing";
+import { DottedGet } from "../parser/Expression";
 
 /** The set of options used to configure an interpreter's execution. */
 export interface ExecutionOptions {
@@ -716,10 +717,12 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
     visitCall(expression: Expr.Call) {
         let functionName = "[anonymous function]";
-        if (expression.callee instanceof Expr.Variable) {
-            if (expression.callee.name.text) {
-                functionName = expression.callee.name.text;
-            }
+        // TODO: autobox
+        if (
+            expression.callee instanceof Expr.Variable ||
+            expression.callee instanceof Expr.DottedGet
+        ) {
+            functionName = expression.callee.name.text;
         }
 
         // evaluate the function to call (it could be the result of another function call)

--- a/test/brsTypes/String.test.js
+++ b/test/brsTypes/String.test.js
@@ -1,33 +1,70 @@
-const BrsTypes = require("../../lib/brsTypes");
+const brs = require("brs");
+const { BrsBoolean, BrsString, RoString } = brs.types;
 
 describe("String", () => {
     describe("lexical comparisons", () => {
-        let a = new BrsTypes.BrsString("alpha");
-        let b = new BrsTypes.BrsString("bravo");
-        let capitalB = new BrsTypes.BrsString("BRAVO");
+        describe("with primitive", () => {
+            let a = new BrsString("alpha");
+            let b = new BrsString("bravo");
+            let capitalB = new BrsString("BRAVO");
 
-        test("less than", () => {
-            expect(a.lessThan(b)).toBe(BrsTypes.BrsBoolean.True);
-            expect(a.lessThan(capitalB)).toBe(BrsTypes.BrsBoolean.False);
+            test("less than", () => {
+                expect(a.lessThan(b)).toBe(BrsBoolean.True);
+                expect(b.lessThan(a)).toBe(BrsBoolean.False);
+                expect(a.lessThan(capitalB)).toBe(BrsBoolean.False);
+                expect(capitalB.lessThan(a)).toBe(BrsBoolean.True);
+            });
+
+            test("greater than", () => {
+                expect(a.greaterThan(b)).toBe(BrsBoolean.False);
+                expect(b.greaterThan(a)).toBe(BrsBoolean.True);
+                expect(a.lessThan(capitalB)).toBe(BrsBoolean.False);
+                expect(capitalB.lessThan(a)).toBe(BrsBoolean.True);
+            });
+
+            test("equal to", () => {
+                let differentA = new BrsString("alpha");
+                expect(a.equalTo(differentA)).toBe(BrsBoolean.True);
+                expect(differentA.equalTo(a)).toBe(BrsBoolean.True);
+                expect(b.equalTo(capitalB)).toBe(BrsBoolean.False);
+                expect(capitalB.equalTo(b)).toBe(BrsBoolean.False);
+            });
         });
 
-        test("greater than", () => {
-            expect(a.greaterThan(b)).toBe(BrsTypes.BrsBoolean.False);
-            expect(a.lessThan(capitalB)).toBe(BrsTypes.BrsBoolean.False);
-        });
+        describe("with RoString", () => {
+            let a = new BrsString("alpha");
+            let b = new RoString(new BrsString("bravo"));
+            let capitalB = new BrsString("BRAVO");
 
-        test("equal to", () => {
-            let differentA = new BrsTypes.BrsString("alpha");
-            expect(a.equalTo(differentA)).toBe(BrsTypes.BrsBoolean.True);
-            expect(b.equalTo(capitalB)).toBe(BrsTypes.BrsBoolean.False);
+            test("less than", () => {
+                expect(a.lessThan(b)).toBe(BrsBoolean.True);
+                expect(b.lessThan(a)).toBe(BrsBoolean.False);
+                expect(a.lessThan(capitalB)).toBe(BrsBoolean.False);
+                expect(capitalB.lessThan(a)).toBe(BrsBoolean.True);
+            });
+
+            test("greater than", () => {
+                expect(a.greaterThan(b)).toBe(BrsBoolean.False);
+                expect(b.greaterThan(a)).toBe(BrsBoolean.True);
+                expect(a.lessThan(capitalB)).toBe(BrsBoolean.False);
+                expect(capitalB.lessThan(a)).toBe(BrsBoolean.True);
+            });
+
+            test("equal to", () => {
+                let boxedA = new RoString(new BrsString("alpha"));
+                expect(a.equalTo(boxedA)).toBe(BrsBoolean.True);
+                expect(boxedA.equalTo(a)).toBe(BrsBoolean.True);
+                expect(b.equalTo(capitalB)).toBe(BrsBoolean.False);
+                expect(capitalB.equalTo(b)).toBe(BrsBoolean.False);
+            });
         });
     });
 
     it("concatenates with other strings", () => {
-        let deliveryFor = new BrsTypes.BrsString("Pizza delivery for: ");
-        let recipient = new BrsTypes.BrsString("I. C. Weiner");
+        let deliveryFor = new BrsString("Pizza delivery for: ");
+        let recipient = new BrsString("I. C. Weiner");
         expect(deliveryFor.concat(recipient)).toEqual(
-            new BrsTypes.BrsString("Pizza delivery for: I. C. Weiner")
+            new BrsString("Pizza delivery for: I. C. Weiner")
         );
     });
 });

--- a/test/brsTypes/components/RoArray.test.js
+++ b/test/brsTypes/components/RoArray.test.js
@@ -3,16 +3,8 @@ const { RoArray, BrsBoolean, BrsString, Int32, BrsInvalid } = brs.types;
 const BrsError = require("../../../lib/Error");
 const { Interpreter } = require("../../../lib/interpreter");
 
-describe("Array", () => {
+describe("RoArray", () => {
     describe("comparisons", () => {
-        it("is less than nothing", () => {
-            let a = new RoArray([]);
-            expect(a.lessThan(a)).toBe(BrsBoolean.False);
-        });
-        it("is greater than nothing", () => {
-            let a = new RoArray([]);
-            expect(a.greaterThan(a)).toBe(BrsBoolean.False);
-        });
         it("is equal to nothing", () => {
             let a = new RoArray([]);
             expect(a.equalTo(a)).toBe(BrsBoolean.False);

--- a/test/brsTypes/components/RoAssociativeArray.test.js
+++ b/test/brsTypes/components/RoAssociativeArray.test.js
@@ -10,16 +10,8 @@ const {
 } = brs.types;
 const { Interpreter } = require("../../../lib/interpreter");
 
-describe("AssociativeArray", () => {
+describe("RoAssociativeArray", () => {
     describe("comparisons", () => {
-        it("is less than nothing", () => {
-            let a = new RoAssociativeArray([]);
-            expect(a.lessThan(a)).toBe(BrsBoolean.False);
-        });
-        it("is greater than nothing", () => {
-            let a = new RoAssociativeArray([]);
-            expect(a.greaterThan(a)).toBe(BrsBoolean.False);
-        });
         it("is equal to nothing", () => {
             let a = new RoAssociativeArray([]);
             expect(a.equalTo(a)).toBe(BrsBoolean.False);

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -424,5 +424,21 @@ describe("RoString", () => {
                 expect(result.elements).toEqual([new BrsString("🐶g"), new BrsString("d dog🐶")]);
             });
         });
+
+        describe("getEntityEncode", () => {
+            it("escapes five special characters", () => {
+                let s = new RoString(
+                    new BrsString(`Let's watch <a href="example.com">Cagney & Lacey</a>!`)
+                );
+                let getEntityEncode = s.getMethod("getEntityEncode");
+                expect(getEntityEncode).toBeInstanceOf(Callable);
+
+                expect(getEntityEncode.call(interpreter)).toEqual(
+                    new BrsString(
+                        String.raw`Let\'s watch \<a href=\"example.com\"\>Cagney \& Lacey\</a\>!`
+                    )
+                );
+            });
+        });
     });
 });

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -1,5 +1,6 @@
 const brs = require("brs");
-const { BrsString, RoString, BrsBoolean } = brs.types;
+const { Int32, BrsString, RoString, BrsBoolean, Callable } = brs.types;
+const { Interpreter } = require("../../../lib/interpreter");
 
 describe("RoString", () => {
     describe("equality", () => {
@@ -22,6 +23,182 @@ describe("RoString", () => {
         });
     });
 
-    // describe("ifStringOps", () => {
-    // });
+    test("toString", () => {
+        expect(new RoString(new BrsString("A1b2C#☃︎")).toString()).toBe("A1b2C#☃︎");
+    });
+
+    describe("ifStringOps", () => {
+        let interpreter;
+
+        beforeEach(() => {
+            interpreter = new Interpreter();
+        });
+
+        describe("setString", () => {
+            let s, setString;
+
+            beforeEach(() => {
+                s = new RoString(new BrsString("before"));
+                setString = s.getMethod("setString");
+                expect(setString).toBeInstanceOf(Callable);
+            });
+
+            it("overwrites its stored string", () => {
+                setString.call(interpreter, new BrsString("after"), new Int32(2));
+                expect(s.intrinsic).toEqual(new BrsString("af"));
+            });
+
+            it("overwrites an empty string for zero `len`", () => {
+                setString.call(interpreter, new BrsString("after"), new Int32(0));
+                expect(s.intrinsic).toEqual(new BrsString(""));
+            });
+
+            it("overwrites an empty string for negative `len`", () => {
+                setString.call(interpreter, new BrsString("after"), new Int32(-1));
+                expect(s.intrinsic).toEqual(new BrsString(""));
+            });
+        });
+
+        describe("appendString", () => {
+            let s, appendString;
+
+            beforeEach(() => {
+                s = new RoString(new BrsString("before"));
+                appendString = s.getMethod("appendString");
+                expect(appendString).toBeInstanceOf(Callable);
+            });
+
+            it("appends positive `len` characters", () => {
+                appendString.call(interpreter, new BrsString("after"), new Int32(3));
+                expect(s.intrinsic).toEqual(new BrsString("beforeaft"));
+            });
+
+            it("appends nothing for zero `len`", () => {
+                appendString.call(interpreter, new BrsString("after"), new Int32(0));
+                expect(s.intrinsic).toEqual(new BrsString("before"));
+            });
+
+            it("appends nothing for negative `len`", () => {
+                appendString.call(interpreter, new BrsString("after"), new Int32(-1));
+                expect(s.intrinsic).toEqual(new BrsString("before"));
+            });
+        });
+
+        describe("len", () => {
+            it("returns the length of the intrinsic string", () => {
+                let s = new RoString(new BrsString("☃☃☃"));
+                let len = s.getMethod("len");
+                expect(len).toBeInstanceOf(Callable);
+                expect(len.call(interpreter)).toEqual(new Int32(3));
+            });
+        });
+
+        describe("left", () => {
+            let s, left;
+
+            beforeEach(() => {
+                s = new RoString(new BrsString("☃ab"));
+                left = s.getMethod("left");
+                expect(left).toBeInstanceOf(Callable);
+            });
+
+            it("returns the entire string for `len` greater than string length", () => {
+                expect(left.call(interpreter, new Int32(500))).toEqual(new BrsString("☃ab"));
+            });
+
+            it("returns the first `len` characters for positive `len`", () => {
+                expect(left.call(interpreter, new Int32(2))).toEqual(new BrsString("☃a"));
+            });
+
+            it("returns an empty string for non-positive `len`", () => {
+                expect(left.call(interpreter, new Int32(0))).toEqual(new BrsString(""));
+                expect(left.call(interpreter, new Int32(-25))).toEqual(new BrsString(""));
+            });
+        });
+
+        describe("right", () => {
+            let s, right;
+
+            beforeEach(() => {
+                s = new RoString(new BrsString("☃ab"));
+                right = s.getMethod("right");
+                expect(right).toBeInstanceOf(Callable);
+            });
+
+            it("returns the entire string for `len` greater than string length", () => {
+                expect(right.call(interpreter, new Int32(500))).toEqual(new BrsString("☃ab"));
+            });
+
+            it("returns the last `len` characters for positive `len`", () => {
+                expect(right.call(interpreter, new Int32(2))).toEqual(new BrsString("ab"));
+            });
+
+            it("returns an empty string for non-positive `len`", () => {
+                expect(right.call(interpreter, new Int32(0))).toEqual(new BrsString(""));
+                expect(right.call(interpreter, new Int32(-25))).toEqual(new BrsString(""));
+            });
+        });
+
+        describe("mid", () => {
+            let s, mid;
+
+            beforeEach(() => {
+                //                              0   0   0   1   1   2   2
+                //                              0   4   8   2   6   0   4
+                s = new RoString(new BrsString("Lorem ipsum dolor sit aMeT"));
+                mid = s.getMethod("mid");
+                expect(mid).toBeInstanceOf(Callable);
+            });
+
+            describe("without `len`", () => {
+                it("returns all characters after positive `start_point`", () => {
+                    expect(mid.call(interpreter, new Int32(12))).toEqual(
+                        new BrsString("dolor sit aMeT")
+                    );
+                });
+
+                it("returns entire string for zero `start_point`", () => {
+                    expect(mid.call(interpreter, new Int32(0))).toEqual(
+                        new BrsString("Lorem ipsum dolor sit aMeT")
+                    );
+                });
+
+                it("returns entire string for negative `start_point`", () => {
+                    expect(mid.call(interpreter, new Int32(-30))).toEqual(
+                        new BrsString("Lorem ipsum dolor sit aMeT")
+                    );
+                });
+
+                it("returns empty string for `start_point` greater than string length", () => {
+                    expect(mid.call(interpreter, new Int32(26))).toEqual(new BrsString(""));
+                });
+            });
+
+            describe("with `len`", () => {
+                it("returns `len` characters after positive `start_point`", () => {
+                    expect(mid.call(interpreter, new Int32(12), new Int32(7))).toEqual(
+                        new BrsString("dolor s")
+                    );
+                });
+
+                it("returns string starting at 0 for negative `start_point` and positive `len`", () => {
+                    expect(mid.call(interpreter, new Int32(-30), new Int32(7))).toEqual(
+                        new BrsString("Lorem i")
+                    );
+                });
+
+                it("returns empty string for negative `start_point` and negative `len`", () => {
+                    expect(mid.call(interpreter, new Int32(-30), new Int32(-9))).toEqual(
+                        new BrsString("")
+                    );
+                });
+
+                it("returns empty string for `start_point` greater than string length", () => {
+                    expect(mid.call(interpreter, new Int32(26), new Int32(5))).toEqual(
+                        new BrsString("")
+                    );
+                });
+            });
+        });
+    });
 });

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -1,5 +1,5 @@
 const brs = require("brs");
-const { Int32, BrsString, RoString, BrsBoolean, Callable } = brs.types;
+const { Int32, Float, BrsString, RoString, BrsBoolean, Callable } = brs.types;
 const { Interpreter } = require("../../../lib/interpreter");
 
 describe("RoString", () => {
@@ -94,10 +94,10 @@ describe("RoString", () => {
         });
 
         describe("left", () => {
-            let s, left;
+            let left;
 
             beforeEach(() => {
-                s = new RoString(new BrsString("☃ab"));
+                let s = new RoString(new BrsString("☃ab"));
                 left = s.getMethod("left");
                 expect(left).toBeInstanceOf(Callable);
             });
@@ -117,10 +117,10 @@ describe("RoString", () => {
         });
 
         describe("right", () => {
-            let s, right;
+            let right;
 
             beforeEach(() => {
-                s = new RoString(new BrsString("☃ab"));
+                let s = new RoString(new BrsString("☃ab"));
                 right = s.getMethod("right");
                 expect(right).toBeInstanceOf(Callable);
             });
@@ -140,12 +140,12 @@ describe("RoString", () => {
         });
 
         describe("mid", () => {
-            let s, mid;
+            let mid;
 
             beforeEach(() => {
-                //                              0   0   0   1   1   2   2
-                //                              0   4   8   2   6   0   4
-                s = new RoString(new BrsString("Lorem ipsum dolor sit aMeT"));
+                //                                  0   0   0   1   1   2   2
+                //                                  0   4   8   2   6   0   4
+                let s = new RoString(new BrsString("Lorem ipsum dolor sit aMeT"));
                 mid = s.getMethod("mid");
                 expect(mid).toBeInstanceOf(Callable);
             });
@@ -202,12 +202,12 @@ describe("RoString", () => {
         });
 
         describe("instr", () => {
-            let s, instr;
+            let instr;
 
             beforeEach(() => {
-                //                              0   0   0   1   1   2   2
-                //                              0   4   8   2   6   0   4
-                s = new RoString(new BrsString("Monday, Tuesday, Happy Days"));
+                //                                  0   0   0   1   1   2   2
+                //                                  0   4   8   2   6   0   4
+                let s = new RoString(new BrsString("Monday, Tuesday, Happy Days"));
                 instr = s.getMethod("instr");
                 expect(instr).toBeInstanceOf(Callable);
             });
@@ -246,10 +246,10 @@ describe("RoString", () => {
         });
 
         describe("replace", () => {
-            let s, replace;
+            let replace;
 
             beforeEach(() => {
-                s = new RoString(new BrsString("tossed salad and scrambled eggs"));
+                let s = new RoString(new BrsString("tossed salad and scrambled eggs"));
                 replace = s.getMethod("replace");
                 expect(replace).toBeInstanceOf(Callable);
             });
@@ -272,7 +272,8 @@ describe("RoString", () => {
         });
 
         describe("trim", () => {
-            let s, trim;
+            let trim;
+
             beforeEach(() => {
                 let whitespace = [
                     String.fromCharCode(0x0a), // newline
@@ -284,13 +285,89 @@ describe("RoString", () => {
                     " ", // just a regular space
                 ].join("");
 
-                s = new RoString(new BrsString(whitespace + "hello" + whitespace));
+                let s = new RoString(new BrsString(whitespace + "hello" + whitespace));
                 trim = s.getMethod("trim");
                 expect(trim).toBeInstanceOf(Callable);
             });
 
             it("removes leading and trailing whitespace", () => {
                 expect(trim.call(interpreter)).toEqual(new BrsString("hello"));
+            });
+        });
+
+        describe("toInt", () => {
+            it("returns 0 for non-numbers", () => {
+                let s = new RoString(new BrsString("I'm just a bill."));
+                let toInt = s.getMethod("toInt");
+                expect(toInt).toBeInstanceOf(Callable);
+
+                expect(toInt.call(interpreter)).toEqual(new Int32(0));
+            });
+
+            it("returns 0 for hex strings", () => {
+                let s = new RoString(new BrsString("&hFF"));
+                let toInt = s.getMethod("toInt");
+                expect(toInt).toBeInstanceOf(Callable);
+
+                expect(toInt.call(interpreter)).toEqual(new Int32(0));
+            });
+
+            it("converts string-formatted integers to Integer type", () => {
+                let s = new RoString(new BrsString("112358"));
+                let toInt = s.getMethod("toInt");
+                expect(toInt).toBeInstanceOf(Callable);
+
+                expect(toInt.call(interpreter)).toEqual(new Int32(112358));
+            });
+
+            it("truncates string-formatted floats to Integer type", () => {
+                let negative = new RoString(new BrsString("-1.9"));
+                let negativeToInt = negative.getMethod("toInt");
+                expect(negativeToInt).toBeInstanceOf(Callable);
+                expect(negativeToInt.call(interpreter)).toEqual(new Int32(-1));
+
+                let positive = new RoString(new BrsString("1.9"));
+                let positiveToInt = positive.getMethod("toInt");
+                expect(positiveToInt).toBeInstanceOf(Callable);
+                expect(positiveToInt.call(interpreter)).toEqual(new Int32(1));
+            });
+        });
+
+        describe("toFloat", () => {
+            it("returns 0 for non-numbers", () => {
+                let s = new RoString(new BrsString("I'm just a bill."));
+                let toFloat = s.getMethod("toFloat");
+                expect(toFloat).toBeInstanceOf(Callable);
+
+                expect(toFloat.call(interpreter)).toEqual(new Float(0));
+            });
+
+            it("returns 0 for hex strings", () => {
+                let s = new RoString(new BrsString("&hFF"));
+                let toFloat = s.getMethod("toFloat");
+                expect(toFloat).toBeInstanceOf(Callable);
+
+                expect(toFloat.call(interpreter)).toEqual(new Float(0));
+            });
+
+            it("converts string-formatted integers to Float type", () => {
+                let s = new RoString(new BrsString("112358"));
+                let toFloat = s.getMethod("toFloat");
+                expect(toFloat).toBeInstanceOf(Callable);
+
+                expect(toFloat.call(interpreter)).toEqual(new Float(112358));
+            });
+
+            it("converts string-formatted floats to Float type", () => {
+                let negative = new RoString(new BrsString("-1.9"));
+                let negativeToFloat = negative.getMethod("toFloat");
+                expect(negativeToFloat).toBeInstanceOf(Callable);
+                expect(negativeToFloat.call(interpreter)).toEqual(new Float(-1.9));
+
+                let positive = new RoString(new BrsString("1.9"));
+                let positiveToFloat = positive.getMethod("toFloat");
+                expect(positiveToFloat).toBeInstanceOf(Callable);
+                expect(positiveToFloat.call(interpreter)).toEqual(new Float(1.9));
             });
         });
     });

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -212,17 +212,37 @@ describe("RoString", () => {
                 expect(instr).toBeInstanceOf(Callable);
             });
 
-            it("returns the index of the first occurrence", () => {
-                expect(instr.call(interpreter, new BrsString("day"))).toEqual(new Int32(3));
+            describe("without start_index", () => {
+                it("returns the index of the first occurrence", () => {
+                    expect(instr.call(interpreter, new BrsString("day"))).toEqual(new Int32(3));
+                });
+
+                it("returns -1 for not-found substrings", () => {
+                    expect(instr.call(interpreter, new BrsString("Fonzie"))).toEqual(new Int32(-1));
+                });
+
+                it.todo("returns 0 for empty substrings");
+                // TODO: compare to RBI
+                // () => expect(instr.call(interpreter, new BrsString(""))).toEqual(new Int32(-1));
             });
 
-            it("returns -1 for not-found substrings", () => {
-                expect(instr.call(interpreter, new BrsString("Fonzie"))).toEqual(new Int32(-1));
-            });
+            describe("with start_index", () => {
+                it("returns the index of the first occurrence after `start_index`", () => {
+                    expect(instr.call(interpreter, new Int32(5), new BrsString("day"))).toEqual(
+                        new Int32(12)
+                    );
+                });
 
-            it.todo("returns 0 for empty substrings");
-            // TODO: compare to RBI
-            // () => expect(instr.call(interpreter, new BrsString(""))).toEqual(new Int32(-1));
+                it("returns -1 for not-found substrings", () => {
+                    expect(instr.call(interpreter, new Int32(5), new BrsString("Monday"))).toEqual(
+                        new Int32(-1)
+                    );
+                });
+
+                it.todo("returns start_index for empty substrings");
+                // TODO: compare to RBI
+                // () => expect(instr.call(interpreter, new BrsString(""))).toEqual(new Int32(-1));
+            });
         });
     });
 });

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -1,5 +1,5 @@
 const brs = require("brs");
-const { Int32, Float, BrsString, RoString, BrsBoolean, Callable } = brs.types;
+const { Int32, Float, BrsString, RoString, RoArray, BrsBoolean, Callable } = brs.types;
 const { Interpreter } = require("../../../lib/interpreter");
 
 describe("RoString", () => {
@@ -368,6 +368,60 @@ describe("RoString", () => {
                 let positiveToFloat = positive.getMethod("toFloat");
                 expect(positiveToFloat).toBeInstanceOf(Callable);
                 expect(positiveToFloat.call(interpreter)).toEqual(new Float(1.9));
+            });
+        });
+
+        describe("tokenize", () => {
+            let tokenize;
+
+            beforeEach(() => {
+                let s = new RoString(new BrsString("good dog"));
+                tokenize = s.getMethod("tokenize");
+                expect(tokenize).toBeInstanceOf(Callable);
+            });
+
+            // TODO: implement after RoList exists
+            it.todo("splits by single-character delimiter");
+            it.todo("splits by multi-character delimiter");
+        });
+
+        describe("split", () => {
+            let split;
+
+            beforeEach(() => {
+                let s = new RoString(new BrsString("🐶good dog🐶"));
+                split = s.getMethod("split");
+                expect(split).toBeInstanceOf(Callable);
+            });
+
+            it("splits characters with an empty string", () => {
+                let result = split.call(interpreter, new BrsString(""));
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual(
+                    ["🐶", "g", "o", "o", "d", " ", "d", "o", "g", "🐶"].map(c => new BrsString(c))
+                );
+            });
+
+            it("returns one section for not-found delimiters", () => {
+                let result = split.call(interpreter, new BrsString("/"));
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([new BrsString("🐶good dog🐶")]);
+            });
+
+            it("returns empty strings for leading and trailing matches", () => {
+                let result = split.call(interpreter, new BrsString("🐶"));
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([
+                    new BrsString(""),
+                    new BrsString("good dog"),
+                    new BrsString(""),
+                ]);
+            });
+
+            it("splits on multi-character sequences", () => {
+                let result = split.call(interpreter, new BrsString("oo"));
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([new BrsString("🐶g"), new BrsString("d dog🐶")]);
             });
         });
     });

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -1,0 +1,27 @@
+const brs = require("brs");
+const { BrsString, RoString, BrsBoolean } = brs.types;
+
+describe("RoString", () => {
+    describe("equality", () => {
+        it("compares to intrinsic strings", () => {
+            let a = new RoString(new BrsString("foo"));
+            let b = new BrsString("foo");
+            let c = new BrsString("bar");
+
+            expect(a.equalTo(b)).toBe(BrsBoolean.True);
+            expect(a.equalTo(c)).toBe(BrsBoolean.False);
+        });
+
+        it("compares to boxed strings", () => {
+            let a = new RoString(new BrsString("foo"));
+            let b = new RoString(new BrsString("foo"));
+            let c = new RoString(new BrsString("bar"));
+
+            expect(a.equalTo(b)).toBe(BrsBoolean.True);
+            expect(a.equalTo(c)).toBe(BrsBoolean.False);
+        });
+    });
+
+    // describe("ifStringOps", () => {
+    // });
+});

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -200,5 +200,29 @@ describe("RoString", () => {
                 });
             });
         });
+
+        describe("instr", () => {
+            let s, instr;
+
+            beforeEach(() => {
+                //                              0   0   0   1   1   2   2
+                //                              0   4   8   2   6   0   4
+                s = new RoString(new BrsString("Monday, Tuesday, Happy Days"));
+                instr = s.getMethod("instr");
+                expect(instr).toBeInstanceOf(Callable);
+            });
+
+            it("returns the index of the first occurrence", () => {
+                expect(instr.call(interpreter, new BrsString("day"))).toEqual(new Int32(3));
+            });
+
+            it("returns -1 for not-found substrings", () => {
+                expect(instr.call(interpreter, new BrsString("Fonzie"))).toEqual(new Int32(-1));
+            });
+
+            it.todo("returns 0 for empty substrings");
+            // TODO: compare to RBI
+            // () => expect(instr.call(interpreter, new BrsString(""))).toEqual(new Int32(-1));
+        });
     });
 });

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -244,5 +244,54 @@ describe("RoString", () => {
                 // () => expect(instr.call(interpreter, new BrsString(""))).toEqual(new Int32(-1));
             });
         });
+
+        describe("replace", () => {
+            let s, replace;
+
+            beforeEach(() => {
+                s = new RoString(new BrsString("tossed salad and scrambled eggs"));
+                replace = s.getMethod("replace");
+                expect(replace).toBeInstanceOf(Callable);
+            });
+
+            it("replaces all instances of `from` with `to`", () => {
+                expect(replace.call(interpreter, new BrsString("s"), new BrsString("$"))).toEqual(
+                    new BrsString("to$$ed $alad and $crambled egg$")
+                );
+            });
+
+            it("returns the original string for empty `from`", () => {
+                expect(
+                    replace.call(
+                        interpreter,
+                        new BrsString(""),
+                        new BrsString("oh baby I hear the blues a-callin'")
+                    )
+                ).toEqual(new BrsString("tossed salad and scrambled eggs"));
+            });
+        });
+
+        describe("trim", () => {
+            let s, trim;
+            beforeEach(() => {
+                let whitespace = [
+                    String.fromCharCode(0x0a), // newline
+                    String.fromCharCode(0x0b), // vertical tab
+                    String.fromCharCode(0x0c), // form feed
+                    String.fromCharCode(0x0d), // carriage return
+                    String.fromCharCode(0xa0), // non-breaking space
+                    "\t", // just a regular tab
+                    " ", // just a regular space
+                ].join("");
+
+                s = new RoString(new BrsString(whitespace + "hello" + whitespace));
+                trim = s.getMethod("trim");
+                expect(trim).toBeInstanceOf(Callable);
+            });
+
+            it("removes leading and trailing whitespace", () => {
+                expect(trim.call(interpreter)).toEqual(new BrsString("hello"));
+            });
+        });
     });
 });

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -440,5 +440,145 @@ describe("RoString", () => {
                 );
             });
         });
+
+        describe("escape", () => {
+            it("escapes characters in the ascii range", () => {
+                let s = new RoString(new BrsString("@&=+/#!*ABcde_-"));
+                let escape = s.getMethod("escape");
+                expect(escape).toBeInstanceOf(Callable);
+
+                expect(escape.call(interpreter)).toEqual(
+                    new BrsString("%40%26%3D%2B%2F%23%21%2AABcde_-")
+                );
+            });
+
+            it("breaks unicode characters into UTF-8 escape sequences", () => {
+                let s = new RoString(new BrsString("•"));
+                let escape = s.getMethod("escape");
+                expect(escape).toBeInstanceOf(Callable);
+
+                expect(escape.call(interpreter)).toEqual(new BrsString("%E2%80%A2"));
+            });
+        });
+
+        describe("unescape", () => {
+            it("unescapes characters in the ascii range", () => {
+                let s = new RoString(new BrsString("%40%26%3D%2B%2F%23%21%2AABcde_-"));
+                let unescape = s.getMethod("unescape");
+                expect(unescape).toBeInstanceOf(Callable);
+
+                expect(unescape.call(interpreter)).toEqual(new BrsString("@&=+/#!*ABcde_-"));
+            });
+
+            it("combines UTF-8 escape sequences into non-ASCII characters", () => {
+                let s = new RoString(new BrsString("%E2%80%A2"));
+                let unescape = s.getMethod("unescape");
+                expect(unescape).toBeInstanceOf(Callable);
+
+                expect(unescape.call(interpreter)).toEqual(new BrsString("•"));
+            });
+        });
+
+        describe("encodeUri", () => {
+            it("URI-encodes ASCII strings", () => {
+                let s = new RoString(
+                    new BrsString("http://example.com/my test.asp?first=jane&last=doe")
+                );
+                let encodeUri = s.getMethod("encodeUri");
+                expect(encodeUri).toBeInstanceOf(Callable);
+
+                expect(encodeUri.call(interpreter)).toEqual(
+                    new BrsString("http://example.com/my%20test.asp?first=jane&last=doe")
+                );
+            });
+
+            it("encodes non-ascii strings as UTF-8 escape sequences", () => {
+                let s = new RoString(new BrsString("http://example.com/?bullet=•"));
+                let encodeUri = s.getMethod("encodeUri");
+                expect(encodeUri).toBeInstanceOf(Callable);
+
+                expect(encodeUri.call(interpreter)).toEqual(
+                    new BrsString("http://example.com/?bullet=%E2%80%A2")
+                );
+            });
+        });
+
+        describe("decodeUri", () => {
+            it("URI-decodes ASCII strings", () => {
+                let s = new RoString(
+                    new BrsString("http://example.com/my%20test.asp?first=jane&last=doe")
+                );
+                let decodeUri = s.getMethod("decodeUri");
+                expect(decodeUri).toBeInstanceOf(Callable);
+
+                expect(decodeUri.call(interpreter)).toEqual(
+                    new BrsString("http://example.com/my test.asp?first=jane&last=doe")
+                );
+            });
+
+            it("decodes UTF-8 escape sequences into non-ASCII characters", () => {
+                let s = new RoString(new BrsString("http://example.com/?bullet=%E2%80%A2"));
+                let decodeUri = s.getMethod("decodeUri");
+                expect(decodeUri).toBeInstanceOf(Callable);
+
+                expect(decodeUri.call(interpreter)).toEqual(
+                    new BrsString("http://example.com/?bullet=•")
+                );
+            });
+        });
+
+        describe("encodeUriComponent", () => {
+            it("encodes the string for use as a URI component", () => {
+                let s = new RoString(
+                    new BrsString("http://example.com/my test.asp?first=jane&last=doe")
+                );
+                let encodeUriComponent = s.getMethod("encodeUriComponent");
+                expect(encodeUriComponent).toBeInstanceOf(Callable);
+
+                expect(encodeUriComponent.call(interpreter)).toEqual(
+                    new BrsString(
+                        "http%3A%2F%2Fexample.com%2Fmy%20test.asp%3Ffirst%3Djane%26last%3Ddoe"
+                    )
+                );
+            });
+
+            it("encodes non-ascii strings as UTF-8 escape sequences", () => {
+                let s = new RoString(new BrsString("http://example.com/?bullet=•"));
+                let encodeUriComponent = s.getMethod("encodeUriComponent");
+                expect(encodeUriComponent).toBeInstanceOf(Callable);
+
+                expect(encodeUriComponent.call(interpreter)).toEqual(
+                    new BrsString("http%3A%2F%2Fexample.com%2F%3Fbullet%3D%E2%80%A2")
+                );
+            });
+        });
+
+        describe("decodeUriComponent", () => {
+            it("decodes an encoded URI component to a readable string", () => {
+                let s = new RoString(
+                    new BrsString(
+                        "http%3A%2F%2Fexample.com%2Fmy%20test.asp%3Ffirst%3Djane%26last%3Ddoe"
+                    )
+                );
+                let decodeUriComponent = s.getMethod("decodeUriComponent");
+                expect(decodeUriComponent).toBeInstanceOf(Callable);
+
+                expect(decodeUriComponent.call(interpreter)).toEqual(
+                    new BrsString("http://example.com/my test.asp?first=jane&last=doe")
+                );
+            });
+
+            it("decodes UTF-8 escape sequences into non-ASCII characters", () => {
+                let s = new RoString(
+                    new BrsString("http%3A%2F%2Fexample.com%2F%3Fbullet%3D%E2%80%A2")
+                );
+                let decodeUriComponent = s.getMethod("decodeUriComponent");
+                expect(decodeUriComponent).toBeInstanceOf(Callable);
+
+                expect(decodeUriComponent.call(interpreter)).toEqual(
+                    new BrsString("http://example.com/?bullet=•")
+                );
+            });
+        });
     });
 });

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -108,11 +108,12 @@ describe("end to end brightscript functions", () => {
     test("components/roString.brs", async () => {
         await execute([resourceFile("components", "roString.brs")], outputStreams);
 
+        expect(allArgs(outputStreams.stderr.write)).toEqual([]);
         expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
             "true", // comparison
             "5", // length
             "b", // split("/")[1]
-            "%F09F%90%B6", // dog emoji, uri-encoded
+            "%F0%9F%90%B6", // dog emoji, uri-encoded
             "🐶", // uri-encoded dog emoji, decoded
         ]);
     });

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -104,4 +104,16 @@ describe("end to end brightscript functions", () => {
             " ]",
         ]);
     });
+
+    test("components/roString.brs", async () => {
+        await execute([resourceFile("components", "roString.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+            "true", // comparison
+            "5", // length
+            "b", // split("/")[1]
+            "%F09F%90%B6", // dog emoji, uri-encoded
+            "🐶", // uri-encoded dog emoji, decoded
+        ]);
+    });
 });

--- a/test/e2e/resources/components/roString.brs
+++ b/test/e2e/resources/components/roString.brs
@@ -2,14 +2,15 @@ sub main()
     ' direct creation
     r = createObject("RoString", "foo")
 
-    ' autoboxing
     s = "bar"
-    s.setString("f")
-    s.appendString("oo", 10)
+
+    r.setString("boo!", 1)
+    r.appendString("ar", 10)
 
     ' comparisons
     print r = s ' => true
 
+    ' autoboxing
     t = "a/b/c"
     print t.len() ' => 5
     print t.split("/")[1] ' => b

--- a/test/e2e/resources/components/roString.brs
+++ b/test/e2e/resources/components/roString.brs
@@ -1,0 +1,20 @@
+sub main()
+    ' direct creation
+    r = createObject("RoString", "foo")
+
+    ' autoboxing
+    s = "bar"
+    s.setString("f")
+    s.appendString("oo", 10)
+
+    ' comparisons
+    print r = s ' => true
+
+    t = "a/b/c"
+    print t.len() ' => 5
+    print t.split("/")[1] ' => b
+
+    u = "🐶"
+    print u.encodeUriComponent() ' => %F0%9F%90%B6
+    print "%F0%9F%90%B6".decodeUriComponent() ' => 🐶
+end sub

--- a/test/interpreter/Comparison.test.js
+++ b/test/interpreter/Comparison.test.js
@@ -12,6 +12,7 @@ const {
     RoArray,
     BrsInvalid,
     RoAssociativeArray,
+    RoString,
 } = brs.types;
 
 let interpreter;
@@ -164,6 +165,7 @@ describe("interpreter comparisons", () => {
     describe("disallowed mixed-type comparisons", () => {
         let int32 = new Int32(2);
         let str = new BrsString("two");
+        let rostr = new RoString(str);
         let int64 = new Int64(2);
 
         // due to a combinatoric explosion of LHS-RHS-operator pairs, just test a representative
@@ -193,13 +195,13 @@ describe("interpreter comparisons", () => {
             ]);
         });
 
-        test("string and 64-bit int", () => {
-            let less = binary(str, Lexeme.Less, int64);
-            let lessEqual = binary(str, Lexeme.LessEqual, int64);
-            let greater = binary(str, Lexeme.Greater, int64);
-            let greaterEqual = binary(str, Lexeme.GreaterEqual, int64);
-            let equal = binary(str, Lexeme.Equal, int64);
-            let notEqual = binary(str, Lexeme.LessGreater, int64);
+        test("roString and 64-bit int", () => {
+            let less = binary(rostr, Lexeme.Less, int64);
+            let lessEqual = binary(rostr, Lexeme.LessEqual, int64);
+            let greater = binary(rostr, Lexeme.Greater, int64);
+            let greaterEqual = binary(rostr, Lexeme.GreaterEqual, int64);
+            let equal = binary(rostr, Lexeme.Equal, int64);
+            let notEqual = binary(rostr, Lexeme.LessGreater, int64);
             let results = interpreter.exec([
                 less,
                 lessEqual,


### PR DESCRIPTION
`roString` — specifically the methods described in `ifStringOps` — is one of the most often-used non-SceneGraph types in the BrightScript language.  It's not necessarily directly created by BrightScript authors, but it gets created whenever `foo.split("/")` or `bar.encodeUriComponent()` are called due to the reference implementation's automatic boxing rules.  Basically, if you use a boxable primitive like an object, it'll get automatically boxed for you, and the temporary boxed value will be destroyed at the end of the operation.

This PR implements the `ifStringOps` functions on a new `roString` type, and includes that automatic boxing behavior.