### PR TITLE
Fixes on roAssociativeArray and roArray

### DIFF
--- a/src/brsTypes/components/RoArray.ts
+++ b/src/brsTypes/components/RoArray.ts
@@ -27,6 +27,7 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             this.sort,
             this.sortBy,
             this.reverse,
+            this.isEmpty,
         ]);
     }
 
@@ -326,6 +327,16 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
         impl: (interpreter: Interpreter, separator: BrsString) => {
             this.elements = this.elements.reverse();
             return BrsInvalid.Instance;
+        },
+    });
+    // ifEnum
+    private isEmpty = new Callable("isEmpty", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (interpreter: Interpreter) => {
+            return BrsBoolean.from(this.elements.length === 0);
         },
     });
 }

--- a/src/brsTypes/components/RoAssociativeArray.ts
+++ b/src/brsTypes/components/RoAssociativeArray.ts
@@ -34,6 +34,7 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
             this.keys,
             this.items,
             this.lookup,
+            this.isEmpty,
         ]);
     }
 
@@ -215,6 +216,19 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
         impl: (interpreter: Interpreter, key: BrsString) => {
             let lKey = key.value.toLowerCase();
             return this.get(new BrsString(lKey));
+        },
+    });
+
+    //--------------------------------- ifEnum ---------------------------------
+
+    /** Returns true if enumeration contains no elements, false otherwise	 */
+    private isEmpty = new Callable("isEmpty", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (interpreter: Interpreter) => {
+            return BrsBoolean.from(this.elements.size === 0);
         },
     });
 }

--- a/src/brsTypes/components/RoAssociativeArray.ts
+++ b/src/brsTypes/components/RoAssociativeArray.ts
@@ -162,7 +162,7 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
             returns: ValueKind.Boolean,
         },
         impl: (interpreter: Interpreter, str: BrsString) => {
-            return this.get(str) !== BrsInvalid.Instance ? BrsBoolean.True : BrsBoolean.False;
+            return this.elements.has(str.value.toLowerCase()) ? BrsBoolean.True : BrsBoolean.False;
         },
     });
 

--- a/test/brsTypes/components/RoAssociativeArray.test.js
+++ b/test/brsTypes/components/RoAssociativeArray.test.js
@@ -194,6 +194,16 @@ describe("RoAssociativeArray", () => {
                 expect(result.kind).toBe(ValueKind.Boolean);
                 expect(result).toBe(BrsBoolean.False);
             });
+            it("returns true even when the value of an item contains invalid in the array", () => {
+                let aa = new RoAssociativeArray([
+                    { name: new BrsString("letter1"), value: BrsInvalid.Instance },
+                ]);
+
+                let doesexist = aa.getMethod("doesexist");
+                let result = doesexist.call(interpreter, new BrsString("letter1"));
+                expect(result.kind).toBe(ValueKind.Boolean);
+                expect(result).toBe(BrsBoolean.True);
+            });
         });
 
         describe("append", () => {

--- a/test/e2e/resources/components/roArray.brs
+++ b/test/e2e/resources/components/roArray.brs
@@ -10,5 +10,5 @@ sub Main()
     print "can delete elements: " arr.delete(1) ' => true
 
     arr.clear()
-    print "can empty itself: " arr.count() = 0  ' => true
+    print "can empty itself: " arr.isEmpty()    ' => true
 end sub

--- a/test/e2e/resources/components/roAssociativeArray.brs
+++ b/test/e2e/resources/components/roAssociativeArray.brs
@@ -14,5 +14,5 @@ sub main()
     print "can check for existence: " aa.doesExist("bar")       ' => true
 
     aa.clear()
-    print "can empty itself: " aa.count() = 0                   ' => true
+    print "can empty itself: " aa.isEmpty()                     ' => true
 end sub


### PR DESCRIPTION
Implements `isEmpty()` for `RoArray` and `RoAssociativeArray` (from `ifEnum` interface), and ensures `doesExist()` returns `true` for explicitly `invalid` properties.

fixes #320 