### PR TITLE
feat(stdlib): Implement global MatchFiles function

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "long": "^3.2.0",
     "luxon": "^1.8.3",
     "memory-fs": "^0.4.1",
+    "nanomatch": "^1.2.13",
     "p-settle": "^2.1.0"
   },
   "devDependencies": {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+// `nanomatch` unfortunately doesn't provide it doesn't provide its own types, there are none in DefinitelyTyped either
+// such a generic declaration works for now, but should be improved in the future
+declare module "nanomatch";

--- a/src/stdlib/File.ts
+++ b/src/stdlib/File.ts
@@ -244,6 +244,7 @@ export const WriteAsciiFile = new Callable("WriteAsciiFile", {
     },
 });
 
+/** Searches a directory for filenames that match a certain pattern. */
 export const MatchFiles = new Callable("MatchFiles", {
     signature: {
         args: [
@@ -269,7 +270,10 @@ export const MatchFiles = new Callable("MatchFiles", {
                 nonegate: true,
             });
 
-            return new RoArray(matchedFiles || []);
+            matchedFiles = (matchedFiles || []).map((match: string) => new BrsString(match));
+
+            // TODO: replace with RoList when that's implemented
+            return new RoArray(matchedFiles);
         } catch (err) {
             // TODO: replace with RoList when that's implemented
             return new RoArray([]);

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -31,6 +31,7 @@ describe("end to end standard libary", () => {
             "true",
             "false",
             "<Component: roArray> =\n[\n    test_backup.txt\n]",
+            "true",
         ]);
     });
 

--- a/test/e2e/resources/stdlib/files.brs
+++ b/test/e2e/resources/stdlib/files.brs
@@ -8,3 +8,6 @@ print DeleteDirectory("tmp:///test_dir/some_no_exist_sub") ' bad delete
 print DeleteDirectory("tmp:///test_dir") ' good delete
 print FormatDrive("does not matter", "will always fail") ' always fail
 print ListDir("tmp:///") 'what's left?
+
+stdlibTestFiles = MatchFiles("pkg:/test/e2e/resources/stdlib/", "*.brs")
+print stdlibTestFiles.count() > 0

--- a/test/stdlib/File.test.js
+++ b/test/stdlib/File.test.js
@@ -8,12 +8,16 @@ const {
     FormatDrive,
     ReadAsciiFile,
     WriteAsciiFile,
+    MatchFiles,
     getPath,
     getVolumeByPath,
 } = require("../../lib/stdlib/index");
 const { Interpreter } = require("../../lib/interpreter");
 const brs = require("brs");
-const { BrsString } = brs.types;
+const { BrsString, RoArray } = brs.types;
+
+const fs = require("fs");
+jest.mock("fs");
 
 let interpreter;
 
@@ -229,6 +233,123 @@ describe("global file I/O functions", () => {
             expect(interpreter.temporaryVolume.readFileSync("/hello.txt").toString()).toEqual(
                 "test contents"
             );
+        });
+    });
+
+    describe("MatchFiles", () => {
+        afterEach(() => {
+            fs.readdirSync.mockRestore();
+        });
+
+        it("returns an empty array for unrecognized paths", () => {
+            let result = MatchFiles.call(
+                interpreter,
+                new BrsString("cat:/kitten.cute"),
+                new BrsString("*")
+            );
+            expect(result).toBeInstanceOf(RoArray);
+            expect(result.elements).toEqual([]);
+        });
+
+        it("returns an empty array for non-existent directories", () => {
+            fs.readdirSync.mockImplementation(() => {
+                throw new Error("directory not found");
+            });
+
+            let result = MatchFiles.call(
+                interpreter,
+                new BrsString("pkg:/does-not-exist"),
+                new BrsString("*")
+            );
+            expect(result).toBeInstanceOf(RoArray);
+            expect(result.elements).toEqual([]);
+        });
+
+        describe("patterns", () => {
+            beforeEach(() => {
+                fs.readdirSync.mockImplementation(() => [
+                    "foo.brs",
+                    "bar.brs",
+                    "baz.brs",
+                    "car.brs",
+                    "directory",
+                    "b*a?d n\\a[me",
+                ]);
+            });
+
+            test("empty patterns", () => {
+                let result = MatchFiles.call(
+                    interpreter,
+                    new BrsString("pkg:/source"),
+                    new BrsString("")
+                );
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([]);
+            });
+
+            test("* matches 0 or more characters", () => {
+                let result = MatchFiles.call(
+                    interpreter,
+                    new BrsString("pkg:/source"),
+                    new BrsString("*.brs")
+                );
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([
+                    new BrsString("foo.brs"),
+                    new BrsString("bar.brs"),
+                    new BrsString("baz.brs"),
+                    new BrsString("car.brs"),
+                ]);
+            });
+
+            test("? matches a single character", () => {
+                let result = MatchFiles.call(
+                    interpreter,
+                    new BrsString("pkg:/source"),
+                    new BrsString("ba?.brs")
+                );
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([
+                    new BrsString("bar.brs"),
+                    new BrsString("baz.brs"),
+                ]);
+            });
+
+            test("character classes in […]", () => {
+                let result = MatchFiles.call(
+                    interpreter,
+                    new BrsString("pkg:/source"),
+                    new BrsString("[a-c]ar.brs")
+                );
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([
+                    new BrsString("bar.brs"),
+                    new BrsString("car.brs"),
+                ]);
+            });
+
+            test("character class negation with [^…]", () => {
+                let result = MatchFiles.call(
+                    interpreter,
+                    new BrsString("pkg:/source"),
+                    new BrsString("[^d-zD-Z]ar.brs")
+                );
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([
+                    new BrsString("bar.brs"),
+                    new BrsString("car.brs"),
+                ]);
+            });
+
+            test("escaped special characters", () => {
+                let result = MatchFiles.call(
+                    interpreter,
+                    new BrsString("pkg:/source"),
+                    new BrsString(String.raw`*\**\?*\\*\[*`)
+                );
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([new BrsString("b*a?d n\\a[me")]);
+            });
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2820,7 +2820,7 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
-nanomatch@^1.2.9:
+nanomatch@^1.2.13, nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
   integrity sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==


### PR DESCRIPTION
`MatchFiles` is a pretty interesting function, in that it (combined with the global `Run` implemented in #149) allow for some _very_ dynamic execution patterns!  RBI supports it, so now we do too.

fixes #107 