### PR TITLE
Implement ifSGNodeField interface

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -8,6 +8,7 @@ import { RoAssociativeArray } from "./RoAssociativeArray";
 import { RoArray } from "./RoArray";
 import { AAMember } from "./RoAssociativeArray";
 import { Float } from "../Float";
+import { Call } from "../../parser/Expression";
 
 class Field {
     // private callbacks;
@@ -42,6 +43,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             this.addfield,
             this.addfields,
             this.getfield,
+            this.removefield,
             this.setfield,
         ]);
     }
@@ -309,6 +311,22 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
         impl: (interpreter: Interpreter, fieldname: BrsString) => {
             return this.get(fieldname);
+        },
+    });
+
+    /** Removes the given field from the node */
+    private removefield = new Callable("removefield", {
+        signature: {
+            args: [new StdlibArgument("fieldname", ValueKind.String)],
+            returns: ValueKind.Boolean,
+        },
+        impl: (interpreter: Interpreter, fieldname: BrsString) => {
+            if (this.get(fieldname) !== BrsInvalid.Instance) {
+                this.elements.delete(fieldname.value);
+                this.fields.delete(fieldname.value);
+            }
+
+            return BrsBoolean.True;
         },
     });
 

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -12,7 +12,7 @@ import { Float } from "../Float";
 class Field {
     private type: string;
     private value: BrsType;
-    private observers: String[] = [];
+    private observers: string[] = [];
 
     constructor(value: BrsType, private alwaysNotify: boolean) {
         this.type = ValueKind.toString(value.kind);
@@ -244,8 +244,8 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             returns: ValueKind.Boolean,
         },
         impl: (interpreter: Interpreter, str: BrsString) => {
-            let deleted = this.fields.delete(str.value);
-            return BrsBoolean.from(deleted);
+            this.fields.delete(str.value);
+            return BrsBoolean.True; //RBI always returns true
         },
     });
 
@@ -361,10 +361,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         ) => {
             let defaultValue = this.getDefaultValue(type.value);
 
-            if (
-                defaultValue !== Uninitialized.Instance &&
-                this.get(fieldname) === BrsInvalid.Instance
-            ) {
+            if (defaultValue !== Uninitialized.Instance && !this.fields.has(fieldname.value)) {
                 this.set(fieldname, defaultValue, alwaysnotify.toBoolean());
             }
 
@@ -385,7 +382,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
             fields.getValue().forEach((value, key) => {
                 let fieldName = new BrsString(key);
-                if (this.get(fieldName) === BrsInvalid.Instance) {
+                if (!this.fields.has(key)) {
                     this.set(fieldName, value);
                 }
             });
@@ -431,11 +428,8 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             returns: ValueKind.Boolean,
         },
         impl: (interpreter: Interpreter, fieldname: BrsString) => {
-            if (this.get(fieldname) !== BrsInvalid.Instance) {
-                this.fields.delete(fieldname.value);
-            }
-
-            return BrsBoolean.True;
+            this.fields.delete(fieldname.value);
+            return BrsBoolean.True; //RBI always returns true
         },
     });
 
@@ -451,7 +445,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         impl: (interpreter: Interpreter, fieldname: BrsString, value: BrsType) => {
             let field = this.get(fieldname);
 
-            if (field === BrsInvalid.Instance) {
+            if (!this.fields.has(fieldname.value)) {
                 return BrsBoolean.False;
             }
 
@@ -477,8 +471,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
             fields.getValue().forEach((value, key) => {
                 let fieldName = new BrsString(key);
-                let field = this.get(fieldName);
-                if (field !== BrsInvalid.Instance) {
+                if (this.fields.has(key)) {
                     this.set(fieldName, value);
                 }
             });
@@ -501,8 +494,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
             aa.getValue().forEach((value, key) => {
                 let fieldName = new BrsString(key);
-                let field = this.get(fieldName);
-                if (field !== BrsInvalid.Instance) {
+                if (this.fields.has(key)) {
                     this.set(fieldName, value);
                 }
             });

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -46,7 +46,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             this.removefield,
             this.setfield,
             this.setfields,
-            //this.update
+            this.update,
         ]);
     }
 
@@ -358,7 +358,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
     });
 
-    /** Updates the value of multiple existing field only if the types match */
+    /** Updates the value of multiple existing field only if the types match. */
     private setfields = new Callable("setfields", {
         signature: {
             args: [new StdlibArgument("fields", ValueKind.Object)],
@@ -382,6 +382,34 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             });
 
             return BrsBoolean.True;
+        },
+    });
+
+    /** Updates the value of multiple existing field only if the types match.
+     * In contrast to setFields method, update always return Uninitialized */
+    private update = new Callable("update", {
+        signature: {
+            args: [new StdlibArgument("aa", ValueKind.Object)],
+            returns: ValueKind.Uninitialized,
+        },
+        impl: (interpreter: Interpreter, aa: RoAssociativeArray) => {
+            if (!(aa instanceof RoAssociativeArray)) {
+                return Uninitialized.Instance;
+            }
+
+            aa.getValue().forEach((value, key) => {
+                let fieldName = new BrsString(key);
+                let field = this.fields.get(key) || { type: "" };
+                let valueType = ValueKind.toString(value.kind);
+                if (
+                    this.get(fieldName) !== BrsInvalid.Instance &&
+                    field.type.toLowerCase() === valueType.toLowerCase()
+                ) {
+                    this.set(fieldName, value);
+                }
+            });
+
+            return Uninitialized.Instance;
         },
     });
 }

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -72,12 +72,12 @@ describe("RoSGNode", () => {
             expect(node.get(new BrsString("foo"))).toBe(ninetyNine);
         });
 
