### PR TITLE
Implement if sg node children

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -16,6 +16,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     readonly kind = ValueKind.Object;
     elements = new Map<string, BrsType>();
     private fields = new Map<string, Field>();
+    private children = new Array<RoSGNode>();
 
     constructor(elements: AAMember[], readonly type: string = "Node") {
         super("roSGNode");
@@ -34,6 +35,9 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             this.keys,
             this.items,
             this.lookup,
+            //ifSGNodeChildren
+            this.appendchild,
+            this.getchildcount,
         ]);
     }
 
@@ -211,6 +215,35 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         impl: (interpreter: Interpreter, key: BrsString) => {
             let lKey = key.value.toLowerCase();
             return this.get(new BrsString(lKey));
+        },
+    });
+
+    private getchildcount = new Callable("getchildcount", {
+        signature: {
+            args: [],
+            returns: ValueKind.Int32,
+        },
+        impl: (interpreter: Interpreter) => {
+            return new Int32(this.children.length);
+        },
+    });
+
+    private appendchild = new Callable("appendchild", {
+        signature: {
+            args: [new StdlibArgument("child", ValueKind.Dynamic)],
+            returns: ValueKind.Boolean,
+        },
+        impl: (interpreter: Interpreter, child: BrsType) => {
+            for (let childNode of this.children) {
+                if (childNode === child) {
+                    return BrsBoolean.True;
+                }
+            }
+            if (child instanceof RoSGNode) {
+                this.children.push(child);
+                return BrsBoolean.True;
+            }
+            return BrsBoolean.False;
         },
     });
 }

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -42,6 +42,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             this.getchildren,
             this.removechild,
             this.getparent,
+            this.createchild,
         ]);
     }
 
@@ -332,6 +333,23 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
         impl: (interpreter: Interpreter) => {
             return this.parent;
+        },
+    });
+
+    /* Creates a child node of type nodeType, and adds the new node to the end of the
+    subject node list of children */
+    private createchild = new Callable("createchild", {
+        signature: {
+            args: [new StdlibArgument("nodetype", ValueKind.String)],
+            returns: ValueKind.Object,
+        },
+        impl: (interpreter: Interpreter, nodetype: BrsString) => {
+            // currently we can't create a custom subclass object of roSGNode,
+            // so we'll always create generic RoSGNode object as child
+            var child = new RoSGNode([]);
+            this.children.push(child);
+            child.setParent(this);
+            return child;
         },
     });
 }

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -282,7 +282,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             let childrenSize = this.children.length;
             if (numChildrenValue <= -1 && indexValue === 0) {
                 //short hand to return all children
-                return new RoArray(this.children);
+                return new RoArray(this.children.slice());
             } else if (numChildrenValue <= 0 || indexValue < 0 || indexValue > childrenSize - 1) {
                 //these never return any children
                 return new RoArray([]);
@@ -346,9 +346,11 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         impl: (interpreter: Interpreter, nodetype: BrsString) => {
             // currently we can't create a custom subclass object of roSGNode,
             // so we'll always create generic RoSGNode object as child
-            var child = new RoSGNode([]);
-            this.children.push(child);
-            child.setParent(this);
+            var child = createNodeByType(nodetype);
+            if (child instanceof RoSGNode) {
+                this.children.push(child);
+                child.setParent(this);
+            }
             return child;
         },
     });

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -280,7 +280,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             let numChildrenValue = num_children.getValue();
             let indexValue = index.getValue();
             let childrenSize = this.children.length;
