### PR TITLE
Block include surrounding whitespace

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1172,7 +1172,7 @@ export class Parser {
             //the block's location starts at the end of the preceeding token, and stops at the beginning of the `end` token
             const preceedingToken = tokens[tokens.indexOf(startingToken) - 1];
             const postceedingToken = tokens[current];
-            var location: Location = {
+            const location: Location = {
                 file: startingToken.location.file,
                 start: {
                     line: preceedingToken.location.end.line,

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1169,7 +1169,18 @@ export class Parser {
                 // TODO: Figure out how to handle unterminated blocks well
             }
 
-            return new Stmt.Block(statements, startingToken.location);
+            //the block's location starts at the end of the preceeding token, and stops at the beginning of the `end` token
+            const preceedingToken = tokens[tokens.indexOf(startingToken) - 1];
+            const postceedingToken = tokens[current];
+            var location: Location = {
+                file: startingToken.location.file,
+                start: {
+                    line: preceedingToken.location.end.line,
+                    column: preceedingToken.location.end.column,
+                },
+                end: postceedingToken.location.start,
+            };
+            return new Stmt.Block(statements, location);
         }
 
         function expression(): Expression {

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -60,25 +60,10 @@ export class Assignment implements Statement {
 }
 
 export class Block implements Statement {
-    constructor(
-        readonly statements: ReadonlyArray<Statement>,
-        readonly startingLocation: Location
-    ) {}
+    constructor(readonly statements: ReadonlyArray<Statement>, readonly location: Location) {}
 
     accept<R>(visitor: Visitor<R>): BrsType {
         return visitor.visitBlock(this);
-    }
-
-    get location() {
-        let end = this.statements.length
-            ? this.statements[this.statements.length - 1].location.end
-            : this.startingLocation.start;
-
-        return {
-            file: this.startingLocation.file,
-            start: this.startingLocation.start,
-            end: end,
-        };
     }
 }
 

--- a/test/parser/controlFlow/__snapshots__/For.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/For.test.js.snap
@@ -4,11 +4,12 @@ exports[`parser for loops accepts a 'step' clause 1`] = `
 Array [
   For {
     "body": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,
@@ -174,11 +175,12 @@ exports[`parser for loops allows 'next' to terminate loop 1`] = `
 Array [
   For {
     "body": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,
@@ -329,11 +331,12 @@ exports[`parser for loops defaults a missing 'step' clause to '1' 1`] = `
 Array [
   For {
     "body": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,

--- a/test/parser/controlFlow/__snapshots__/ForEach.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/ForEach.test.js.snap
@@ -4,11 +4,12 @@ exports[`parser foreach loops allows 'next' to terminate loop 1`] = `
 Array [
   ForEach {
     "body": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,
@@ -108,11 +109,12 @@ exports[`parser foreach loops requires a name and target 1`] = `
 Array [
   ForEach {
     "body": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,

--- a/test/parser/controlFlow/__snapshots__/If.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/If.test.js.snap
@@ -57,15 +57,15 @@ Array [
       },
     },
     "elseBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 23,
-          "line": 8,
+          "column": 16,
+          "line": 9,
         },
         "file": "",
         "start": Object {
-          "column": 20,
-          "line": 8,
+          "column": 21,
+          "line": 7,
         },
       },
       "statements": Array [
@@ -182,15 +182,15 @@ Array [
           },
         },
         "thenBranch": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 23,
-              "line": 5,
+              "column": 16,
+              "line": 7,
             },
             "file": "",
             "start": Object {
-              "column": 20,
-              "line": 5,
+              "column": 30,
+              "line": 4,
             },
           },
           "statements": Array [
@@ -309,15 +309,15 @@ Array [
       },
     ],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 23,
-          "line": 3,
+          "column": 16,
+          "line": 4,
         },
         "file": "",
         "start": Object {
-          "column": 20,
-          "line": 3,
+          "column": 25,
+          "line": 2,
         },
       },
       "statements": Array [
@@ -481,15 +481,15 @@ Array [
     "elseBranch": undefined,
     "elseIfs": Array [],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 23,
-          "line": 3,
+          "column": 16,
+          "line": 5,
         },
         "file": "",
         "start": Object {
-          "column": 20,
-          "line": 3,
+          "column": 30,
+          "line": 2,
         },
       },
       "statements": Array [
@@ -720,15 +720,15 @@ Array [
       },
     },
     "elseBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 23,
-          "line": 5,
+          "column": 16,
+          "line": 7,
         },
         "file": "",
         "start": Object {
-          "column": 20,
-          "line": 5,
+          "column": 21,
+          "line": 4,
         },
       },
       "statements": Array [
@@ -846,15 +846,15 @@ Array [
     },
     "elseIfs": Array [],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 23,
-          "line": 3,
+          "column": 16,
+          "line": 4,
         },
         "file": "",
         "start": Object {
-          "column": 20,
-          "line": 3,
+          "column": 30,
+          "line": 2,
         },
       },
       "statements": Array [
@@ -1014,15 +1014,15 @@ Array [
       },
     },
     "elseBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 23,
-          "line": 8,
+          "column": 16,
+          "line": 9,
         },
         "file": "",
         "start": Object {
-          "column": 20,
-          "line": 8,
+          "column": 21,
+          "line": 7,
         },
       },
       "statements": Array [
@@ -1139,15 +1139,15 @@ Array [
           },
         },
         "thenBranch": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 23,
-              "line": 5,
+              "column": 16,
+              "line": 7,
             },
             "file": "",
             "start": Object {
-              "column": 20,
-              "line": 5,
+              "column": 35,
+              "line": 4,
             },
           },
           "statements": Array [
@@ -1266,15 +1266,15 @@ Array [
       },
     ],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 23,
-          "line": 3,
+          "column": 16,
+          "line": 4,
         },
         "file": "",
         "start": Object {
-          "column": 20,
-          "line": 3,
+          "column": 30,
+          "line": 2,
         },
       },
       "statements": Array [
@@ -1454,7 +1454,7 @@ Array [
     "elseBranch": undefined,
     "elseIfs": Array [],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": 41,
           "line": 2,
@@ -1591,14 +1591,14 @@ Array [
     "elseBranch": undefined,
     "elseIfs": Array [],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 29,
+          "column": 35,
           "line": 2,
         },
         "file": "",
         "start": Object {
-          "column": 23,
+          "column": 22,
           "line": 2,
         },
       },
@@ -1692,15 +1692,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 18,
-            "line": 3,
+            "column": 12,
+            "line": 4,
           },
           "file": "",
           "start": Object {
-            "column": 16,
-            "line": 3,
+            "column": 36,
+            "line": 2,
           },
         },
         "statements": Array [
@@ -1859,14 +1859,14 @@ Array [
       },
     },
     "elseBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 47,
+          "column": 54,
           "line": 2,
         },
         "file": "",
         "start": Object {
-          "column": 41,
+          "column": 40,
           "line": 2,
         },
       },
@@ -1913,14 +1913,14 @@ Array [
     },
     "elseIfs": Array [],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 29,
+          "column": 36,
           "line": 2,
         },
         "file": "",
         "start": Object {
-          "column": 23,
+          "column": 22,
           "line": 2,
         },
       },
@@ -2045,7 +2045,7 @@ Array [
       },
     },
     "elseBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
@@ -2163,7 +2163,7 @@ Array [
           },
         },
         "thenBranch": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
               "column": -9,
               "line": -9,
@@ -2231,7 +2231,7 @@ Array [
       },
     ],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
@@ -2377,7 +2377,7 @@ Array [
     "elseBranch": undefined,
     "elseIfs": Array [],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
@@ -2536,7 +2536,7 @@ Array [
       },
     },
     "elseBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
@@ -2603,7 +2603,7 @@ Array [
     },
     "elseIfs": Array [],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
@@ -2762,7 +2762,7 @@ Array [
       },
     },
     "elseBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
@@ -2880,7 +2880,7 @@ Array [
           },
         },
         "thenBranch": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
               "column": -9,
               "line": -9,
@@ -2948,7 +2948,7 @@ Array [
       },
     ],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
@@ -3076,14 +3076,14 @@ Array [
     "elseBranch": undefined,
     "elseIfs": Array [],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 28,
+          "column": 38,
           "line": 2,
         },
         "file": "",
         "start": Object {
-          "column": 23,
+          "column": 22,
           "line": 2,
         },
       },
@@ -3193,14 +3193,14 @@ Array [
       },
     },
     "elseBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 81,
+          "column": 93,
           "line": 2,
         },
         "file": "",
         "start": Object {
-          "column": 76,
+          "column": 75,
           "line": 2,
         },
       },
@@ -3267,14 +3267,14 @@ Array [
           },
         },
         "thenBranch": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 58,
+              "column": 70,
               "line": 2,
             },
             "file": "",
             "start": Object {
-              "column": 53,
+              "column": 52,
               "line": 2,
             },
           },
@@ -3324,14 +3324,14 @@ Array [
       },
     ],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 26,
+          "column": 39,
           "line": 2,
         },
         "file": "",
         "start": Object {
-          "column": 21,
+          "column": 20,
           "line": 2,
         },
       },
@@ -3481,14 +3481,14 @@ Array [
     "elseBranch": undefined,
     "elseIfs": Array [],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 28,
-          "line": 2,
+          "column": 12,
+          "line": 3,
         },
         "file": "",
         "start": Object {
-          "column": 22,
+          "column": 21,
           "line": 2,
         },
       },
@@ -3598,14 +3598,14 @@ Array [
     "elseBranch": undefined,
     "elseIfs": Array [],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 31,
+          "column": 66,
           "line": 2,
         },
         "file": "",
         "start": Object {
-          "column": 27,
+          "column": 26,
           "line": 2,
         },
       },
@@ -3649,14 +3649,14 @@ Array [
           },
           "value": Function {
             "body": Block {
-              "startingLocation": Object {
+              "location": Object {
                 "end": Object {
-                  "column": 47,
+                  "column": 56,
                   "line": 2,
                 },
                 "file": "",
                 "start": Object {
-                  "column": 42,
+                  "column": 41,
                   "line": 2,
                 },
               },
@@ -3806,15 +3806,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 18,
-            "line": 3,
+            "column": 12,
+            "line": 10,
           },
           "file": "",
           "start": Object {
-            "column": 16,
-            "line": 3,
+            "column": 23,
+            "line": 2,
           },
         },
         "statements": Array [
@@ -3873,15 +3873,15 @@ Array [
               },
             },
             "elseBranch": Block {
-              "startingLocation": Object {
+              "location": Object {
                 "end": Object {
-                  "column": 25,
-                  "line": 8,
+                  "column": 16,
+                  "line": 9,
                 },
                 "file": "",
                 "start": Object {
-                  "column": 20,
-                  "line": 8,
+                  "column": 22,
+                  "line": 7,
                 },
               },
               "statements": Array [
@@ -3983,15 +3983,15 @@ Array [
                   },
                 },
                 "thenBranch": Block {
-                  "startingLocation": Object {
+                  "location": Object {
                     "end": Object {
-                      "column": 25,
-                      "line": 6,
+                      "column": 16,
+                      "line": 7,
                     },
                     "file": "",
                     "start": Object {
-                      "column": 20,
-                      "line": 6,
+                      "column": 31,
+                      "line": 5,
                     },
                   },
                   "statements": Array [
@@ -4040,15 +4040,15 @@ Array [
               },
             ],
             "thenBranch": Block {
-              "startingLocation": Object {
+              "location": Object {
                 "end": Object {
-                  "column": 25,
-                  "line": 4,
+                  "column": 16,
+                  "line": 5,
                 },
                 "file": "",
                 "start": Object {
-                  "column": 20,
-                  "line": 4,
+                  "column": 26,
+                  "line": 3,
                 },
               },
               "statements": Array [
@@ -4254,14 +4254,14 @@ Array [
     "elseBranch": undefined,
     "elseIfs": Array [],
     "thenBranch": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
-          "column": 28,
+          "column": 35,
           "line": 2,
         },
         "file": "",
         "start": Object {
-          "column": 22,
+          "column": 21,
           "line": 2,
         },
       },

--- a/test/parser/controlFlow/__snapshots__/While.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/While.test.js.snap
@@ -4,11 +4,12 @@ exports[`parser while statements while with exit 1`] = `
 Array [
   While {
     "body": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,
@@ -133,11 +134,12 @@ exports[`parser while statements while without exit 1`] = `
 Array [
   While {
     "body": Block {
-      "startingLocation": Object {
+      "location": Object {
         "end": Object {
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,

--- a/test/parser/expression/__snapshots__/AssociativeArrayLiterals.test.js.snap
+++ b/test/parser/expression/__snapshots__/AssociativeArrayLiterals.test.js.snap
@@ -148,11 +148,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,

--- a/test/parser/expression/__snapshots__/Call.test.js.snap
+++ b/test/parser/expression/__snapshots__/Call.test.js.snap
@@ -128,13 +128,13 @@ Array [
       "body": Block {
         "location": Object {
           "end": Object {
-            "column": 22,
-            "line": 4,
+            "column": 12,
+            "line": 5,
           },
           "file": "",
           "start": Object {
-            "column": 16,
-            "line": 4,
+            "column": 29,
+            "line": 2,
           },
         },
         "statements": Array [
@@ -255,13 +255,13 @@ Array [
       "body": Block {
         "location": Object {
           "end": Object {
-            "column": 19,
+            "column": 12,
             "line": 7,
           },
           "file": "",
           "start": Object {
-            "column": 12,
-            "line": 7,
+            "column": 29,
+            "line": 6,
           },
         },
         "statements": Array [],

--- a/test/parser/expression/__snapshots__/Call.test.js.snap
+++ b/test/parser/expression/__snapshots__/Call.test.js.snap
@@ -126,15 +126,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 22,
-            "line": 3,
+            "column": 12,
+            "line": 4,
           },
           "file": "",
           "start": Object {
-            "column": 16,
-            "line": 3,
+            "column": 29,
+            "line": 2,
           },
         },
         "statements": Array [
@@ -253,15 +253,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 19,
+            "column": 12,
             "line": 6,
           },
           "file": "",
           "start": Object {
-            "column": 12,
-            "line": 6,
+            "column": 29,
+            "line": 5,
           },
         },
         "statements": Array [],
@@ -329,15 +329,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 22,
-            "line": 3,
+            "column": 12,
+            "line": 4,
           },
           "file": "",
           "start": Object {
-            "column": 16,
-            "line": 3,
+            "column": 29,
+            "line": 2,
           },
         },
         "statements": Array [],
@@ -400,15 +400,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 19,
+            "column": 12,
             "line": 6,
           },
           "file": "",
           "start": Object {
-            "column": 12,
-            "line": 6,
+            "column": 29,
+            "line": 5,
           },
         },
         "statements": Array [],

--- a/test/parser/expression/__snapshots__/Function.test.js.snap
+++ b/test/parser/expression/__snapshots__/Function.test.js.snap
@@ -39,11 +39,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -168,11 +169,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -472,11 +474,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -651,11 +654,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -871,11 +875,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -1114,11 +1119,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -1204,11 +1210,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -1333,11 +1340,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -1423,11 +1431,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -1513,11 +1522,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -1642,11 +1652,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -1946,11 +1957,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -2125,11 +2137,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -2345,11 +2358,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -2588,11 +2602,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -2685,11 +2700,12 @@ Array [
       "args": Array [
         Function {
           "body": Block {
-            "startingLocation": Object {
+            "location": Object {
               "end": Object {
                 "column": -9,
                 "line": -9,
               },
+              "file": undefined,
               "start": Object {
                 "column": -9,
                 "line": -9,

--- a/test/parser/statement/Block.test.js
+++ b/test/parser/statement/Block.test.js
@@ -1,0 +1,91 @@
+const brs = require("brs");
+const { Lexeme } = brs.lexer;
+const { BrsString, Int32 } = brs.types;
+
+const { token, identifier, EOF } = require("../ParserTests");
+
+describe("block statements", () => {
+    it("includes surrounding whitespace for function body", () => {
+        const { tokens } = brs.lexer.Lexer.scan(`
+            sub Main()
+                age = 1
+            end sub
+        `);
+        const { statements, errors } = brs.parser.Parser.parse(tokens);
+        expect(errors.length).toEqual(0);
+
+        let blockLocation = statements[0].func.body.location;
+        console.log(blockLocation);
+        //the block location should begin immediately following `sub Main()`, and end immediately preceeding the first character of `end sub`
+        expect(blockLocation).toEqual({
+            file: "",
+            start: { line: 2, column: 23 },
+            end: { line: 4, column: 12 },
+        });
+
+        expect(statements).toMatchSnapshot();
+    });
+
+    it("includes surrounding whitespace for if-elseif-else statements", () => {
+        const { tokens } = brs.lexer.Lexer.scan(`
+            sub Main()
+                if true then
+                    print "true"
+                else if true then
+                    print "true"
+                else
+                    print "true"
+                end if
+            end sub
+        `);
+        const { statements, errors } = brs.parser.Parser.parse(tokens);
+        expect(errors.length).toEqual(0);
+
+        const ifStatement = statements[0].func.body.statements[0];
+
+        const thenBlock = ifStatement.thenBranch;
+        expect(thenBlock.location).toEqual({
+            file: "",
+            start: { line: 3, column: 29 },
+            end: { line: 5, column: 16 },
+        });
+
+        const elseIfBlock = ifStatement.elseIfs[0].thenBranch;
+        expect(elseIfBlock.location).toEqual({
+            file: "",
+            start: { line: 5, column: 34 },
+            end: { line: 7, column: 16 },
+        });
+
+        const elseBlock = ifStatement.elseBranch;
+        expect(elseBlock.location).toEqual({
+            file: "",
+            start: { line: 7, column: 21 },
+            end: { line: 9, column: 16 },
+        });
+
+        expect(statements).toMatchSnapshot();
+    });
+
+    it("includes surrounding whitespace for a for-loop body", () => {
+        const { tokens } = brs.lexer.Lexer.scan(`
+            sub Main()
+                For i = 0 To 10 Step 1
+                    print i
+                End For
+            end sub
+        `);
+        const { statements, errors } = brs.parser.Parser.parse(tokens);
+        expect(errors.length).toEqual(0);
+
+        let loopBlock = statements[0].func.body.statements[0].body;
+        //the block location should begin immediately following `step 1`, and end immediately preceeding the first character of `end for`
+        expect(loopBlock.location).toEqual({
+            file: "",
+            start: { line: 3, column: 39 },
+            end: { line: 5, column: 16 },
+        });
+
+        expect(statements).toMatchSnapshot();
+    });
+});

--- a/test/parser/statement/__snapshots__/Block.test.js.snap
+++ b/test/parser/statement/__snapshots__/Block.test.js.snap
@@ -1,5 +1,300 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`block statements includes surrounding whitespace for a for-loop body 1`] = `
+Array [
+  Function {
+    "func": Function {
+      "body": Block {
+        "location": Object {
+          "end": Object {
+            "column": 12,
+            "line": 6,
+          },
+          "file": "",
+          "start": Object {
+            "column": 23,
+            "line": 2,
+          },
+        },
+        "statements": Array [
+          For {
+            "body": Block {
+              "location": Object {
+                "end": Object {
+                  "column": 16,
+                  "line": 5,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 39,
+                  "line": 3,
+                },
+              },
+              "statements": Array [
+                Print {
+                  "expressions": Array [
+                    Variable {
+                      "name": Object {
+                        "isReserved": false,
+                        "kind": "Identifier",
+                        "literal": undefined,
+                        "location": Object {
+                          "end": Object {
+                            "column": 27,
+                            "line": 4,
+                          },
+                          "file": "",
+                          "start": Object {
+                            "column": 26,
+                            "line": 4,
+                          },
+                        },
+                        "text": "i",
+                      },
+                    },
+                  ],
+                  "tokens": Object {
+                    "print": Object {
+                      "isReserved": true,
+                      "kind": "Print",
+                      "literal": undefined,
+                      "location": Object {
+                        "end": Object {
+                          "column": 25,
+                          "line": 4,
+                        },
+                        "file": "",
+                        "start": Object {
+                          "column": 20,
+                          "line": 4,
+                        },
+                      },
+                      "text": "print",
+                    },
+                  },
+                },
+              ],
+            },
+            "counterDeclaration": Assignment {
+              "name": Object {
+                "isReserved": false,
+                "kind": "Identifier",
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 21,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 20,
+                    "line": 3,
+                  },
+                },
+                "text": "i",
+              },
+              "tokens": Object {
+                "equals": Object {
+                  "isReserved": false,
+                  "kind": "Equal",
+                  "literal": undefined,
+                  "location": Object {
+                    "end": Object {
+                      "column": 23,
+                      "line": 3,
+                    },
+                    "file": "",
+                    "start": Object {
+                      "column": 22,
+                      "line": 3,
+                    },
+                  },
+                  "text": "=",
+                },
+              },
+              "value": Literal {
+                "_location": Object {
+                  "end": Object {
+                    "column": 25,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 24,
+                    "line": 3,
+                  },
+                },
+                "value": Int32 {
+                  "kind": 3,
+                  "value": 0,
+                },
+              },
+            },
+            "finalValue": Literal {
+              "_location": Object {
+                "end": Object {
+                  "column": 31,
+                  "line": 3,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 29,
+                  "line": 3,
+                },
+              },
+              "value": Int32 {
+                "kind": 3,
+                "value": 10,
+              },
+            },
+            "increment": Literal {
+              "_location": Object {
+                "end": Object {
+                  "column": 38,
+                  "line": 3,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 37,
+                  "line": 3,
+                },
+              },
+              "value": Int32 {
+                "kind": 3,
+                "value": 1,
+              },
+            },
+            "tokens": Object {
+              "endFor": Object {
+                "isReserved": false,
+                "kind": "EndFor",
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 23,
+                    "line": 5,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 16,
+                    "line": 5,
+                  },
+                },
+                "text": "End For",
+              },
+              "for": Object {
+                "isReserved": true,
+                "kind": "For",
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 19,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 16,
+                    "line": 3,
+                  },
+                },
+                "text": "For",
+              },
+              "step": Object {
+                "isReserved": true,
+                "kind": "Step",
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 36,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 32,
+                    "line": 3,
+                  },
+                },
+                "text": "Step",
+              },
+              "to": Object {
+                "isReserved": true,
+                "kind": "To",
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 28,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 26,
+                    "line": 3,
+                  },
+                },
+                "text": "To",
+              },
+            },
+          },
+        ],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": "EndSub",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 19,
+            "line": 6,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 6,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": "Sub",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 15,
+            "line": 2,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 2,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": "Identifier",
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 20,
+          "line": 2,
+        },
+        "file": "",
+        "start": Object {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "text": "Main",
+    },
+  },
+]
+`;
+
 exports[`block statements includes surrounding whitespace for function body 1`] = `
 Array [
   Function {

--- a/test/parser/statement/__snapshots__/Block.test.js.snap
+++ b/test/parser/statement/__snapshots__/Block.test.js.snap
@@ -1,0 +1,471 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`block statements includes surrounding whitespace for function body 1`] = `
+Array [
+  Function {
+    "func": Function {
+      "body": Block {
+        "location": Object {
+          "end": Object {
+            "column": 12,
+            "line": 4,
+          },
+          "file": "",
+          "start": Object {
+            "column": 23,
+            "line": 2,
+          },
+        },
+        "statements": Array [
+          Assignment {
+            "name": Object {
+              "isReserved": false,
+              "kind": "Identifier",
+              "literal": undefined,
+              "location": Object {
+                "end": Object {
+                  "column": 19,
+                  "line": 3,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 16,
+                  "line": 3,
+                },
+              },
+              "text": "age",
+            },
+            "tokens": Object {
+              "equals": Object {
+                "isReserved": false,
+                "kind": "Equal",
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 21,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 20,
+                    "line": 3,
+                  },
+                },
+                "text": "=",
+              },
+            },
+            "value": Literal {
+              "_location": Object {
+                "end": Object {
+                  "column": 23,
+                  "line": 3,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 22,
+                  "line": 3,
+                },
+              },
+              "value": Int32 {
+                "kind": 3,
+                "value": 1,
+              },
+            },
+          },
+        ],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": "EndSub",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 19,
+            "line": 4,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 4,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": "Sub",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 15,
+            "line": 2,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 2,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": "Identifier",
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 20,
+          "line": 2,
+        },
+        "file": "",
+        "start": Object {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "text": "Main",
+    },
+  },
+]
+`;
+
+exports[`block statements includes surrounding whitespace for if-elseif-else statements 1`] = `
+Array [
+  Function {
+    "func": Function {
+      "body": Block {
+        "location": Object {
+          "end": Object {
+            "column": 12,
+            "line": 10,
+          },
+          "file": "",
+          "start": Object {
+            "column": 23,
+            "line": 2,
+          },
+        },
+        "statements": Array [
+          If {
+            "condition": Literal {
+              "_location": Object {
+                "end": Object {
+                  "column": 23,
+                  "line": 3,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 19,
+                  "line": 3,
+                },
+              },
+              "value": BrsBoolean {
+                "kind": 1,
+                "value": true,
+              },
+            },
+            "elseBranch": Block {
+              "location": Object {
+                "end": Object {
+                  "column": 16,
+                  "line": 9,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 21,
+                  "line": 7,
+                },
+              },
+              "statements": Array [
+                Print {
+                  "expressions": Array [
+                    Literal {
+                      "_location": Object {
+                        "end": Object {
+                          "column": 32,
+                          "line": 8,
+                        },
+                        "file": "",
+                        "start": Object {
+                          "column": 26,
+                          "line": 8,
+                        },
+                      },
+                      "value": BrsString {
+                        "kind": 2,
+                        "value": "true",
+                      },
+                    },
+                  ],
+                  "tokens": Object {
+                    "print": Object {
+                      "isReserved": true,
+                      "kind": "Print",
+                      "literal": undefined,
+                      "location": Object {
+                        "end": Object {
+                          "column": 25,
+                          "line": 8,
+                        },
+                        "file": "",
+                        "start": Object {
+                          "column": 20,
+                          "line": 8,
+                        },
+                      },
+                      "text": "print",
+                    },
+                  },
+                },
+              ],
+            },
+            "elseIfs": Array [
+              Object {
+                "condition": Literal {
+                  "_location": Object {
+                    "end": Object {
+                      "column": 28,
+                      "line": 5,
+                    },
+                    "file": "",
+                    "start": Object {
+                      "column": 24,
+                      "line": 5,
+                    },
+                  },
+                  "value": BrsBoolean {
+                    "kind": 1,
+                    "value": true,
+                  },
+                },
+                "thenBranch": Block {
+                  "location": Object {
+                    "end": Object {
+                      "column": 16,
+                      "line": 7,
+                    },
+                    "file": "",
+                    "start": Object {
+                      "column": 34,
+                      "line": 5,
+                    },
+                  },
+                  "statements": Array [
+                    Print {
+                      "expressions": Array [
+                        Literal {
+                          "_location": Object {
+                            "end": Object {
+                              "column": 32,
+                              "line": 6,
+                            },
+                            "file": "",
+                            "start": Object {
+                              "column": 26,
+                              "line": 6,
+                            },
+                          },
+                          "value": BrsString {
+                            "kind": 2,
+                            "value": "true",
+                          },
+                        },
+                      ],
+                      "tokens": Object {
+                        "print": Object {
+                          "isReserved": true,
+                          "kind": "Print",
+                          "literal": undefined,
+                          "location": Object {
+                            "end": Object {
+                              "column": 25,
+                              "line": 6,
+                            },
+                            "file": "",
+                            "start": Object {
+                              "column": 20,
+                              "line": 6,
+                            },
+                          },
+                          "text": "print",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            "thenBranch": Block {
+              "location": Object {
+                "end": Object {
+                  "column": 16,
+                  "line": 5,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 29,
+                  "line": 3,
+                },
+              },
+              "statements": Array [
+                Print {
+                  "expressions": Array [
+                    Literal {
+                      "_location": Object {
+                        "end": Object {
+                          "column": 32,
+                          "line": 4,
+                        },
+                        "file": "",
+                        "start": Object {
+                          "column": 26,
+                          "line": 4,
+                        },
+                      },
+                      "value": BrsString {
+                        "kind": 2,
+                        "value": "true",
+                      },
+                    },
+                  ],
+                  "tokens": Object {
+                    "print": Object {
+                      "isReserved": true,
+                      "kind": "Print",
+                      "literal": undefined,
+                      "location": Object {
+                        "end": Object {
+                          "column": 25,
+                          "line": 4,
+                        },
+                        "file": "",
+                        "start": Object {
+                          "column": 20,
+                          "line": 4,
+                        },
+                      },
+                      "text": "print",
+                    },
+                  },
+                },
+              ],
+            },
+            "tokens": Object {
+              "elseIfs": Array [
+                Object {
+                  "isReserved": false,
+                  "kind": "ElseIf",
+                  "literal": undefined,
+                  "location": Object {
+                    "end": Object {
+                      "column": 23,
+                      "line": 5,
+                    },
+                    "file": "",
+                    "start": Object {
+                      "column": 16,
+                      "line": 5,
+                    },
+                  },
+                  "text": "else if",
+                },
+              ],
+              "endIf": undefined,
+              "if": Object {
+                "isReserved": true,
+                "kind": "If",
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 16,
+                    "line": 3,
+                  },
+                },
+                "text": "if",
+              },
+              "then": Object {
+                "isReserved": true,
+                "kind": "Identifier",
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 28,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 24,
+                    "line": 3,
+                  },
+                },
+                "text": "then",
+              },
+            },
+          },
+        ],
+      },
+      "end": Object {
+        "isReserved": false,
+        "kind": "EndSub",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 19,
+            "line": 10,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 10,
+          },
+        },
+        "text": "end sub",
+      },
+      "keyword": Object {
+        "isReserved": true,
+        "kind": "Sub",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 15,
+            "line": 2,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 2,
+          },
+        },
+        "text": "sub",
+      },
+      "parameters": Array [],
+      "returns": 10,
+    },
+    "name": Object {
+      "isReserved": false,
+      "kind": "Identifier",
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": 20,
+          "line": 2,
+        },
+        "file": "",
+        "start": Object {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "text": "Main",
+    },
+  },
+]
+`;

--- a/test/parser/statement/__snapshots__/Function.test.js.snap
+++ b/test/parser/statement/__snapshots__/Function.test.js.snap
@@ -12,15 +12,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 26,
-              "line": 3,
+              "column": 16,
+              "line": 4,
             },
             "file": "",
             "start": Object {
-              "column": 20,
-              "line": 3,
+              "column": 39,
+              "line": 2,
             },
           },
           "statements": Array [
@@ -122,15 +122,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 26,
-              "line": 7,
+              "column": 16,
+              "line": 8,
             },
             "file": "",
             "start": Object {
-              "column": 20,
-              "line": 7,
+              "column": 40,
+              "line": 6,
             },
           },
           "statements": Array [
@@ -232,15 +232,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 26,
-              "line": 11,
+              "column": 16,
+              "line": 12,
             },
             "file": "",
             "start": Object {
-              "column": 20,
-              "line": 11,
+              "column": 38,
+              "line": 10,
             },
           },
           "statements": Array [
@@ -342,15 +342,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 26,
-              "line": 15,
+              "column": 16,
+              "line": 16,
             },
             "file": "",
             "start": Object {
-              "column": 20,
-              "line": 15,
+              "column": 39,
+              "line": 14,
             },
           },
           "statements": Array [
@@ -458,11 +458,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -744,11 +745,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -905,11 +907,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -1064,11 +1067,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -1289,11 +1293,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -1361,11 +1366,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -1472,11 +1478,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -1548,15 +1555,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 25,
-              "line": 3,
+              "column": 16,
+              "line": 4,
             },
             "file": "",
             "start": Object {
-              "column": 20,
-              "line": 3,
+              "column": 32,
+              "line": 2,
             },
           },
           "statements": Array [
@@ -1660,15 +1667,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 23,
+              "column": 16,
               "line": 8,
             },
             "file": "",
             "start": Object {
-              "column": 16,
-              "line": 8,
+              "column": 34,
+              "line": 6,
             },
           },
           "statements": Array [],