-        it("overwrites values with existing keys", () => {
+        it("overwrites values with existing keys if they are the same type", () => {
             let node = new RoSGNode([{ name: new BrsString("foo"), value: new Int32(-99) }]);
 
-            node.set(new BrsString("foo"), new BrsString("not ninetynine"));
+            node.set(new BrsString("foo"), new Int32(66));
 
-            expect(node.get(new BrsString("foo"))).toEqual(new BrsString("not ninetynine"));
+            expect(node.get(new BrsString("foo"))).toEqual(new Int32(66));
         });
     });
 
@@ -244,10 +244,7 @@ describe("RoSGNode", () => {
                 expect(keys).toBeTruthy();
 
                 let result = keys.call(interpreter);
-                expect(result.getElements()).toEqual(
-                    new RoArray([change, cletter, focusable, focusedChild, id, letter1, letter2])
-                        .elements
-                );
+                expect(result.getElements()).toEqual([change, cletter, focusable, focusedChild, id, letter1, letter2]);
             });
 
             it("returns an empty array from an empty associative array", () => {
@@ -262,9 +259,7 @@ describe("RoSGNode", () => {
                 expect(keys).toBeTruthy();
 
                 let result = keys.call(interpreter);
-                expect(result.getElements()).toEqual(
-                    new RoArray([change, focusable, focusedChild, id]).elements
-                );
+                expect(result.getElements()).toEqual([change, focusable, focusedChild, id]);
             });
         });
 
@@ -287,10 +282,7 @@ describe("RoSGNode", () => {
                 let items = node.getMethod("items");
                 expect(items).toBeTruthy();
                 let result = items.call(interpreter);
-                expect(result.getElements()).toEqual(
-                    new RoArray([id, focusedChild, letter1, letter2, cletter, change, focusable])
-                        .elements
-                );
+                expect(result.getElements()).toEqual([id, focusedChild, letter1, letter2, cletter, change, focusable]);
             });
 
             it("returns an empty array from an empty associative array", () => {
@@ -305,10 +297,7 @@ describe("RoSGNode", () => {
                 expect(items).toBeTruthy();
 
                 let result = items.call(interpreter);
-                expect(result.getElements()).toEqual(
-                    new RoArray([id, focusedChild, change, focusable]).elements
-                );
-            });
+                expect(result.getElements()).toEqual([id, focusedChild, change, focusable]);
         });
     });
 
@@ -432,6 +421,21 @@ describe("RoSGNode", () => {
                 let result = getField.call(interpreter, new BrsString("field1"));
                 expect(result).toEqual(new BrsString(""));
                 expect(node.get(new BrsString("field1"))).toEqual(new BrsString(""));
+            });
+        });
+
+        describe("observefield", () => {
+            it("adds an observer", () => {
+                let node = new RoSGNode([
+                    { name: new BrsString("foo"), value: new Int32(-99) },
+                    { name: new BrsString("bar"), value: new BrsString("hello") },
+                ]);
+
+                let observeField = node.getMethod("observefield")
+                expect(observeField).toBeTruthy();
+                
+                let result = observeField.call(interpreter, new BrsString("foo"), new BrsString("callMePlease"));
+                expect(result).toEqual(BrsBoolean.True);
             });
         });
 

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -503,5 +503,73 @@ describe("RoSGNode", () => {
                 expect(node.getFields().size).toEqual(0);
             });
         });
