### PR TITLE
Functions and constructors to auto-convert between Int and Float

### DIFF
--- a/src/brsTypes/Callable.ts
+++ b/src/brsTypes/Callable.ts
@@ -3,6 +3,8 @@ import * as Brs from ".";
 import * as Expr from "../parser/Expression";
 import { Scope } from "../interpreter/Environment";
 import { Location } from "../lexer";
+import { Int32 } from "./Int32";
+import { Float } from "./Float";
 
 /** An argument to a BrightScript `function` or `sub`. */
 export interface Argument {
@@ -252,6 +254,24 @@ export class Callable implements Brs.BrsValue {
                 expected.type.kind === Brs.ValueKind.Dynamic ||
                 expected.type.kind === Brs.ValueKind.Object
             ) {
+                return;
+            }
+
+            if (
+                expected.type.kind === Brs.ValueKind.Float &&
+                received.kind === Brs.ValueKind.Int32
+            ) {
+                let old = args[index] as Int32;
+                args[index] = new Float(old.getValue());
+                return;
+            }
+
+            if (
+                expected.type.kind === Brs.ValueKind.Int32 &&
+                received.kind === Brs.ValueKind.Float
+            ) {
+                let old = args[index] as Float;
+                args[index] = new Int32(old.getValue());
                 return;
             }
 

--- a/src/brsTypes/Callable.ts
+++ b/src/brsTypes/Callable.ts
@@ -261,8 +261,7 @@ export class Callable implements Brs.BrsValue {
                 expected.type.kind === Brs.ValueKind.Float &&
                 received.kind === Brs.ValueKind.Int32
             ) {
-                let old = args[index] as Int32;
-                args[index] = new Float(old.getValue());
+                args[index] = new Float(received.getValue());
                 return;
             }
 
@@ -270,8 +269,7 @@ export class Callable implements Brs.BrsValue {
                 expected.type.kind === Brs.ValueKind.Int32 &&
                 received.kind === Brs.ValueKind.Float
             ) {
-                let old = args[index] as Float;
-                args[index] = new Int32(old.getValue());
+                args[index] = new Int32(received.getValue());
                 return;
             }
 

--- a/src/brsTypes/Int32.ts
+++ b/src/brsTypes/Int32.ts
@@ -15,18 +15,18 @@ export class Int32 implements Numeric, Comparable {
 
     /**
      * Creates a new BrightScript 32-bit integer value representing the provided `value`.
-     * @param value the value to store in the BrightScript number, rounded to the nearest 32-bit
+     * @param value the value to store in the BrightScript number, truncated to a 32-bit
      *              integer.
      */
     constructor(initialValue: number) {
-        this.value = Math.round(initialValue);
+        this.value = Math.trunc(initialValue);
     }
 
     /**
      * Creates a new BrightScript 32-bit integer value representing the integer contained in
      * `asString`.
      * @param asString the string representation of the value to store in the BrightScript 32-bit
-     *                 int. Will be rounded to the nearest 32-bit integer.
+     *                 int. Will be truncated to a 32-bit integer.
      * @returns a BrightScript 32-bit integer value representing `asString`.
      */
     static fromString(asString: string): Int32 {

--- a/src/brsTypes/Int64.ts
+++ b/src/brsTypes/Int64.ts
@@ -21,7 +21,7 @@ export class Int64 implements Numeric, Comparable {
         if (value instanceof Long) {
             this.value = value;
         } else {
-            this.value = Long.fromNumber(Math.round(value));
+            this.value = Long.fromNumber(Math.trunc(value));
         }
     }
 
@@ -41,14 +41,6 @@ export class Int64 implements Numeric, Comparable {
         }
 
         let i64 = new Int64(Long.fromString(asString, undefined, radix));
-        const decimalLocation = asString.indexOf(".");
-        if (decimalLocation > -1 && decimalLocation + 1 < asString.length) {
-            // Long.fromString truncates to integers instead of rounding, so manually add one to
-            // compensate if necessary
-            if (asString[decimalLocation + 1] >= "5" && asString[decimalLocation + 1] <= "9") {
-                i64 = new Int64(i64.getValue().add(Long.ONE));
-            }
-        }
         return i64;
     }
 

--- a/src/brsTypes/components/Timespan.ts
+++ b/src/brsTypes/components/Timespan.ts
@@ -64,7 +64,7 @@ export class Timespan extends BrsComponent implements BrsValue {
             returns: ValueKind.Int32,
         },
         impl: (_: Interpreter) => {
-            return new Int32((Date.now() - this.markTime) / 1000);
+            return new Int32(Math.round((Date.now() - this.markTime) / 1000));
         },
     });
 