@@ -1744,15 +1751,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 23,
+              "column": 16,
               "line": 3,
             },
             "file": "",
             "start": Object {
-              "column": 16,
-              "line": 3,
+              "column": 33,
+              "line": 2,
             },
           },
           "statements": Array [],
@@ -1815,15 +1822,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 23,
+              "column": 16,
               "line": 6,
             },
             "file": "",
             "start": Object {
-              "column": 16,
-              "line": 6,
+              "column": 34,
+              "line": 5,
             },
           },
           "statements": Array [],
@@ -1886,15 +1893,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 23,
+              "column": 16,
               "line": 9,
             },
             "file": "",
             "start": Object {
-              "column": 16,
-              "line": 9,
+              "column": 32,
+              "line": 8,
             },
           },
           "statements": Array [],
@@ -1957,15 +1964,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 23,
+              "column": 16,
               "line": 12,
             },
             "file": "",
             "start": Object {
-              "column": 16,
-              "line": 12,
+              "column": 33,
+              "line": 11,
             },
           },
           "statements": Array [],
@@ -2034,11 +2041,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -2106,11 +2114,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -2217,11 +2226,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -2503,11 +2513,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -2664,11 +2675,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -2823,11 +2835,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -3052,15 +3065,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 25,
-              "line": 3,
+              "column": 16,
+              "line": 4,
             },
             "file": "",
             "start": Object {
-              "column": 20,
-              "line": 3,
+              "column": 27,
+              "line": 2,
             },
           },
           "statements": Array [
@@ -3164,15 +3177,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 23,
+              "column": 16,
               "line": 8,
             },
             "file": "",
             "start": Object {
-              "column": 16,
-              "line": 8,
+              "column": 34,
+              "line": 6,
             },
           },
           "statements": Array [],