-            if (numChildrenValue <= -1 && indexValue == 0) {
+            if (numChildrenValue <= -1 && indexValue === 0) {
                 //short hand to return all children
                 return new RoArray(this.children);
             } else if (numChildrenValue <= 0 || indexValue < 0 || indexValue > childrenSize - 1) {

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -283,7 +283,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             if (numChildrenValue <= -1 && indexValue === 0) {
                 //short hand to return all children
                 return new RoArray(this.children.slice());
-            } else if (numChildrenValue <= 0 || indexValue < 0 || indexValue > childrenSize - 1) {
+            } else if (numChildrenValue <= 0 || indexValue < 0 || indexValue >= childrenSize) {
                 //these never return any children
                 return new RoArray([]);
             } else {
@@ -308,7 +308,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         impl: (interpreter: Interpreter, child: BrsType) => {
             var spliceIndex = -1;
             if (child instanceof RoSGNode) {
-                for (var i = 0; i < this.children.length; i++) {
+                for (let i = 0; i < this.children.length; i++) {
                     let childNode = this.children[i];
                     if (childNode === child) {
                         spliceIndex = i;
@@ -319,9 +319,8 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                     this.children.splice(spliceIndex, 1);
                 }
                 return BrsBoolean.True;
-            } else {
-                return BrsBoolean.False;
             }
+            return BrsBoolean.False;
         },
     });
     /* If the subject node has been added to a parent node list of children,

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -17,6 +17,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     elements = new Map<string, BrsType>();
     private fields = new Map<string, Field>();
     private children = new Array<RoSGNode>();
+    private parent: RoSGNode | BrsInvalid = BrsInvalid.Instance;
 
     constructor(elements: AAMember[], readonly type: string = "Node") {
         super("roSGNode");
@@ -40,6 +41,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             this.getchildcount,
             this.getchildren,
             this.removechild,
+            this.getparent,
         ]);
     }
 
@@ -106,6 +108,14 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         }
         this.elements.set(index.value.toLowerCase(), value);
         return BrsInvalid.Instance;
+    }
+
+    setParent(parent: RoSGNode) {
+        this.parent = parent;
+    }
+
+    removeParent() {
+        this.parent = BrsInvalid.Instance;
     }
 
     /** Removes all elements from the node */
@@ -247,6 +257,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             }
             if (child instanceof RoSGNode) {
                 this.children.push(child);
+                child.setParent(this);
                 return BrsBoolean.True;
             }
             return BrsBoolean.False;
@@ -300,6 +311,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                     let childNode = this.children[i];
                     if (childNode === child) {
                         spliceIndex = i;
+                        child.removeParent();
                     }
                 }
                 if (spliceIndex >= 0) {
@@ -309,6 +321,17 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             } else {
                 return BrsBoolean.False;
             }
+        },
+    });
+    /* If the subject node has been added to a parent node list of children,
+    return the parent node, otherwise return invalid.*/
+    private getparent = new Callable("getparent", {
+        signature: {
+            args: [],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (interpreter: Interpreter) => {
+            return this.parent;
         },
     });
 }

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -251,12 +251,10 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             returns: ValueKind.Boolean,
         },
         impl: (interpreter: Interpreter, child: BrsType) => {
-            for (let childNode of this.children) {
-                if (childNode === child) {
+            if (child instanceof RoSGNode) {
+                if (this.children.includes(child)) {
                     return BrsBoolean.True;
                 }
-            }
-            if (child instanceof RoSGNode) {
                 this.children.push(child);
                 child.setParent(this);
                 return BrsBoolean.True;
@@ -288,8 +286,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                 return new RoArray([]);
             } else {
                 //only valid cases
-                let endSliceIndex = Math.min(indexValue + numChildrenValue, childrenSize);
-                return new RoArray(this.children.slice(indexValue, endSliceIndex));
+                return new RoArray(this.children.slice(indexValue, indexValue + numChildrenValue));
             }
 
             return new RoArray([]);
@@ -306,16 +303,10 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             returns: ValueKind.Boolean,
         },
         impl: (interpreter: Interpreter, child: BrsType) => {
-            var spliceIndex = -1;
             if (child instanceof RoSGNode) {
-                for (let i = 0; i < this.children.length; i++) {
-                    let childNode = this.children[i];
-                    if (childNode === child) {
-                        spliceIndex = i;
-                        child.removeParent();
-                    }
-                }
+                let spliceIndex = this.children.indexOf(child);
                 if (spliceIndex >= 0) {
+                    child.removeParent();
                     this.children.splice(spliceIndex, 1);
                 }
                 return BrsBoolean.True;
@@ -345,7 +336,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         impl: (interpreter: Interpreter, nodetype: BrsString) => {
             // currently we can't create a custom subclass object of roSGNode,
             // so we'll always create generic RoSGNode object as child
-            var child = createNodeByType(nodetype);
+            let child = createNodeByType(nodetype);
             if (child instanceof RoSGNode) {
                 this.children.push(child);
                 child.setParent(this);

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -38,6 +38,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             //ifSGNodeChildren
             this.appendchild,
             this.getchildcount,
+            this.getchildren,
         ]);
     }
 
@@ -244,6 +245,34 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                 return BrsBoolean.True;
             }
             return BrsBoolean.False;
+        },
+    });
+
+    private getchildren = new Callable("getchildren", {
+        signature: {
+            args: [
+                new StdlibArgument("num_children", ValueKind.Int32),
+                new StdlibArgument("index", ValueKind.Int32),
+            ],
+            returns: ValueKind.Object,
+        },
+        impl: (interpreter: Interpreter, num_children: Int32, index: Int32) => {
+            let numChildrenValue = num_children.getValue();
+            let indexValue = index.getValue();
+            let childrenSize = this.children.length;
+            if (numChildrenValue <= -1 && indexValue == 0) {
+                //short hand to return all children
+                return new RoArray(this.children);
+            } else if (numChildrenValue <= 0 || indexValue < 0 || indexValue > childrenSize - 1) {
+                //these never return any children
+                return new RoArray([]);
+            } else {
+                //only valid cases
+                let endSliceIndex = Math.min(indexValue + numChildrenValue, childrenSize);
+                return new RoArray(this.children.slice(indexValue, endSliceIndex));
+            }
+
+            return new RoArray([]);
         },
     });
 }

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -39,6 +39,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             this.appendchild,
             this.getchildcount,
             this.getchildren,