@@ -82,7 +82,7 @@ export class Timespan extends BrsComponent implements BrsValue {
             let dateToParse = luxon.DateTime.fromISO(date.value, { zone: "utc" });
 
             if (dateToParse.isValid) {
-                dateAsSeconds = (Date.parse(dateToParse.toISO()) - now) / 1000;
+                dateAsSeconds = Math.round((Date.parse(dateToParse.toISO()) - now) / 1000);
             } else {
                 dateAsSeconds = 2077252342;
             }

--- a/test/brsTypes/Callable.test.js
+++ b/test/brsTypes/Callable.test.js
@@ -129,6 +129,38 @@ describe("Callable", () => {
             });
         });
 
+        it("allows float to be passed to an integer argument", () => {
+            const hasArgs = new BrsTypes.Callable("acceptsAnything", {
+                signature: {
+                    args: [new BrsTypes.StdlibArgument("intArg", BrsTypes.ValueKind.Int32)],
+                    returns: BrsTypes.String,
+                },
+                impl: () => {},
+            });
+
+            expect(
+                hasArgs
+                    .getAllSignatureMismatches([new BrsTypes.Float(1.5)])
+                    .map(mm => mm.mismatches)[0]
+            ).toEqual([]);
+        });
+
+        it("allows integer to be passed to a float argument", () => {
+            const hasArgs = new BrsTypes.Callable("acceptsAnything", {
+                signature: {
+                    args: [new BrsTypes.StdlibArgument("floatArg", BrsTypes.ValueKind.Float)],
+                    returns: BrsTypes.String,
+                },
+                impl: () => {},
+            });
+
+            expect(
+                hasArgs
+                    .getAllSignatureMismatches([new BrsTypes.Int32(4)])
+                    .map(mm => mm.mismatches)[0]
+            ).toEqual([]);
+        });
+
         it("allows any type for dynamic and object", () => {
             const hasArgs = new BrsTypes.Callable("acceptsAnything", {
                 signature: {

--- a/test/brsTypes/Int32.test.js
+++ b/test/brsTypes/Int32.test.js
@@ -10,18 +10,18 @@ const {
 } = require("../../lib/brsTypes");
 
 describe("Int32", () => {
-    it("rounds initial values to integers", () => {
+    it("truncates initial values to integers", () => {
         let three = new Int32(3.4);
         let four = new Int32(3.5);
         expect(three.getValue()).toBe(3);
-        expect(four.getValue()).toBe(4);
+        expect(four.getValue()).toBe(3);
     });
 
     it("creates base-10 integers from strings", () => {
         let three = Int32.fromString("3.4");
         let four = Int32.fromString("3.5");
         expect(three.getValue()).toBe(3);
-        expect(four.getValue()).toBe(4);
+        expect(four.getValue()).toBe(3);
     });
 
     it("creates base-16 integers from strings", () => {

--- a/test/brsTypes/Int64.test.js
+++ b/test/brsTypes/Int64.test.js
@@ -12,17 +12,13 @@ const Long = require("long");
 
 describe("Int64", () => {
     it("truncates initial values to integers", () => {
-        let three = new Int64(3.4);
-        let four = new Int64(3.5);
-        expect(three.getValue().toNumber()).toBe(3);
-        expect(four.getValue().toNumber()).toBe(3);
+        let threePointNine = new Int64(3.9);
+        expect(threePointNine.getValue().toNumber()).toBe(3);
     });
 
     it("creates base-10 integers from strings", () => {
-        let three = Int64.fromString("3.4");
-        let four = Int64.fromString("3.5");
-        expect(three.getValue().toNumber()).toBe(3);
-        expect(four.getValue().toNumber()).toBe(3);
+        let threePointNine = Int64.fromString("3.9");
+        expect(threePointNine.getValue().toNumber()).toBe(3);
     });
 
     it("creates base-16 integers from strings", () => {

--- a/test/brsTypes/Int64.test.js
+++ b/test/brsTypes/Int64.test.js
@@ -11,18 +11,18 @@ const {
 const Long = require("long");
 
 describe("Int64", () => {
-    it("rounds initial values to integers", () => {
+    it("truncates initial values to integers", () => {
         let three = new Int64(3.4);
         let four = new Int64(3.5);
         expect(three.getValue().toNumber()).toBe(3);
-        expect(four.getValue().toNumber()).toBe(4);
+        expect(four.getValue().toNumber()).toBe(3);
     });
 
     it("creates base-10 integers from strings", () => {
         let three = Int64.fromString("3.4");
         let four = Int64.fromString("3.5");
         expect(three.getValue().toNumber()).toBe(3);
-        expect(four.getValue().toNumber()).toBe(4);
+        expect(four.getValue().toNumber()).toBe(3);
     });
 
     it("creates base-16 integers from strings", () => {


### PR DESCRIPTION
Roku does truncate float to integer (not round) so I also changed the constructor of Int32 and Int64 to correctly mimic the behavior.

fixes #280 