--- a/test/parser/statement/__snapshots__/Goto.test.js.snap
+++ b/test/parser/statement/__snapshots__/Goto.test.js.snap
@@ -5,15 +5,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 20,
-            "line": 4,
+            "column": 12,
+            "line": 6,
           },
           "file": "",
           "start": Object {
-            "column": 16,
-            "line": 4,
+            "column": 23,
+            "line": 2,
           },
         },
         "statements": Array [

--- a/test/parser/statement/__snapshots__/Increment.test.js.snap
+++ b/test/parser/statement/__snapshots__/Increment.test.js.snap
@@ -5,11 +5,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,

--- a/test/parser/statement/__snapshots__/LibraryStatement.test.js.snap
+++ b/test/parser/statement/__snapshots__/LibraryStatement.test.js.snap
@@ -9,15 +9,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 19,
+              "column": 12,
               "line": 3,
             },
             "file": "",
             "start": Object {
-              "column": 12,
-              "line": 3,
+              "column": 23,
+              "line": 2,
             },
           },
           "statements": Array [],
@@ -131,15 +131,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 23,
-              "line": 3,
+              "column": 12,
+              "line": 4,
             },
             "file": "",
             "start": Object {
-              "column": 16,
-              "line": 3,
+              "column": 23,
+              "line": 2,
             },
           },
           "statements": Array [
@@ -252,15 +252,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 25,
-              "line": 3,
+              "column": 12,
+              "line": 6,
             },
             "file": "",
             "start": Object {
-              "column": 16,
-              "line": 3,
+              "column": 23,
+              "line": 2,
             },
           },
           "statements": Array [
@@ -431,15 +431,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 23,
-              "line": 3,
+              "column": 12,
+              "line": 4,
             },
             "file": "",
             "start": Object {
-              "column": 16,
-              "line": 3,
+              "column": 23,
+              "line": 2,
             },
           },
           "statements": Array [
@@ -590,15 +590,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 23,
-              "line": 4,
+              "column": 12,
+              "line": 5,
             },
             "file": "",
             "start": Object {
-              "column": 16,
-              "line": 4,
+              "column": 23,
+              "line": 3,
             },
           },
           "statements": Array [
@@ -751,15 +751,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 19,
+              "column": 12,
               "line": 4,
             },
             "file": "",
             "start": Object {
-              "column": 12,
-              "line": 4,
+              "column": 23,
+              "line": 3,
             },
           },
           "statements": Array [],