+            this.removechild,
         ]);
     }
 
@@ -219,6 +220,8 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
     });
 
+    /* Return the current number of children in the subject node list of children.
+    This is always a non-negative number. */
     private getchildcount = new Callable("getchildcount", {
         signature: {
             args: [],
@@ -229,6 +232,8 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
     });
 
+    /* Adds a child node to the end of the subject node list of children so that it is
+    traversed last (of those children) during render. */
     private appendchild = new Callable("appendchild", {
         signature: {
             args: [new StdlibArgument("child", ValueKind.Dynamic)],
@@ -248,6 +253,9 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
     });
 
+    /* Retrieves the number of child nodes specified by num_children from the subject
+    node, starting at the position specified by index. Returns an array of the child nodes
+    retrieved. If num_children is -1, return all the children. */
     private getchildren = new Callable("getchildren", {
         signature: {
             args: [
@@ -273,6 +281,34 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             }
 
             return new RoArray([]);
+        },
+    });
+
+    /* Finds a child node in the subject node list of children, and if found,
+    remove it from the list of children. The match is made on the basis of actual
+    object identity, that is, the value of the pointer to the child node.
+    return false if trying to remove anything that's not a node */
+    private removechild = new Callable("removechild", {
+        signature: {
+            args: [new StdlibArgument("child", ValueKind.Dynamic)],
+            returns: ValueKind.Boolean,
+        },
+        impl: (interpreter: Interpreter, child: BrsType) => {
+            var spliceIndex = -1;
+            if (child instanceof RoSGNode) {
+                for (var i = 0; i < this.children.length; i++) {
+                    let childNode = this.children[i];
+                    if (childNode === child) {
+                        spliceIndex = i;
+                    }
+                }
+                if (spliceIndex >= 0) {
+                    this.children.splice(spliceIndex, 1);
+                }
+                return BrsBoolean.True;
+            } else {
+                return BrsBoolean.False;
+            }
         },
     });
 }

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -16,7 +16,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     readonly kind = ValueKind.Object;
     elements = new Map<string, BrsType>();
     private fields = new Map<string, Field>();
-    private children = new Array<RoSGNode>();
+    private children: RoSGNode[] = [];
     private parent: RoSGNode | BrsInvalid = BrsInvalid.Instance;
 
     constructor(elements: AAMember[], readonly type: string = "Node") {

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -280,17 +280,20 @@ describe("RoSGNode", () => {
     });
 
     describe("ifSGNodeChildren", () => {
-        let interpreter;
+        let interpreter, parent, child1, child2, child3, child4;
 
         beforeEach(() => {
             interpreter = new Interpreter();
+            parent = new RoSGNode([{ name: new BrsString("parent"), value: new BrsString("1") }]);
+            child1 = new RoSGNode([{ name: new BrsString("child"), value: new BrsString("2") }]);
+            child2 = new RoSGNode([{ name: new BrsString("child"), value: new BrsString("3") }]);
+            child3 = new RoSGNode([{ name: new BrsString("child"), value: new BrsString("4") }]);
+            child4 = new RoSGNode([{ name: new BrsString("child"), value: new BrsString("5") }]);
         });
 
         describe("getchildcount", () => {
             it("returns the number of children", () => {
-                let node = new RoSGNode([]);
-
-                let getChildCount = node.getMethod("getchildcount");
+                let getChildCount = parent.getMethod("getchildcount");
                 expect(getChildCount).toBeTruthy();
 
                 let result = getChildCount.call(interpreter);
@@ -300,17 +303,10 @@ describe("RoSGNode", () => {
 
         describe("appendchild", () => {
             it("appends a child to the node", () => {
-                let parent = new RoSGNode([
-                    { name: new BrsString("parent"), value: new BrsString("1") },
-                ]);
-                let child = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("2") },
-                ]);
-
                 let appendChild = parent.getMethod("appendchild");
                 let getChildCount = parent.getMethod("getchildcount");
 
-                let result = appendChild.call(interpreter, child);
+                let result = appendChild.call(interpreter, child1);
                 let childCount = getChildCount.call(interpreter);
                 expect(result).toEqual(BrsBoolean.True);
                 expect(appendChild).toBeTruthy();
@@ -318,33 +314,23 @@ describe("RoSGNode", () => {
             });
 
             it("appends invalid to the node", () => {
-                let parent = new RoSGNode([
-                    { name: new BrsString("parent"), value: new BrsString("1") },
-                ]);
-                let child = BrsInvalid.Instance;
+                let invalidChild = BrsInvalid.Instance;
 
                 let appendChild = parent.getMethod("appendchild");
                 let getChildCount = parent.getMethod("getchildcount");
 
-                let result = appendChild.call(interpreter, child);
+                let result = appendChild.call(interpreter, invalidChild);
                 let childCount = getChildCount.call(interpreter);
                 expect(result).toEqual(BrsBoolean.False);
                 expect(childCount).toEqual(new Int32(0));
             });
 
             it("doesn't append the same node twice", () => {
-                let parent = new RoSGNode([
-                    { name: new BrsString("parent"), value: new BrsString("1") },
-                ]);
-                let child = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("2") },
-                ]);
-
                 let appendChild = parent.getMethod("appendchild");
                 let getChildCount = parent.getMethod("getchildcount");
 
-                let result = appendChild.call(interpreter, child);
-                appendChild.call(interpreter, child);
+                let result = appendChild.call(interpreter, child1);
+                appendChild.call(interpreter, child1);
                 let childCount = getChildCount.call(interpreter);
                 expect(result).toEqual(BrsBoolean.True);
                 expect(childCount).toEqual(new Int32(1));
@@ -353,10 +339,6 @@ describe("RoSGNode", () => {
 
         describe("getchildren", () => {
             it("get children of node without children", () => {
-                let parent = new RoSGNode([
-                    { name: new BrsString("parent"), value: new BrsString("1") },
-                ]);
-
                 let getChildren = parent.getMethod("getchildren");
                 let getChildCount = parent.getMethod("getchildcount");
 
@@ -369,19 +351,6 @@ describe("RoSGNode", () => {
             });
 
             it("get all children of node with children", () => {
-                let parent = new RoSGNode([
-                    { name: new BrsString("parent"), value: new BrsString("1") },
-                ]);
-                let child1 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("2") },
-                ]);
-                let child2 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("3") },
-                ]);
-                let child3 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("4") },
-                ]);
-
                 let getChildren = parent.getMethod("getchildren");
                 let getChildCount = parent.getMethod("getchildcount");
                 let appendChild = parent.getMethod("appendchild");
@@ -397,23 +366,7 @@ describe("RoSGNode", () => {
                 expect(result.elements).toEqual([child1, child2, child3]);
             });
 
-            it("get subset of children of node", () => {
-                let parent = new RoSGNode([
-                    { name: new BrsString("parent"), value: new BrsString("1") },
-                ]);
-                let child1 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("2") },
-                ]);
-                let child2 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("3") },
-                ]);
-                let child3 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("4") },
-                ]);
-                let child4 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("5") },
-                ]);
-
+            it("get last two children", () => {
                 let getChildren = parent.getMethod("getchildren");
                 let getChildCount = parent.getMethod("getchildcount");
                 let appendChild = parent.getMethod("appendchild");
@@ -429,21 +382,65 @@ describe("RoSGNode", () => {
                 expect(childCount).toEqual(new Int32(4));
                 expect(result).toBeInstanceOf(RoArray);
                 expect(result.elements).toEqual([child3, child4]);
+            });
+
+            it("pass in large child count", () => {
+                let getChildren = parent.getMethod("getchildren");
+                let getChildCount = parent.getMethod("getchildcount");
+                let appendChild = parent.getMethod("appendchild");
+
+                appendChild.call(interpreter, child1);
+                appendChild.call(interpreter, child2);
+                appendChild.call(interpreter, child3);
+                appendChild.call(interpreter, child4);
 
                 // pass in more children count than there are children, should just return 2 with offset of 2
                 let result1 = getChildren.call(interpreter, new Int32(20), new Int32(2));
                 expect(result1).toBeInstanceOf(RoArray);
                 expect(result1.elements).toEqual([child3, child4]);
+            });
+
+            it("pass in negative indices", () => {
+                let getChildren = parent.getMethod("getchildren");
+                let getChildCount = parent.getMethod("getchildcount");
+                let appendChild = parent.getMethod("appendchild");
+
+                appendChild.call(interpreter, child1);
+                appendChild.call(interpreter, child2);
+                appendChild.call(interpreter, child3);
+                appendChild.call(interpreter, child4);
 
                 // pass in negative indices
                 let result2 = getChildren.call(interpreter, new Int32(-10), new Int32(-50));
                 expect(result2).toBeInstanceOf(RoArray);
                 expect(result2.elements).toEqual([]);
+            });
+
+            it("pass in negative start index", () => {
+                let getChildren = parent.getMethod("getchildren");
+                let getChildCount = parent.getMethod("getchildcount");
+                let appendChild = parent.getMethod("appendchild");
+
+                appendChild.call(interpreter, child1);
+                appendChild.call(interpreter, child2);
+                appendChild.call(interpreter, child3);
+                appendChild.call(interpreter, child4);
 
                 // pass in just negative start index
                 let result3 = getChildren.call(interpreter, new Int32(5), new Int32(-50));
                 expect(result3).toBeInstanceOf(RoArray);
                 expect(result3.elements).toEqual([]);
+            });
+
+            it("get first 3 children", () => {
+                let getChildren = parent.getMethod("getchildren");
+                let getChildCount = parent.getMethod("getchildcount");
+                let appendChild = parent.getMethod("appendchild");
+
+                appendChild.call(interpreter, child1);
+                appendChild.call(interpreter, child2);
+                appendChild.call(interpreter, child3);
+                appendChild.call(interpreter, child4);
 
                 // get first 3 children
                 let result4 = getChildren.call(interpreter, new Int32(3), new Int32(0));
@@ -454,19 +451,6 @@ describe("RoSGNode", () => {
 
         describe("removechild", () => {
             it("remove a child node from parent", () => {
-                let parent = new RoSGNode([
-                    { name: new BrsString("parent"), value: new BrsString("1") },
-                ]);
-                let child1 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("2") },
-                ]);
-                let child2 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("3") },
-                ]);
-                let child3 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("4") },
-                ]);
-
                 let removeChild = parent.getMethod("removechild");
                 let getChildren = parent.getMethod("getchildren");
                 let getChildCount = parent.getMethod("getchildcount");
@@ -511,19 +495,6 @@ describe("RoSGNode", () => {
             });
 
             it("remove non-node things from parent", () => {
-                let parent = new RoSGNode([
-                    { name: new BrsString("parent"), value: new BrsString("1") },
-                ]);
-                let child1 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("2") },
-                ]);
-                let child2 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("3") },
-                ]);
-                let child3 = new RoSGNode([
-                    { name: new BrsString("child"), value: new BrsString("4") },
-                ]);
-
                 let removeChild = parent.getMethod("removechild");
                 let getChildren = parent.getMethod("getchildren");
                 let getChildCount = parent.getMethod("getchildcount");

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -296,8 +296,6 @@ describe("RoSGNode", () => {
                 let result = getChildCount.call(interpreter);
                 expect(result).toEqual(new Int32(0));
             });
