### PR TITLE
feat(stdlib,e2e): Implement global `Run` function

### DIFF
--- a/src/brsTypes/Callable.ts
+++ b/src/brsTypes/Callable.ts
@@ -68,7 +68,7 @@ export interface Signature {
 }
 
 /** A BrightScript function signature paired with its implementation. */
-type SignatureAndImplementation = {
+export type SignatureAndImplementation = {
     /** A BrightScript function's signature. */
     signature: Signature;
     /** The implementation corresponding to `signature`. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,15 +96,14 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
     return interpreter.exec(statements);
 }
 
-export function executeSync(filenames: string[], options: Partial<ExecutionOptions>) {
+export function executeSync(fileContents: string[], options: Partial<ExecutionOptions>) {
     const executionOptions = Object.assign(defaultExecutionOptions, options);
     const interpreter = new Interpreter(executionOptions); // shared between files
 
     let manifest = PP.getManifestSync(executionOptions.root);
 
-    let allStatements = filenames
-        .map(filename => {
-            let contents = fs.readFileSync(filename, "utf-8");
+    let allStatements = fileContents
+        .map(contents => {
             let scanResults = Lexer.scan(contents);
             let preprocessor = new PP.Preprocessor();
             let preprocessorResults = preprocessor.preprocess(scanResults.tokens, manifest);

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,16 +103,20 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
  * @param filename the paths to BrightScript files to execute synchronously
  * @param options configuration for the execution, including the streams to use for `stdout` and
  *                `stderr` and the base directory for path resolution
+ * @param args the set of arguments to pass to the `main` function declared in one of the provided filenames
  *
  * @returns the value returned by the executed file(s)
  */
-export function executeSync(filenames: string[], options: Partial<ExecutionOptions>) {
+export function executeSync(
+    filenames: string[],
+    options: Partial<ExecutionOptions>,
+    args: BrsTypes.BrsType[]
+) {
     const executionOptions = Object.assign(defaultExecutionOptions, options);
     const interpreter = new Interpreter(executionOptions); // shared between files
 
     let manifest = PP.getManifestSync(executionOptions.root);
 
-    // TODO: re-add file reading here
     let allStatements = filenames
         .map(filename => {
             let contents = fs.readFileSync(filename, "utf8");
@@ -123,7 +127,7 @@ export function executeSync(filenames: string[], options: Partial<ExecutionOptio
         })
         .reduce((allStatements, statements) => [...allStatements, ...statements], []);
 
-    return interpreter.exec(allStatements);
+    return interpreter.exec(allStatements, ...args);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,15 +96,27 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
     return interpreter.exec(statements);
 }
 
-export function executeSync(fileContents: string[], options: Partial<ExecutionOptions>) {
+/**
+ * A synchronous version of `execute`. Executes a BrightScript file by path and writes its output to the streams
+ * provided in `options`.
+ *
+ * @param filename the paths to BrightScript files to execute synchronously
+ * @param options configuration for the execution, including the streams to use for `stdout` and
+ *                `stderr` and the base directory for path resolution
+ *
+ * @returns the value returned by the executed file(s)
+ */
+export function executeSync(filenames: string[], options: Partial<ExecutionOptions>) {
     const executionOptions = Object.assign(defaultExecutionOptions, options);
     const interpreter = new Interpreter(executionOptions); // shared between files
 
     let manifest = PP.getManifestSync(executionOptions.root);
 
-    let allStatements = fileContents
-        .map(contents => {
-            let scanResults = Lexer.scan(contents);
+    // TODO: re-add file reading here
+    let allStatements = filenames
+        .map(filename => {
+            let contents = fs.readFileSync(filename, "utf8");
+            let scanResults = Lexer.scan(contents, filename);
             let preprocessor = new PP.Preprocessor();
             let preprocessorResults = preprocessor.preprocess(scanResults.tokens, manifest);
             return Parser.parse(preprocessorResults.processedTokens).statements;

--- a/src/lexer/ReservedWords.ts
+++ b/src/lexer/ReservedWords.ts
@@ -50,7 +50,7 @@ export const ReservedWords = new Set([
 ]);
 
 /**
- * The set of keywords in the refrence BrightScript runtime. Any of these that *are not* reserved
+ * The set of keywords in the reference BrightScript runtime. Any of these that *are not* reserved
  * words can be used within a BrightScript file for other purposes, e.g. `tab`.
  *
  * Unfortunately there's no canonical source for this!

--- a/src/preprocessor/Manifest.ts
+++ b/src/preprocessor/Manifest.ts
@@ -31,6 +31,23 @@ export async function getManifest(rootDir: string): Promise<Manifest> {
 }
 
 /**
+ * A synchronous version of `getManifest`.
+ * @param rootDir the root directory in which a `manifest` file is expected
+ * @returns a map of string to JavaScript number, string, or boolean, representing the manifest
+ *          file's contents
+ */
+export function getManifestSync(rootDir: string): Manifest {
+    let manifestPath = path.join(rootDir, "manifest");
+
+    if (!fs.existsSync(manifestPath)) {
+        return new Map();
+    }
+
+    let contents = fs.readFileSync(manifestPath, "utf-8");
+    return parseManifest(contents);
+}
+
+/**
  * Attempts to parse a `manifest` file's contents into a map of string to JavaScript
  * number, string, or boolean.
  * @param contents the text contents of a manifest file.

--- a/src/preprocessor/index.ts
+++ b/src/preprocessor/index.ts
@@ -64,4 +64,4 @@ import { BrsError } from "../Error";
 import { ParseError } from "../parser";
 export { Chunk };
 export { Parser } from "./Parser";
-export { getManifest, getBsConst, Manifest } from "./Manifest";
+export { getManifest, getManifestSync, getBsConst, Manifest } from "./Manifest";

--- a/src/stdlib/File.ts
+++ b/src/stdlib/File.ts
@@ -2,17 +2,25 @@ import { Callable, ValueKind, BrsString, BrsBoolean, RoArray, StdlibArgument } f
 import { Interpreter } from "../interpreter";
 import { URL } from "url";
 import MemoryFileSystem from "memory-fs";
+import * as fs from "fs";
+
+type Volume = MemoryFileSystem | typeof fs;
 
 /*
  * Returns a memfs volume based on the brs path uri.  For example, passing in
- * "tmp:///test.txt" will return the memfs temporary volume on the interpreter.
+ * "tmp:/test.txt" will return the memfs temporary volume on the interpreter.
  *
  * Returns invalid in no appopriate volume is found for the path
  */
-export function getVolumeByPath(interpreter: Interpreter, path: string): MemoryFileSystem | null {
+export function getVolumeByPath(interpreter: Interpreter, path: string): Volume | null {
     try {
         const protocol = new URL(path).protocol;
-        if (protocol === "tmp:") return interpreter.temporaryVolume;
+        if (protocol === "tmp:") {
+            return interpreter.temporaryVolume;
+        }
+        if (protocol === "pkg:") {
+            return fs;
+        }
     } catch (err) {
         return null;
     }
@@ -21,9 +29,9 @@ export function getVolumeByPath(interpreter: Interpreter, path: string): MemoryF
 
 /*
  * Returns a memfs file path from a brs file uri
- *   ex. "tmp:///test/test1.txt" -> "/test/test1.txt"
+ *   ex. "tmp:/test/test1.txt" -> "/test/test1.txt"
  */
-export function getMemfsPath(fileUri: string) {
+export function getPath(fileUri: string) {
     return new URL(fileUri).pathname;
 }
 
@@ -46,8 +54,8 @@ export const CopyFile = new Callable("CopyFile", {
             return BrsBoolean.False;
         }
 
-        const srcMemfsPath = getMemfsPath(src.value);
-        const dstMemfsPath = getMemfsPath(dst.value);
+        const srcMemfsPath = getPath(src.value);
+        const dstMemfsPath = getPath(dst.value);
         try {
             let contents = srcVolume.readFileSync(srcMemfsPath);
             dstVolume.writeFileSync(dstMemfsPath, contents);
@@ -77,8 +85,8 @@ export const MoveFile = new Callable("MoveFile", {
             return BrsBoolean.False;
         }
 
-        const srcMemfsPath = getMemfsPath(src.value);
-        const dstMemfsPath = getMemfsPath(dst.value);
+        const srcMemfsPath = getPath(src.value);
+        const dstMemfsPath = getPath(dst.value);
         try {
             let contents = srcVolume.readFileSync(srcMemfsPath);
             dstVolume.writeFileSync(dstMemfsPath, contents);
@@ -102,7 +110,7 @@ export const DeleteFile = new Callable("DeleteFile", {
             return BrsBoolean.False;
         }
 
-        const memfsPath = getMemfsPath(file.value);
+        const memfsPath = getPath(file.value);
         try {
             volume.unlinkSync(memfsPath);
             return BrsBoolean.True;
@@ -124,7 +132,7 @@ export const DeleteDirectory = new Callable("DeleteDirectory", {
             return BrsBoolean.False;
         }
 
-        const memfsPath = getMemfsPath(dir.value);
+        const memfsPath = getPath(dir.value);
         try {
             volume.rmdirSync(memfsPath);
             return BrsBoolean.True;
@@ -146,7 +154,7 @@ export const CreateDirectory = new Callable("CreateDirectory", {
             return BrsBoolean.False;
         }
 
-        const memfsPath = getMemfsPath(dir.value);
+        const memfsPath = getPath(dir.value);
         try {
             volume.mkdirSync(memfsPath);
             return BrsBoolean.True;
@@ -185,7 +193,7 @@ export const ListDir = new Callable("ListDir", {
             return new RoArray([]);
         }
 
-        const memfsPath = getMemfsPath(path.value);
+        const memfsPath = getPath(path.value);
         try {
             let subPaths = volume.readdirSync(memfsPath).map(s => new BrsString(s));
             return new RoArray(subPaths);
@@ -207,7 +215,7 @@ export const ReadAsciiFile = new Callable("ReadAsciiFile", {
             return new BrsString("");
         }
 
-        const memfsPath = getMemfsPath(filepath.value);
+        const memfsPath = getPath(filepath.value);
         return new BrsString(volume.readFileSync(memfsPath).toString());
     },
 });
@@ -227,7 +235,7 @@ export const WriteAsciiFile = new Callable("WriteAsciiFile", {
             return BrsBoolean.False;
         }
 
-        const memfsPath = getMemfsPath(filepath.value);
+        const memfsPath = getPath(filepath.value);
         volume.writeFileSync(memfsPath, text.value);
         return BrsBoolean.True;
     },

--- a/src/stdlib/Run.ts
+++ b/src/stdlib/Run.ts
@@ -1,0 +1,34 @@
+import * as path from "path";
+
+import * as brs from "../";
+import { BrsType, ValueKind, Callable, BrsString, BrsInvalid, StdlibArgument } from "../brsTypes";
+import { Interpreter } from "../interpreter";
+import { getVolumeByPath, getPath } from "./File";
+
+export const Run = new Callable("Run", {
+    signature: {
+        args: [
+            new StdlibArgument("filename", ValueKind.String),
+            new StdlibArgument("arg0", ValueKind.Dynamic, BrsInvalid.Instance),
+        ],
+        returns: ValueKind.String,
+    },
+    impl: (interpreter: Interpreter, filename: BrsString, ...args: BrsType[]) => {
+        let volume = getVolumeByPath(interpreter, filename.value);
+        let pathToFile = path.join(interpreter.options.root, getPath(filename.value));
+
+        // if the file-to-run doesn't exist, RBI returns invalid
+        if (!volume) {
+            return BrsInvalid.Instance;
+        }
+
+        try {
+            let contents = volume.readFileSync(pathToFile, "utf8");
+            let results = brs.executeSync([contents], interpreter.options);
+            return results[0] || BrsInvalid.Instance;
+        } catch (err) {
+            // swallow errors and just return invalid; RBI returns invalid for "file doesn't exist" errors
+            return BrsInvalid.Instance;
+        }
+    },
+});

--- a/src/stdlib/Run.ts
+++ b/src/stdlib/Run.ts
@@ -23,11 +23,11 @@ export const Run = new Callable("Run", {
         }
 
         try {
-            let contents = volume.readFileSync(pathToFile, "utf8");
-            let results = brs.executeSync([contents], interpreter.options);
+            let results = brs.executeSync([pathToFile], interpreter.options);
             return results[0] || BrsInvalid.Instance;
         } catch (err) {
-            // swallow errors and just return invalid; RBI returns invalid for "file doesn't exist" errors
+            // swallow errors and just return invalid; RBI returns invalid for "file doesn't exist" errors,
+            // syntax errors, etc.
             return BrsInvalid.Instance;
         }
     },

--- a/src/stdlib/Run.ts
+++ b/src/stdlib/Run.ts
@@ -1,34 +1,108 @@
 import * as path from "path";
 
 import * as brs from "../";
-import { BrsType, ValueKind, Callable, BrsString, BrsInvalid, StdlibArgument } from "../brsTypes";
+import {
+    BrsType,
+    ValueKind,
+    Callable,
+    BrsString,
+    BrsInvalid,
+    StdlibArgument,
+    SignatureAndImplementation,
+    RoArray,
+    isBrsString,
+} from "../brsTypes";
 import { Interpreter } from "../interpreter";
 import { getVolumeByPath, getPath } from "./File";
+import { BrsComponent } from "../brsTypes/components/BrsComponent";
 
-export const Run = new Callable("Run", {
-    signature: {
-        args: [
-            new StdlibArgument("filename", ValueKind.String),
-            new StdlibArgument("arg0", ValueKind.Dynamic, BrsInvalid.Instance),
-        ],
-        returns: ValueKind.String,
-    },
-    impl: (interpreter: Interpreter, filename: BrsString, ...args: BrsType[]) => {
-        let volume = getVolumeByPath(interpreter, filename.value);
-        let pathToFile = path.join(interpreter.options.root, getPath(filename.value));
+/**
+ * Runs a file (or set of files) with the provided arguments, returning either the value returned by those files'
+ * `main` function or `invalid` if an error occurs.
+ *
+ * @param interpreter the interpreter hosting this call to `Run`
+ * @param filenames a list of files to lex, parse, and run
+ * @param args the arguments to pass into the found `main` function
+ *
+ * @returns the value returned by the executed file(s) if no errors are detected, otherwise `invalid`
+ */
+function runFiles(interpreter: Interpreter, filenames: BrsString[], args: BrsType[]) {
+    let volumes = filenames.map(filename => getVolumeByPath(interpreter, filename.value));
+    let pathsToFiles = filenames.map(filename =>
+        path.join(interpreter.options.root, getPath(filename.value))
+    );
 
-        // if the file-to-run doesn't exist, RBI returns invalid
-        if (!volume) {
+    // if the file-to-run doesn't exist, RBI returns invalid
+    if (!volumes.every(volume => volume != null)) {
+        return BrsInvalid.Instance;
+    }
+
+    try {
+        let results = brs.executeSync(pathsToFiles, interpreter.options, args);
+        return results[0] || BrsInvalid.Instance;
+    } catch (err) {
+        // swallow errors and just return invalid; RBI returns invalid for "file doesn't exist" errors,
+        // syntax errors, etc.
+        return BrsInvalid.Instance;
+    }
+}
+
+/**
+ * Creates several copies of the provided signature and implementation pair, simulating variadic types by creating a
+ * function that accepts zero args, one that accepts one arg, one that accepts two args, (…).
+ *
+ * @param signatureAndImpl the base signature and implementation to make variadic
+ *
+ * @returns an array containing psuedo-variadic versions of the provided signature and implementation
+ */
+function variadic(signatureAndImpl: SignatureAndImplementation): SignatureAndImplementation[] {
+    let { signature, impl } = signatureAndImpl;
+    return [
+        signatureAndImpl,
+        ...new Array(10).fill(0).map((_, numArgs) => {
+            return {
+                signature: {
+                    args: [
+                        ...signature.args,
+                        ...new Array(numArgs)
+                            .fill(0)
+                            .map((_, i) => new StdlibArgument(`arg${i}`, ValueKind.Dynamic)),
+                    ],
+                    returns: signature.returns,
+                },
+                impl: impl,
+            };
+        }),
+    ];
+}
+
+export const Run = new Callable(
+    "Run",
+    ...variadic({
+        signature: {
+            args: [new StdlibArgument("filename", ValueKind.String)],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (interpreter: Interpreter, filename: BrsString, ...args: BrsType[]) => {
+            return runFiles(interpreter, [filename], args);
+        },
+    }),
+    ...variadic({
+        signature: {
+            args: [new StdlibArgument("filenamearray", ValueKind.Object)],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (interpreter: Interpreter, filenamearray: BrsComponent, ...args: BrsType[]) => {
+            if (
+                filenamearray instanceof RoArray &&
+                filenamearray.getElements().every(isBrsString)
+            ) {
+                return runFiles(interpreter, filenamearray.getElements() as BrsString[], args);
+            }
+
+            // RBI seems to hard-reboot when passed a non-empty associative array, but returns invalid for empty
+            // AA's. Let's return invalid to be safe.
             return BrsInvalid.Instance;
-        }
-
-        try {
-            let results = brs.executeSync([pathToFile], interpreter.options);
-            return results[0] || BrsInvalid.Instance;
-        } catch (err) {
-            // swallow errors and just return invalid; RBI returns invalid for "file doesn't exist" errors,
-            // syntax errors, etc.
-            return BrsInvalid.Instance;
-        }
-    },
-});
+        },
+    })
+);

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -1,5 +1,4 @@
-import { Callable, ValueKind, BrsType, BrsInvalid } from "../brsTypes";
-import { Interpreter } from "../interpreter";
+import { Callable, ValueKind, BrsInvalid } from "../brsTypes";
 
 let warningShown = false;
 
@@ -23,5 +22,6 @@ export * from "./File";
 export * from "./Json";
 export * from "./Math";
 export * from "./Print";
+export * from "./Run";
 export * from "./String";
 export * from "./Type";

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -103,4 +103,16 @@ describe("end to end standard libary", () => {
             ].join("\n"),
         ]);
     });
+
+    test("stdlib/run.brs", async () => {
+        await execute([resourceFile("stdlib", "run.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+            "in run.brs",
+            "    in runme.brs",
+            "returned to run.brs",
+            "runme.brs returned: ",
+            "2",
+        ]);
+    });
 });

--- a/test/e2e/resources/stdlib/run.brs
+++ b/test/e2e/resources/stdlib/run.brs
@@ -1,0 +1,6 @@
+sub main()
+    print "in run.brs"
+    result = Run("pkg:/test/e2e/resources/stdlib/runme.brs")
+    print "returned to run.brs"
+    print "runme.brs returned: " result
+end sub

--- a/test/e2e/resources/stdlib/runme.brs
+++ b/test/e2e/resources/stdlib/runme.brs
@@ -1,0 +1,8 @@
+function main()
+    print "    in runme.brs"
+    return addOne(1)
+end function
+
+function addOne(a as integer) as integer
+    return a + 1
+end function

--- a/test/stdlib/File.test.js
+++ b/test/stdlib/File.test.js
@@ -8,7 +8,7 @@ const {
     FormatDrive,
     ReadAsciiFile,
     WriteAsciiFile,
-    getMemfsPath,
+    getPath,
     getVolumeByPath,
 } = require("../../lib/stdlib/index");
 const { Interpreter } = require("../../lib/interpreter");
@@ -30,8 +30,8 @@ describe("global file I/O functions", () => {
         });
 
         it("converts a brs path to a memfs path", () => {
-            expect(getMemfsPath("tmp:/test.txt")).toEqual("/test.txt");
-            expect(getMemfsPath("tmp:///test.txt")).toEqual("/test.txt");
+            expect(getPath("tmp:/test.txt")).toEqual("/test.txt");
+            expect(getPath("tmp:///test.txt")).toEqual("/test.txt");
         });
     });
 

--- a/test/stdlib/Run.test.js
+++ b/test/stdlib/Run.test.js
@@ -1,0 +1,64 @@
+const brs = require("brs");
+const { BrsString, BrsInvalid } = brs.types;
+const { Run } = require("../../lib/stdlib");
+const { Interpreter } = require("../../lib/interpreter");
+const fs = require("fs");
+
+jest.mock("fs");
+
+describe("global Run function", () => {
+    let interpreter;
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        fs.readFileSync.mockRestore();
+    });
+
+    it("returns invalid for unrecognized devices", () => {
+        expect(Run.call(interpreter, new BrsString("notADevice:/etc/hosts"))).toBe(
+            BrsInvalid.Instance
+        );
+    });
+
+    it("returns invalid for unreadable files", () => {
+        fs.readFileSync.mockImplementation(() => {
+            throw new Error("file not found");
+        });
+        expect(Run.call(interpreter, new BrsString("notADevice:/etc/hosts"))).toBe(
+            BrsInvalid.Instance
+        );
+    });
+
+    it("returns invalid for lexing errors", () => {
+        fs.readFileSync.mockImplementation(() => `can't lex this`);
+        expect(Run.call(interpreter, new BrsString("pkg:/errors/lex.brs"))).toBe(
+            BrsInvalid.Instance
+        );
+    });
+
+    it("returns invalid for parse errors", () => {
+        fs.readFileSync.mockImplementationOnce(() => `if return "parse error" exit while`);
+        expect(Run.call(interpreter, new BrsString("pkg:/errors/parse.brs"))).toBe(
+            BrsInvalid.Instance
+        );
+    });
+
+    it("returns invalid for runtime errors", () => {
+        fs.readFileSync.mockImplementationOnce(() => `sub main(): _ = {}: _.crash(): end sub`);
+        expect(Run.call(interpreter, new BrsString("pkg:/errors/exec.brs"))).toBe(
+            BrsInvalid.Instance
+        );
+    });
+
+    it("returns whatever the executed file returns", () => {
+        fs.readFileSync.mockImplementationOnce(
+            () => `function main(): return "I'm a return value!": end function`
+        );
+        expect(Run.call(interpreter, new BrsString("pkg:/success/exec.brs"))).toEqual(
+            new BrsString("I'm a return value!")
+        );
+    });
+});


### PR DESCRIPTION
RBI's standard library includes a `Run` function, used to allow a BrightScript file to execute another BrightScript file given its full file path (using a `main` function as its entry point).  That's real handy, as it'll allow several files with `main` functions to co-exist, as long as they're not all in the `source/` directory.