@@ -871,15 +871,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 19,
+              "column": 12,
               "line": 4,
             },
             "file": "",
             "start": Object {
-              "column": 12,
-              "line": 4,
+              "column": 23,
+              "line": 3,
             },
           },
           "statements": Array [],
@@ -1032,15 +1032,15 @@ Object {
     Function {
       "func": Function {
         "body": Block {
-          "startingLocation": Object {
+          "location": Object {
             "end": Object {
-              "column": 19,
+              "column": 12,
               "line": 4,
             },
             "file": "",
             "start": Object {
-              "column": 12,
-              "line": 4,
+              "column": 23,
+              "line": 3,
             },
           },
           "statements": Array [],

--- a/test/parser/statement/__snapshots__/Misc.test.js.snap
+++ b/test/parser/statement/__snapshots__/Misc.test.js.snap
@@ -5,15 +5,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 26,
-            "line": 3,
+            "column": 16,
+            "line": 6,
           },
           "file": "",
           "start": Object {
-            "column": 20,
-            "line": 3,
+            "column": 27,
+            "line": 2,
           },
         },
         "statements": Array [
@@ -181,15 +181,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 23,
-            "line": 3,
+            "column": 16,
+            "line": 4,
           },
           "file": "",
           "start": Object {
-            "column": 20,
-            "line": 3,
+            "column": 27,
+            "line": 2,
           },
         },
         "statements": Array [
@@ -279,15 +279,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 23,
-            "line": 3,
+            "column": 16,
+            "line": 4,
           },
           "file": "",
           "start": Object {
-            "column": 20,
-            "line": 3,
+            "column": 27,
+            "line": 2,
           },
         },
         "statements": Array [
@@ -411,15 +411,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 22,
-            "line": 3,
+            "column": 12,
+            "line": 56,
           },
           "file": "",
           "start": Object {
-            "column": 16,
-            "line": 3,
+            "column": 23,
+            "line": 2,
           },
         },
         "statements": Array [
@@ -3387,15 +3387,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 22,
-            "line": 3,
+            "column": 12,
+            "line": 11,
           },
           "file": "",
           "start": Object {
-            "column": 16,
-            "line": 3,
+            "column": 23,
+            "line": 2,
           },
         },
         "statements": Array [

--- a/test/parser/statement/__snapshots__/ReturnStatement.test.js.snap
+++ b/test/parser/statement/__snapshots__/ReturnStatement.test.js.snap
@@ -5,11 +5,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -135,11 +136,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -235,11 +237,12 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,

--- a/test/parser/statement/__snapshots__/Set.test.js.snap
+++ b/test/parser/statement/__snapshots__/Set.test.js.snap
@@ -198,11 +198,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,
@@ -506,11 +507,12 @@ Array [
     },
     "value": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
             "column": -9,
             "line": -9,
           },
+          "file": undefined,
           "start": Object {
             "column": -9,
             "line": -9,

--- a/test/parser/statement/__snapshots__/Stop.test.js.snap
+++ b/test/parser/statement/__snapshots__/Stop.test.js.snap
@@ -5,15 +5,15 @@ Array [
   Function {
     "func": Function {
       "body": Block {
-        "startingLocation": Object {
+        "location": Object {
           "end": Object {
-            "column": 25,
-            "line": 3,
+            "column": 12,
+            "line": 7,
           },
           "file": "",
           "start": Object {
-            "column": 16,
-            "line": 3,
+            "column": 23,
+            "line": 2,
           },
         },
         "statements": Array [


### PR DESCRIPTION
Updates `Stmt.Block` locations to include surrounding whitespace, and renamed `startingLocation` to `location`. 

Fixes #159