-
-            //TODO: test when the node does have children
         });
 
         describe("appendchild", () => {

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -592,5 +592,21 @@ describe("RoSGNode", () => {
                 expect(parentNode2).toEqual(BrsInvalid.Instance);
             });
         });
+
+        describe("createchild", () => {
+            it("create generic roSGNode as child", () => {
+                let parent = new RoSGNode([
+                    { name: new BrsString("parent"), value: new BrsString("1") },
+                ]);
+
+                let createChild = parent.getMethod("createchild");
+                let getChildren = parent.getMethod("getchildren");
+
+                let childNode = createChild.call(interpreter, new BrsString("Node"));
+                let result = getChildren.call(interpreter, new Int32(-1), new Int32(0));
+                expect(createChild).toBeTruthy();
+                expect(result.elements[0]).toEqual(childNode);
+            });
+        });
     });
 });

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -546,5 +546,51 @@ describe("RoSGNode", () => {
                 expect(childCount).toEqual(new Int32(2));
             });
         });
+
+        describe("getparent", () => {
+            it("get parent of node", () => {
+                let parent = new RoSGNode([
+                    { name: new BrsString("parent"), value: new BrsString("1") },
+                ]);
+                let child1 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("2") },
+                ]);
+
+                let getParent = child1.getMethod("getparent");
+                let appendChild = parent.getMethod("appendchild");
+
+                appendChild.call(interpreter, child1);
+                let parentNode = getParent.call(interpreter);
+                expect(getParent).toBeTruthy();
+                expect(parentNode).toEqual(parent);
+            });
+
+            it("get parent of node without parent", () => {
+                let parent = new RoSGNode([
+                    { name: new BrsString("parent"), value: new BrsString("1") },
+                ]);
+                let child1 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("2") },
+                ]);
+
+                let getParent = child1.getMethod("getparent");
+                let appendChild = parent.getMethod("appendchild");
+                let removeChild = parent.getMethod("removechild");
+
+                // node should start without a parent
+                let parentNode = getParent.call(interpreter);
+                expect(parentNode).toEqual(BrsInvalid.Instance);
+
+                // appends a node as child
+                appendChild.call(interpreter, child1);
+                let parentNode1 = getParent.call(interpreter);
+                expect(parentNode1).toEqual(parent);
+
+                // remove parent from child again, should get invalid as parent
+                removeChild.call(interpreter, child1);
+                let parentNode2 = getParent.call(interpreter);
+                expect(parentNode2).toEqual(BrsInvalid.Instance);
+            });
+        });
     });
 });

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -352,5 +352,106 @@ describe("RoSGNode", () => {
                 expect(childCount).toEqual(new Int32(1));
             });
         });