+
+        describe("setfields", () => {
+            it("updates the value of existing fields", () => {
+                let node = new RoSGNode([]);
+                const strVal = "updated string";
+                const intVal = 666;
+                let initialFields = new RoAssociativeArray([
+                    { name: new BrsString("field1"), value: new BrsString("a string") },
+                    { name: new BrsString("field2"), value: new Int32(-1) },
+                    { name: new BrsString("field3"), value: BrsBoolean.False },
+                ]);
+
+                let addFields = node.getMethod("addfields");
+                let setFields = node.getMethod("setfields");
+                let getField = node.getMethod("getfield");
+                expect(setFields).toBeTruthy();
+
+                let result = addFields.call(interpreter, initialFields);
+                expect(result).toEqual(BrsBoolean.True);
+
+                let updatedFields = new RoAssociativeArray([
+                    { name: new BrsString("field1"), value: new BrsString(strVal) },
+                    { name: new BrsString("field2"), value: new Int32(intVal) },
+                ]);
+
+                result = setFields.call(interpreter, updatedFields);
+                expect(result).toEqual(BrsBoolean.True);
+                expect(node.getFields().size).toEqual(3);
+
+                result = getField.call(interpreter, new BrsString("field1"));
+                expect(result.value).toEqual(strVal);
+
+                result = getField.call(interpreter, new BrsString("field2"));
+                expect(result.value).toEqual(intVal);
+            });
+
+            it("doesn't update the value of existing fields if types don't match", () => {
+                let node = new RoSGNode([]);
+                const strVal = "a string";
+                const intVal = -1;
+                let initialFields = new RoAssociativeArray([
+                    { name: new BrsString("field1"), value: new BrsString(strVal) },
+                    { name: new BrsString("field2"), value: new Int32(intVal) },
+                ]);
+
+                let addFields = node.getMethod("addfields");
+                let setFields = node.getMethod("setfields");
+                let getField = node.getMethod("getfield");
+
+                let result = addFields.call(interpreter, initialFields);
+                expect(result).toEqual(BrsBoolean.True);
+
+                let updatedFields = new RoAssociativeArray([
+                    { name: new BrsString("field1"), value: BrsInvalid.Instance },
+                    { name: new BrsString("field2"), value: BrsBoolean.False },
+                ]);
+
+                result = setFields.call(interpreter, updatedFields);
+                expect(result).toEqual(BrsBoolean.True);
+                expect(node.getFields().size).toEqual(2);
+
+                result = getField.call(interpreter, new BrsString("field1"));
+                expect(result.value).toEqual(strVal);
+
+                result = getField.call(interpreter, new BrsString("field2"));
+                expect(result.value).toEqual(intVal);
+            });
+        });
     });
 });

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -402,6 +402,54 @@ describe("RoSGNode", () => {
             });
         });
 