+
+        describe("getchildren", () => {
+            it("get children of node without children", () => {
+                let parent = new RoSGNode([
+                    { name: new BrsString("parent"), value: new BrsString("1") },
+                ]);
+
+                let getChildren = parent.getMethod("getchildren");
+                let getChildCount = parent.getMethod("getchildcount");
+
+                let result = getChildren.call(interpreter, new Int32(-1), new Int32(0));
+                let childCount = getChildCount.call(interpreter);
+                expect(getChildren).toBeTruthy();
+                expect(childCount).toEqual(new Int32(0));
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([]);
+            });
+
+            it("get all children of node with children", () => {
+                let parent = new RoSGNode([
+                    { name: new BrsString("parent"), value: new BrsString("1") },
+                ]);
+                let child1 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("2") },
+                ]);
+                let child2 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("3") },
+                ]);
+                let child3 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("4") },
+                ]);
+
+                let getChildren = parent.getMethod("getchildren");
+                let getChildCount = parent.getMethod("getchildcount");
+                let appendChild = parent.getMethod("appendchild");
+
+                appendChild.call(interpreter, child1);
+                appendChild.call(interpreter, child2);
+                appendChild.call(interpreter, child3);
+
+                let result = getChildren.call(interpreter, new Int32(-1), new Int32(0));
+                let childCount = getChildCount.call(interpreter);
+                expect(childCount).toEqual(new Int32(3));
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([child1, child2, child3]);
+            });
+
+            it("get subset of children of node", () => {
+                let parent = new RoSGNode([
+                    { name: new BrsString("parent"), value: new BrsString("1") },
+                ]);
+                let child1 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("2") },
+                ]);
+                let child2 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("3") },
+                ]);
+                let child3 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("4") },
+                ]);
+                let child4 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("5") },
+                ]);
+
+                let getChildren = parent.getMethod("getchildren");
+                let getChildCount = parent.getMethod("getchildcount");
+                let appendChild = parent.getMethod("appendchild");
+
+                appendChild.call(interpreter, child1);
+                appendChild.call(interpreter, child2);
+                appendChild.call(interpreter, child3);
+                appendChild.call(interpreter, child4);
+
+                // get last 2 children
+                let result = getChildren.call(interpreter, new Int32(2), new Int32(2));
+                let childCount = getChildCount.call(interpreter);
+                expect(childCount).toEqual(new Int32(4));
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([child3, child4]);
+
+                // pass in more children count than there are children, should just return 2 with offset of 2
+                let result1 = getChildren.call(interpreter, new Int32(20), new Int32(2));
+                expect(result1).toBeInstanceOf(RoArray);
+                expect(result1.elements).toEqual([child3, child4]);
+
+                // pass in negative indices
+                let result2 = getChildren.call(interpreter, new Int32(-10), new Int32(-50));
+                expect(result2).toBeInstanceOf(RoArray);
+                expect(result2.elements).toEqual([]);
+
+                // pass in just negative start index
+                let result3 = getChildren.call(interpreter, new Int32(5), new Int32(-50));
+                expect(result3).toBeInstanceOf(RoArray);
+                expect(result3.elements).toEqual([]);
+
+                // get first 3 children
+                let result4 = getChildren.call(interpreter, new Int32(3), new Int32(0));
+                expect(result4).toBeInstanceOf(RoArray);
+                expect(result4.elements).toEqual([child1, child2, child3]);
+            });
+        });
     });
 });

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -453,5 +453,98 @@ describe("RoSGNode", () => {
                 expect(result4.elements).toEqual([child1, child2, child3]);
             });
         });