+        describe("removefield", () => {
+            it("removes a field from the node", () => {
+                let node = new RoSGNode([
+                    { name: new BrsString("letter1"), value: new BrsString("a") },
+                    { name: new BrsString("letter2"), value: new BrsString("b") },
+                    { name: new BrsString("letter3"), value: new BrsString("c") },
+                ]);
+
+                let addField = node.getMethod("addfield");
+                let removeField = node.getMethod("removefield");
+                expect(removeField).toBeTruthy();
+
+                let result = addField.call(
+                    interpreter,
+                    new BrsString("field1"),
+                    new BrsString("string"),
+                    BrsBoolean.False
+                );
+                expect(result).toEqual(BrsBoolean.True);
+                expect(node.getFields().size).toEqual(1);
+
+                result = removeField.call(interpreter, new BrsString("field1"));
+                expect(result).toEqual(BrsBoolean.True);
+                expect(node.getFields().size).toEqual(0);
+            });
+
+            it("doesn't remove a non existing field", () => {
+                let node = new RoSGNode([]);
+
+                let addField = node.getMethod("addfield");
+                let removeField = node.getMethod("removefield");
+                expect(removeField).toBeTruthy();
+
+                let result = addField.call(
+                    interpreter,
+                    new BrsString("field1"),
+                    new BrsString("string"),
+                    BrsBoolean.False
+                );
+                expect(result).toEqual(BrsBoolean.True);
+                expect(node.getFields().size).toEqual(1);
+
+                result = removeField.call(interpreter, new BrsString("field2"));
+                expect(result).toEqual(BrsBoolean.True);
+                expect(node.getFields().size).toEqual(1);
+            });
+        });
+
         describe("setfield", () => {
             it("updates the value of an existing field", () => {
                 let node = new RoSGNode([]);

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -30,6 +30,10 @@ describe("RoSGNode", () => {
             expect(node.toString()).toEqual(
                 `<Component: roSGNode:Node> =
 {
+    change: <UNINITIALIZED>
+    focusable: false
+    focusedchild: invalid
+    id: 
     array: <Component: roArray>
     associative-array: <Component: roAssociativeArray>
     node: <Component: roSGNode:Node>
@@ -91,7 +95,7 @@ describe("RoSGNode", () => {
                 let clear = node.getMethod("clear");
                 expect(clear).toBeTruthy();
                 expect(clear.call(interpreter)).toBe(BrsInvalid.Instance);
-                expect(node.elements).toEqual(new Map());
+                expect(node.getFields()).toEqual(new Map());
             });
         });
 
@@ -150,7 +154,7 @@ describe("RoSGNode", () => {
                 expect(count).toBeTruthy();
 
                 let result = count.call(interpreter);
-                expect(result).toEqual(new Int32(2));
+                expect(result).toEqual(new Int32(6));
             });
         });
 
@@ -222,6 +226,10 @@ describe("RoSGNode", () => {
 
         describe("keys", () => {
             it("returns an array of keys from the associative array in lexicographical order", () => {
+                let change = new BrsString("change");
+                let focusable = new BrsString("focusable");
+                let focusedChild = new BrsString("focusedchild");
+                let id = new BrsString("id");
                 let letter1 = new BrsString("letter1");
                 let letter2 = new BrsString("letter2");
                 let cletter = new BrsString("cletter");
@@ -236,22 +244,36 @@ describe("RoSGNode", () => {
                 expect(keys).toBeTruthy();
 
                 let result = keys.call(interpreter);
-                expect(result.elements).toEqual(new RoArray([cletter, letter1, letter2]).elements);
+                expect(result.getElements()).toEqual(
+                    new RoArray([change, cletter, focusable, focusedChild, id, letter1, letter2])
+                        .elements
+                );
             });
 
             it("returns an empty array from an empty associative array", () => {
+                let change = new BrsString("change");
+                let focusable = new BrsString("focusable");
+                let focusedChild = new BrsString("focusedchild");
+                let id = new BrsString("id");
+
                 let node = new RoSGNode([]);
 
                 let keys = node.getMethod("keys");
                 expect(keys).toBeTruthy();
 
                 let result = keys.call(interpreter);
-                expect(result.elements).toEqual(new RoArray([]).elements);
+                expect(result.getElements()).toEqual(
+                    new RoArray([change, focusable, focusedChild, id]).elements
+                );
             });
         });
 
         describe("items", () => {
             it("returns an array of values from the associative array in lexicographical order", () => {
+                let change = BrsBoolean.False;
+                let focusable = BrsInvalid.Instance;
+                let focusedChild = Uninitialized.Instance;
+                let id = new BrsString("");
                 let cletter = new BrsString("c");
                 let letter1 = new BrsString("a");
                 let letter2 = new BrsString("b");
@@ -265,17 +287,27 @@ describe("RoSGNode", () => {
                 let items = node.getMethod("items");
                 expect(items).toBeTruthy();
                 let result = items.call(interpreter);
-                expect(result.elements).toEqual(new RoArray([letter1, letter2, cletter]).elements);
+                expect(result.getElements()).toEqual(
+                    new RoArray([id, focusedChild, letter1, letter2, cletter, change, focusable])
+                        .elements
+                );
             });
 
             it("returns an empty array from an empty associative array", () => {
+                let change = BrsBoolean.False;
+                let focusable = BrsInvalid.Instance;
+                let focusedChild = Uninitialized.Instance;
+                let id = new BrsString("");
+
                 let node = new RoSGNode([]);
 
                 let items = node.getMethod("items");
                 expect(items).toBeTruthy();
 
                 let result = items.call(interpreter);
-                expect(result.elements).toEqual(new RoArray([]).elements);
+                expect(result.getElements()).toEqual(
+                    new RoArray([id, focusedChild, change, focusable]).elements
+                );
             });
         });
     });
@@ -301,7 +333,7 @@ describe("RoSGNode", () => {
                     BrsBoolean.True
                 );
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getFields().size).toEqual(1);
+                expect(node.getFields().size).toEqual(5);
             });
 
             it("doesn't add the field if the type is not valid", () => {
@@ -316,7 +348,7 @@ describe("RoSGNode", () => {
                     BrsBoolean.True
                 );
                 expect(result).toEqual(BrsBoolean.True); //Brightscript interpreter returns true here
-                expect(node.getFields().size).toEqual(0);
+                expect(node.getFields().size).toEqual(4);
             });
         });
 
@@ -337,7 +369,7 @@ describe("RoSGNode", () => {
 
                 let result = addFields.call(interpreter, fields);
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getFields().size).toEqual(6);
+                expect(node.getFields().size).toEqual(10);
             });
 
             it("doesn't add duplicated fields", () => {
@@ -350,7 +382,7 @@ describe("RoSGNode", () => {
                 let addFields = node.getMethod("addfields");
                 let result = addFields.call(interpreter, fields);
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getFields().size).toEqual(2);
+                expect(node.getFields().size).toEqual(6);
 
                 let moreFields = new RoAssociativeArray([
                     { name: new BrsString("field1"), value: new BrsString("my string") },
@@ -359,7 +391,7 @@ describe("RoSGNode", () => {
                 ]);
                 result = addFields.call(interpreter, moreFields);
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getFields().size).toEqual(3); //Only adds the non duplicated
+                expect(node.getFields().size).toEqual(7); //Only adds the non duplicated
             });
 
             it("only adds fields if passed as an associative array", () => {
@@ -370,7 +402,7 @@ describe("RoSGNode", () => {
 
                 let result = addFields.call(interpreter, fields);
                 expect(result).toEqual(BrsBoolean.False);
-                expect(node.getFields().size).toEqual(0);
+                expect(node.getFields().size).toEqual(4);
             });
         });
 
@@ -405,11 +437,7 @@ describe("RoSGNode", () => {
 
         describe("removefield", () => {
             it("removes a field from the node", () => {
-                let node = new RoSGNode([
-                    { name: new BrsString("letter1"), value: new BrsString("a") },
-                    { name: new BrsString("letter2"), value: new BrsString("b") },
-                    { name: new BrsString("letter3"), value: new BrsString("c") },
-                ]);
+                let node = new RoSGNode([]);
 
                 let addField = node.getMethod("addfield");
                 let removeField = node.getMethod("removefield");
@@ -422,11 +450,11 @@ describe("RoSGNode", () => {
                     BrsBoolean.False
                 );
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getFields().size).toEqual(1);
+                expect(node.getFields().size).toEqual(5);
 
                 result = removeField.call(interpreter, new BrsString("field1"));
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getFields().size).toEqual(0);
+                expect(node.getFields().size).toEqual(4);
             });
 
             it("doesn't remove a non existing field", () => {
@@ -443,11 +471,11 @@ describe("RoSGNode", () => {
                     BrsBoolean.False
                 );
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getFields().size).toEqual(1);
+                expect(node.getFields().size).toEqual(5);
 
                 result = removeField.call(interpreter, new BrsString("field2"));
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getFields().size).toEqual(1);
+                expect(node.getFields().size).toEqual(5);
             });
         });
 
@@ -501,7 +529,7 @@ describe("RoSGNode", () => {
                 let setField = node.getMethod("setfield");
                 let result = setField.call(interpreter, new BrsString("field1"), new Int32(999));
                 expect(result).toEqual(BrsBoolean.False);
-                expect(node.getFields().size).toEqual(0);
+                expect(node.getFields().size).toEqual(4);
             });
         });
 
@@ -531,7 +559,7 @@ describe("RoSGNode", () => {
 
                 result = setFields.call(interpreter, updatedFields);
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getFields().size).toEqual(3);
+                expect(node.getFields().size).toEqual(7);
 
                 result = getField.call(interpreter, new BrsString("field1"));
                 expect(result.value).toEqual(strVal);
@@ -563,7 +591,7 @@ describe("RoSGNode", () => {
 
                 result = setFields.call(interpreter, updatedFields);
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getFields().size).toEqual(2);
+                expect(node.getFields().size).toEqual(6);
 
                 result = getField.call(interpreter, new BrsString("field1"));
                 expect(result.value).toEqual(strVal);
@@ -599,7 +627,7 @@ describe("RoSGNode", () => {
 
                 result = update.call(interpreter, updatedFields);
                 expect(result).toEqual(Uninitialized.Instance);
-                expect(node.getFields().size).toEqual(3);
+                expect(node.getFields().size).toEqual(7);
 
                 result = getField.call(interpreter, new BrsString("field1"));
                 expect(result.value).toEqual(strVal);
@@ -631,7 +659,7 @@ describe("RoSGNode", () => {
 
                 result = update.call(interpreter, updatedFields);
                 expect(result).toEqual(Uninitialized.Instance);
-                expect(node.getFields().size).toEqual(2);
+                expect(node.getFields().size).toEqual(6);
 
                 result = getField.call(interpreter, new BrsString("field1"));
                 expect(result.value).toEqual(strVal);

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -302,6 +302,21 @@ describe("RoSGNode", () => {
                 expect(result).toEqual(BrsBoolean.True);
                 expect(node.getFields().size).toEqual(1);
             });
+
+            it("doesn't add the field if the type is not valid", () => {
+                let node = new RoSGNode([]);
+
+                let addField = node.getMethod("addfield");
+
+                let result = addField.call(
+                    interpreter,
+                    new BrsString("field1"),
+                    new BrsString("not-valid-type"),
+                    BrsBoolean.True
+                );
+                expect(result).toEqual(BrsBoolean.True); //Brightscript interpreter returns true here
+                expect(node.getFields().size).toEqual(0);
+            });
         });
 
         describe("addfields", () => {
@@ -334,7 +349,7 @@ describe("RoSGNode", () => {
                 let addFields = node.getMethod("addfields");
                 let result = addFields.call(interpreter, fields);
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getElements().length).toEqual(2);
+                expect(node.getFields().size).toEqual(2);
 
                 let moreFields = new RoAssociativeArray([
                     { name: new BrsString("field1"), value: new BrsString("my string") },
@@ -343,7 +358,7 @@ describe("RoSGNode", () => {
                 ]);
                 result = addFields.call(interpreter, moreFields);
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getElements().length).toEqual(3); //Only adds the non duplicated
+                expect(node.getFields().size).toEqual(3); //Only adds the non duplicated
             });
 
             it("only adds fields if passed as an associative array", () => {
@@ -384,6 +399,60 @@ describe("RoSGNode", () => {
                 let result = getField.call(interpreter, new BrsString("field1"));
                 expect(result).toEqual(new BrsString(""));
                 expect(node.get(new BrsString("field1"))).toEqual(new BrsString(""));
+            });
+        });
+
+        describe("setfield", () => {
+            it("updates the value of an existing field", () => {
+                let node = new RoSGNode([]);
+                const strVal = "value updated";
+
+                let addField = node.getMethod("addfield");
+                let setField = node.getMethod("setfield");
+                let getField = node.getMethod("getfield");
+                expect(setField).toBeTruthy();
+
+                let result = addField.call(
+                    interpreter,
+                    new BrsString("field1"),
+                    new BrsString("string"),
+                    BrsBoolean.False
+                );
+                expect(result).toEqual(BrsBoolean.True);
+                result = setField.call(interpreter, new BrsString("field1"), new BrsString(strVal));
+                expect(result).toEqual(BrsBoolean.True);
+                result = getField.call(interpreter, new BrsString("field1"));
+                expect(result.value).toEqual(strVal);
+            });
+
+            it("doesn't update the value of a field if not the same type", () => {
+                let node = new RoSGNode([]);
+
+                let addField = node.getMethod("addfield");
+                let setField = node.getMethod("setfield");
+
+                let result = addField.call(
+                    interpreter,
+                    new BrsString("field1"),
+                    new BrsString("integer"),
+                    BrsBoolean.False
+                );
+                expect(result).toEqual(BrsBoolean.True);
+                result = setField.call(
+                    interpreter,
+                    new BrsString("field1"),
+                    new BrsString("new value")
+                );
+                expect(result).toEqual(BrsBoolean.False);
+            });
+
+            it("doesn't update the value of a non existing field", () => {
+                let node = new RoSGNode([]);
+
+                let setField = node.getMethod("setfield");
+                let result = setField.call(interpreter, new BrsString("field1"), new Int32(999));
+                expect(result).toEqual(BrsBoolean.False);
+                expect(node.getFields().size).toEqual(0);
             });
         });
     });

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -278,4 +278,113 @@ describe("RoSGNode", () => {
             });
         });
     });
+
+    describe("ifSGNodeField", () => {
+        let interpreter;
+
+        beforeEach(() => {
+            interpreter = new Interpreter();
+        });
+
+        describe("addfield", () => {
+            it("adds a field to the object", () => {
+                let node = new RoSGNode([]);
+
+                let addField = node.getMethod("addfield");
+                expect(addField).toBeTruthy();
+
+                let result = addField.call(
+                    interpreter,
+                    new BrsString("field1"),
+                    new BrsString("string"),
+                    BrsBoolean.True
+                );
+                expect(result).toEqual(BrsBoolean.True);
+                expect(node.getFields().size).toEqual(1);
+            });
+        });
+
+        describe("addfields", () => {
+            it("adds multiple field to the object", () => {
+                let node = new RoSGNode([]);
+                let fields = new RoAssociativeArray([
+                    { name: new BrsString("associative-array"), value: new RoAssociativeArray([]) },
+                    { name: new BrsString("node"), value: new RoSGNode([]) },
+                    { name: new BrsString("boolean"), value: BrsBoolean.True },
+                    { name: new BrsString("string"), value: new BrsString("a string") },
+                    { name: new BrsString("number"), value: new Int32(-1) },
+                    { name: new BrsString("invalid"), value: BrsInvalid.Instance },
+                ]);
+
+                let addFields = node.getMethod("addfields");
+                expect(addFields).toBeTruthy();
+
+                let result = addFields.call(interpreter, fields);
+                expect(result).toEqual(BrsBoolean.True);
+                expect(node.getFields().size).toEqual(6);
+            });
+
+            it("doesn't add duplicated fields", () => {
+                let node = new RoSGNode([]);
+                let fields = new RoAssociativeArray([
+                    { name: new BrsString("field1"), value: new BrsString("a string") },
+                    { name: new BrsString("field2"), value: new Int32(-1) },
+                ]);
+
+                let addFields = node.getMethod("addfields");
+                let result = addFields.call(interpreter, fields);
+                expect(result).toEqual(BrsBoolean.True);
+                expect(node.getElements().length).toEqual(2);
+
+                let moreFields = new RoAssociativeArray([
+                    { name: new BrsString("field1"), value: new BrsString("my string") },
+                    { name: new BrsString("field2"), value: new Int32(-10) },
+                    { name: new BrsString("field3"), value: BrsInvalid.Instance },
+                ]);
+                result = addFields.call(interpreter, moreFields);
+                expect(result).toEqual(BrsBoolean.True);
+                expect(node.getElements().length).toEqual(3); //Only adds the non duplicated
+            });
+
+            it("only adds fields if passed as an associative array", () => {
+                let node = new RoSGNode([]);
+                let fields = "non associative array";
+
+                let addFields = node.getMethod("addfields");
+
+                let result = addFields.call(interpreter, fields);
+                expect(result).toEqual(BrsBoolean.False);
+                expect(node.getFields().size).toEqual(0);
+            });
+        });
+
+        describe("getfield", () => {
+            it("gets an non-existing field from node", () => {
+                let node = new RoSGNode([]);
+
+                let getField = node.getMethod("getfield");
+                expect(getField).toBeTruthy();
+
+                let result = getField.call(interpreter, new BrsString("field1"));
+                expect(result).toEqual(BrsInvalid.Instance);
+            });
+
+            it("gets the value of a defined field", () => {
+                let node = new RoSGNode([]);
+
+                let addField = node.getMethod("addfield");
+                addField.call(
+                    interpreter,
+                    new BrsString("field1"),
+                    new BrsString("string"),
+                    BrsBoolean.True
+                );
+
+                let getField = node.getMethod("getfield");
+                let result = getField.call(interpreter, new BrsString("field1"));
+                expect(result).toEqual(new BrsString(""));
+                expect(node.get(new BrsString("field1"))).toEqual(new BrsString(""));
+            });
+        });
+    });
 });

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -8,6 +8,7 @@ const {
     Int32,
     BrsInvalid,
     ValueKind,
+    Uninitialized,
 } = brs.types;
 const { Interpreter } = require("../../../lib/interpreter");
 
@@ -562,6 +563,74 @@ describe("RoSGNode", () => {
 
                 result = setFields.call(interpreter, updatedFields);
                 expect(result).toEqual(BrsBoolean.True);
+                expect(node.getFields().size).toEqual(2);
+
+                result = getField.call(interpreter, new BrsString("field1"));
+                expect(result.value).toEqual(strVal);
+
+                result = getField.call(interpreter, new BrsString("field2"));
+                expect(result.value).toEqual(intVal);
+            });
+        });
+
+        describe("update", () => {
+            it("updates the value of existing fields", () => {
+                let node = new RoSGNode([]);
+                const strVal = "updated string";
+                const intVal = 666;
+                let initialFields = new RoAssociativeArray([
+                    { name: new BrsString("field1"), value: new BrsString("a string") },
+                    { name: new BrsString("field2"), value: new Int32(-1) },
+                    { name: new BrsString("field3"), value: BrsBoolean.False },
+                ]);
+
+                let addFields = node.getMethod("addfields");
+                let update = node.getMethod("update");
+                let getField = node.getMethod("getfield");
+                expect(update).toBeTruthy();
+
+                let result = addFields.call(interpreter, initialFields);
+                expect(result).toEqual(BrsBoolean.True);
+
+                let updatedFields = new RoAssociativeArray([
+                    { name: new BrsString("field1"), value: new BrsString(strVal) },
+                    { name: new BrsString("field2"), value: new Int32(intVal) },
+                ]);
+
+                result = update.call(interpreter, updatedFields);
+                expect(result).toEqual(Uninitialized.Instance);
+                expect(node.getFields().size).toEqual(3);
+
+                result = getField.call(interpreter, new BrsString("field1"));
+                expect(result.value).toEqual(strVal);
+
+                result = getField.call(interpreter, new BrsString("field2"));
+                expect(result.value).toEqual(intVal);
+            });
+
+            it("doesn't update the value of existing fields if types don't match", () => {
+                let node = new RoSGNode([]);
+                const strVal = "a string";
+                const intVal = -1;
+                let initialFields = new RoAssociativeArray([
+                    { name: new BrsString("field1"), value: new BrsString(strVal) },
+                    { name: new BrsString("field2"), value: new Int32(intVal) },
+                ]);
+
+                let addFields = node.getMethod("addfields");
+                let update = node.getMethod("update");
+                let getField = node.getMethod("getfield");
+
+                let result = addFields.call(interpreter, initialFields);
+                expect(result).toEqual(BrsBoolean.True);
+
+                let updatedFields = new RoAssociativeArray([
+                    { name: new BrsString("field1"), value: BrsInvalid.Instance },
+                    { name: new BrsString("field2"), value: BrsBoolean.False },
+                ]);
+
+                result = update.call(interpreter, updatedFields);
+                expect(result).toEqual(Uninitialized.Instance);
                 expect(node.getFields().size).toEqual(2);
 
                 result = getField.call(interpreter, new BrsString("field1"));

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -109,7 +109,7 @@ describe("RoSGNode", () => {
                 let deleteCall = node.getMethod("delete");
                 expect(deleteCall).toBeTruthy();
                 expect(deleteCall.call(interpreter, new BrsString("foo"))).toBe(BrsBoolean.True);
-                expect(deleteCall.call(interpreter, new BrsString("baz"))).toBe(BrsBoolean.False);
+                expect(deleteCall.call(interpreter, new BrsString("baz"))).toBe(BrsBoolean.True);
                 expect(node.get(new BrsString("foo"))).toEqual(BrsInvalid.Instance);
             });
         });
@@ -244,7 +244,15 @@ describe("RoSGNode", () => {
                 expect(keys).toBeTruthy();
 
                 let result = keys.call(interpreter);
-                expect(result.getElements()).toEqual([change, cletter, focusable, focusedChild, id, letter1, letter2]);
+                expect(result.getElements()).toEqual([
+                    change,
+                    cletter,
+                    focusable,
+                    focusedChild,
+                    id,
+                    letter1,
+                    letter2,
+                ]);
             });
 
             it("returns an empty array from an empty associative array", () => {
@@ -282,7 +290,15 @@ describe("RoSGNode", () => {
                 let items = node.getMethod("items");
                 expect(items).toBeTruthy();
                 let result = items.call(interpreter);
-                expect(result.getElements()).toEqual([id, focusedChild, letter1, letter2, cletter, change, focusable]);
+                expect(result.getElements()).toEqual([
+                    id,
+                    focusedChild,
+                    letter1,
+                    letter2,
+                    cletter,
+                    change,
+                    focusable,
+                ]);
             });
 
             it("returns an empty array from an empty associative array", () => {
@@ -298,6 +314,7 @@ describe("RoSGNode", () => {
 
                 let result = items.call(interpreter);
                 expect(result.getElements()).toEqual([id, focusedChild, change, focusable]);
+            });
         });
     });
 
@@ -342,7 +359,7 @@ describe("RoSGNode", () => {
         });
 
         describe("addfields", () => {
-            it("adds multiple field to the object", () => {
+            it("adds multiple fields to the node", () => {
                 let node = new RoSGNode([]);
                 let fields = new RoAssociativeArray([
                     { name: new BrsString("associative-array"), value: new RoAssociativeArray([]) },
@@ -431,10 +448,14 @@ describe("RoSGNode", () => {
                     { name: new BrsString("bar"), value: new BrsString("hello") },
                 ]);
 
-                let observeField = node.getMethod("observefield")
+                let observeField = node.getMethod("observefield");
                 expect(observeField).toBeTruthy();
-                
-                let result = observeField.call(interpreter, new BrsString("foo"), new BrsString("callMePlease"));
+
+                let result = observeField.call(
+                    interpreter,
+                    new BrsString("foo"),
+                    new BrsString("callMePlease")
+                );
                 expect(result).toEqual(BrsBoolean.True);
             });
         });
@@ -466,7 +487,6 @@ describe("RoSGNode", () => {
 
                 let addField = node.getMethod("addfield");
                 let removeField = node.getMethod("removefield");
-                expect(removeField).toBeTruthy();
 
                 let result = addField.call(
                     interpreter,
@@ -480,6 +500,18 @@ describe("RoSGNode", () => {
                 result = removeField.call(interpreter, new BrsString("field2"));
                 expect(result).toEqual(BrsBoolean.True);
                 expect(node.getFields().size).toEqual(5);
+            });
+
+            it("removes a field defined as invalid", () => {
+                let node = new RoSGNode([
+                    { name: new BrsString("useless"), value: BrsInvalid.Instance },
+                ]);
+
+                let removeField = node.getMethod("removefield");
+
+                result = removeField.call(interpreter, new BrsString("useless"));
+                expect(result).toEqual(BrsBoolean.True);
+                expect(node.getFields().size).toEqual(4);
             });
         });
 

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -76,11 +76,11 @@ describe("end to end brightscript functions", () => {
 
         expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
             "node size: ",
-            "3",
+            "7",
             "node keys size: ",
-            "3",
+            "7",
             "node items size: ",
-            "3",
+            "7",
             "can delete elements: ",
             "true",
             "can look up elements: ",
@@ -91,6 +91,18 @@ describe("end to end brightscript functions", () => {
             "true",
             "can empty itself: ",
             "true",
+            "node size: ",
+            "3",
+            "node size: ",
+            "2",
+            "field3 in node is: ",
+            "false",
+            "field3 in node now is: ",
+            "true",
+            "field1 in node now is: ",
+            "hello",
+            "field3 in node now is: ",
+            "false",
         ]);
     });
 

--- a/test/e2e/resources/components/roSGNode.brs
+++ b/test/e2e/resources/components/roSGNode.brs
@@ -6,9 +6,9 @@ sub main()
     node1.addReplace("bar", 5)
     node1.append({ baz: false })
 
-    print "node size: " node1.count()                              ' => 3
-    print "node keys size: " node1.keys().count()                  ' => 3
-    print "node items size: " node1.items().count()                ' => 3
+    print "node size: " node1.count()                              ' => 7
+    print "node keys size: " node1.keys().count()                  ' => 7
+    print "node items size: " node1.items().count()                ' => 7
     print "can delete elements: " node1.delete("baz")              ' => true
     print "can look up elements: " node1.lookup("foo") = "foo"     ' => true
     print "can look up elements (brackets): " node1["foo"] = "foo" ' => true
@@ -16,4 +16,21 @@ sub main()
 
     node1.clear()
     print "can empty itself: " node1.count() = 0                   ' => true
+
+    node1.addField("field1", "string", false)
+    node1.addFields({ field2: 0, field3: false})
+
+    print "node size: " node1.count()                              ' => 3
+    
+    node1.removeField("field2")
+    print "node size: " node1.count()                              ' => 2
+
+    print "field3 in node is: " node1.getField("field3")           ' => false
+
+    node1.setField("field3", true)
+    print "field3 in node now is: " node1.getField("field3")      ' => true
+
+    node1.setFields({ field1: "hello", field3: false })
+    print "field1 in node now is: " node1.getField("field1")      ' => hello
+    print "field3 in node now is: " node1.getField("field3")      ' => false
 end sub

--- a/test/e2e/resources/components/roSGNode.brs
+++ b/test/e2e/resources/components/roSGNode.brs
@@ -35,6 +35,9 @@ sub main()
     print "field1 in node now is: " node1.getField("field1")      ' => hello
     print "field3 in node now is: " node1.getField("field3")      ' => false
 
+    node1.observeField("field1", "onSomethingChanged")
+    node1.setField("field1", "world")
+
     'ifNodeChildren tests
     parentNode = createObject("roSGNode", "Node")
     parentNode.id = "parent"
@@ -52,4 +55,8 @@ sub main()
     print "parent child count: " parentNode.getChildCount()        ' => 2
     children = parentNode.getChildren(-1, 0)
     print "children size: " children.count()                       ' => 2
+end sub
+
+sub onSomethingChanged()
+    print "oops, something changed here"
 end sub


### PR DESCRIPTION
This PR implements 6 of the most used functions in ifSGNodeField interface:

- setField
- addFields
- getField
- addField
- setFields
- removeField
- update (This made the more sense to be implemented as part of the fields since it isn't related with the ifSGNodeChildren)

I'm still working on the `observeField` implemented but I want to do a checkpoint here since I've changed quite a bit the RoSGNode class.