+
+        describe("removechild", () => {
+            it("remove a child node from parent", () => {
+                let parent = new RoSGNode([
+                    { name: new BrsString("parent"), value: new BrsString("1") },
+                ]);
+                let child1 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("2") },
+                ]);
+                let child2 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("3") },
+                ]);
+                let child3 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("4") },
+                ]);
+
+                let removeChild = parent.getMethod("removechild");
+                let getChildren = parent.getMethod("getchildren");
+                let getChildCount = parent.getMethod("getchildcount");
+                let appendChild = parent.getMethod("appendchild");
+
+                appendChild.call(interpreter, child1);
+                appendChild.call(interpreter, child2);
+                appendChild.call(interpreter, child3);
+
+                // remove child 2
+                removeChild.call(interpreter, child2);
+                let result = getChildren.call(interpreter, new Int32(-1), new Int32(0));
+                let childCount = getChildCount.call(interpreter);
+                expect(removeChild).toBeTruthy();
+                expect(childCount).toEqual(new Int32(2));
+                expect(result).toBeInstanceOf(RoArray);
+                expect(result.elements).toEqual([child1, child3]);
+
+                // remove child 3
+                removeChild.call(interpreter, child3);
+                let result1 = getChildren.call(interpreter, new Int32(-1), new Int32(0));
+                let childCount1 = getChildCount.call(interpreter);
+                expect(childCount1).toEqual(new Int32(1));
+                expect(result1).toBeInstanceOf(RoArray);
+                expect(result1.elements).toEqual([child1]);
+
+                // remove child 1
+                removeChild.call(interpreter, child1);
+                let result2 = getChildren.call(interpreter, new Int32(-1), new Int32(0));
+                let childCount2 = getChildCount.call(interpreter);
+                expect(childCount2).toEqual(new Int32(0));
+                expect(result2).toBeInstanceOf(RoArray);
+                expect(result2.elements).toEqual([]);
+
+                // try to remove child 1 again, but shouldn't do anything
+                removeChild.call(interpreter, child1);
+                let result3 = getChildren.call(interpreter, new Int32(-1), new Int32(0));
+                let childCount3 = getChildCount.call(interpreter);
+                expect(childCount3).toEqual(new Int32(0));
+                expect(result3).toBeInstanceOf(RoArray);
+                expect(result3.elements).toEqual([]);
+            });
+
+            it("remove non-node things from parent", () => {
+                let parent = new RoSGNode([
+                    { name: new BrsString("parent"), value: new BrsString("1") },
+                ]);
+                let child1 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("2") },
+                ]);
+                let child2 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("3") },
+                ]);
+                let child3 = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("4") },
+                ]);
+
+                let removeChild = parent.getMethod("removechild");
+                let getChildren = parent.getMethod("getchildren");
+                let getChildCount = parent.getMethod("getchildcount");
+                let appendChild = parent.getMethod("appendchild");
+
+                appendChild.call(interpreter, child1);
+                appendChild.call(interpreter, child2);
+                appendChild.call(interpreter, child3);
+
+                // only returns true if we are removing roSGNode type object
+                let result = removeChild.call(interpreter, child1);
+                expect(result).toEqual(BrsBoolean.True);
+                let result1 = removeChild.call(interpreter, new BrsString("some string"));
+                expect(result1).toEqual(BrsBoolean.False);
+                let result2 = removeChild.call(interpreter, new Int32(5));
+                expect(result2).toEqual(BrsBoolean.False);
+                let childCount = getChildCount.call(interpreter);
+                expect(childCount).toEqual(new Int32(2));
+            });
+        });
     });
 });

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -455,6 +455,7 @@ describe("RoSGNode", () => {
                 let getChildren = parent.getMethod("getchildren");
                 let getChildCount = parent.getMethod("getchildcount");
                 let appendChild = parent.getMethod("appendchild");
+                expect(removeChild).toBeTruthy();
 
                 appendChild.call(interpreter, child1);
                 appendChild.call(interpreter, child2);
@@ -464,7 +465,6 @@ describe("RoSGNode", () => {
                 removeChild.call(interpreter, child2);
                 let result = getChildren.call(interpreter, new Int32(-1), new Int32(0));
                 let childCount = getChildCount.call(interpreter);
-                expect(removeChild).toBeTruthy();
                 expect(childCount).toEqual(new Int32(2));
                 expect(result).toBeInstanceOf(RoArray);
                 expect(result.elements).toEqual([child1, child3]);

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -278,4 +278,79 @@ describe("RoSGNode", () => {
             });
         });
     });
+
+    describe("ifSGNodeChildren", () => {
+        let interpreter;
+
+        beforeEach(() => {
+            interpreter = new Interpreter();
+        });
+
+        describe("getchildcount", () => {
+            it("returns the number of children", () => {
+                let node = new RoSGNode([]);
+
+                let getChildCount = node.getMethod("getchildcount");
+                expect(getChildCount).toBeTruthy();
+
+                let result = getChildCount.call(interpreter);
+                expect(result).toEqual(new Int32(0));
+            });
+
+            //TODO: test when the node does have children
+        });
+
+        describe("appendchild", () => {
+            it("appends a child to the node", () => {
+                let parent = new RoSGNode([
+                    { name: new BrsString("parent"), value: new BrsString("1") },
+                ]);
+                let child = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("2") },
+                ]);
+
+                let appendChild = parent.getMethod("appendchild");
+                let getChildCount = parent.getMethod("getchildcount");
+
+                let result = appendChild.call(interpreter, child);
+                let childCount = getChildCount.call(interpreter);
+                expect(result).toEqual(BrsBoolean.True);
+                expect(appendChild).toBeTruthy();
+                expect(childCount).toEqual(new Int32(1));
+            });
+
+            it("appends invalid to the node", () => {
+                let parent = new RoSGNode([
+                    { name: new BrsString("parent"), value: new BrsString("1") },
+                ]);
+                let child = BrsInvalid.Instance;
+
+                let appendChild = parent.getMethod("appendchild");
+                let getChildCount = parent.getMethod("getchildcount");
+
+                let result = appendChild.call(interpreter, child);
+                let childCount = getChildCount.call(interpreter);
+                expect(result).toEqual(BrsBoolean.False);
+                expect(childCount).toEqual(new Int32(0));
+            });
+
+            it("doesn't append the same node twice", () => {
+                let parent = new RoSGNode([
+                    { name: new BrsString("parent"), value: new BrsString("1") },
+                ]);
+                let child = new RoSGNode([
+                    { name: new BrsString("child"), value: new BrsString("2") },
+                ]);
+
+                let appendChild = parent.getMethod("appendchild");
+                let getChildCount = parent.getMethod("getchildcount");
+
+                let result = appendChild.call(interpreter, child);
+                appendChild.call(interpreter, child);
+                let childCount = getChildCount.call(interpreter);
+                expect(result).toEqual(BrsBoolean.True);
+                expect(childCount).toEqual(new Int32(1));
+            });
+        });
+    });
 });

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -91,6 +91,21 @@ describe("end to end brightscript functions", () => {
             "true",
             "can empty itself: ",
             "true",
+            //ifNodeChildren tests
+            "parent child count: ",
+            "0",
+            "get same parent from child: ",
+            "true",
+            "parent child count: ",
+            "1",
+            "parent child count: ",
+            "2",
+            "parent child count: ",
+            "3",
+            "parent child count: ",
+            "2",
+            "children size: ",
+            "2",
         ]);
     });
 

--- a/test/e2e/resources/components/roSGNode.brs
+++ b/test/e2e/resources/components/roSGNode.brs
@@ -16,4 +16,22 @@ sub main()
 
     node1.clear()
     print "can empty itself: " node1.count() = 0                   ' => true
+
+    'ifNodeChildren tests
+    parentNode = createObject("roSGNode", "Node")
+    parentNode.id = "parent"
+    print "parent child count: " parentNode.getChildCount()        ' => 0
+    childNode = parentNode.createChild("Node")
+    testParent = childNode.getParent()
+    print "get same parent from child: " parentNode.id = testParent.id '=> true
+    print "parent child count: " parentNode.getChildCount()        ' => 1
+    childNode2 = createObject("roSGNode", "Node")
+    parentNode.appendChild(childNode2)
+    print "parent child count: " parentNode.getChildCount()        ' => 2
+    childNode3 = parentNode.createChild("Node")
+    print "parent child count: " parentNode.getChildCount()        ' => 3
+    parentNode.removeChild(childNode)
+    print "parent child count: " parentNode.getChildCount()        ' => 2
+    children = parentNode.getChildren(-1, 0)
+    print "children size: " children.count()                       ' => 2
 end sub


### PR DESCRIPTION
This PR implements 6 of the most used functions in `ifSGNodeChildren` interface:
- appendChild()
- getChildCount()
- getChildren()
- removeChild()
- getParent()
- createChild()