### PR TITLE
feat(extension): Add _brs_.runInScope

### DIFF
--- a/src/brsTypes/Callable.ts
+++ b/src/brsTypes/Callable.ts
@@ -267,4 +267,35 @@ export class Callable implements Brs.BrsValue {
 
         return reasons;
     }
+
+    /**
+     * Creates several copies of the provided signature and implementation pair, simulating variadic types by creating a
+     * function that accepts zero args, one that accepts one arg, one that accepts two args, (…).
+     *
+     * @param signatureAndImpl the base signature and implementation to make variadic
+     *
+     * @returns an array containing psuedo-variadic versions of the provided signature and implementation
+     */
+    static variadic(signatureAndImpl: SignatureAndImplementation): SignatureAndImplementation[] {
+        let { signature, impl } = signatureAndImpl;
+        return [
+            signatureAndImpl,
+            ...new Array(10).fill(0).map((_, numArgs) => {
+                return {
+                    signature: {
+                        args: [
+                            ...signature.args,
+                            ...new Array(numArgs)
+                                .fill(0)
+                                .map(
+                                    (_, i) => new StdlibArgument(`arg${i}`, Brs.ValueKind.Dynamic)
+                                ),
+                        ],
+                        returns: signature.returns,
+                    },
+                    impl: impl,
+                };
+            }),
+        ];
+    }
 }

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -1,0 +1,8 @@
+import { RoAssociativeArray, BrsString } from "../brsTypes";
+import { mockComponent } from "./mockComponent";
+import { RunInScope } from "./RunInScope";
+
+export const _brs_ = new RoAssociativeArray([
+    { name: new BrsString("mockComponent"), value: mockComponent },
+    { name: new BrsString("runInScope"), value: RunInScope },
+]);

--- a/src/extensions/mockComponent.ts
+++ b/src/extensions/mockComponent.ts
@@ -2,16 +2,13 @@ import {
     BrsType,
     ValueKind,
     Callable,
-    BrsString,
     StdlibArgument,
     BrsInvalid,
     RoAssociativeArray,
-    Uninitialized,
 } from "../brsTypes";
-import { MockNode } from "./MockNode";
 import { Interpreter } from "../interpreter";
 
-const mockComponent = new Callable("mockComponent", {
+export const mockComponent = new Callable("mockComponent", {
     signature: {
         args: [
             new StdlibArgument("objToMock", ValueKind.String),
@@ -24,7 +21,3 @@ const mockComponent = new Callable("mockComponent", {
         return BrsInvalid.Instance;
     },
 });
-
-export const _brs_ = new RoAssociativeArray([
-    { name: new BrsString("mockComponent"), value: mockComponent },
-]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,27 +97,20 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
 }
 
 /**
- * A synchronous version of `execute`. Executes a BrightScript file by path and writes its output to the streams
- * provided in `options`.
+ * A synchronous version of the lexer-parser flow.
  *
- * @param filename the paths to BrightScript files to execute synchronously
+ * @param filename the paths to BrightScript files to lex and parse synchronously
  * @param options configuration for the execution, including the streams to use for `stdout` and
  *                `stderr` and the base directory for path resolution
- * @param args the set of arguments to pass to the `main` function declared in one of the provided filenames
  *
- * @returns the value returned by the executed file(s)
+ * @returns the AST produced from lexing and parsing the provided files
  */
-export function executeSync(
-    filenames: string[],
-    options: Partial<ExecutionOptions>,
-    args: BrsTypes.BrsType[]
-) {
+export function lexParseSync(filenames: string[], options: Partial<ExecutionOptions>) {
     const executionOptions = Object.assign(defaultExecutionOptions, options);
-    const interpreter = new Interpreter(executionOptions); // shared between files
 
     let manifest = PP.getManifestSync(executionOptions.root);
 
-    let allStatements = filenames
+    return filenames
         .map(filename => {
             let contents = fs.readFileSync(filename, "utf8");
             let scanResults = Lexer.scan(contents, filename);
@@ -126,8 +119,6 @@ export function executeSync(
             return Parser.parse(preprocessorResults.processedTokens).statements;
         })
         .reduce((allStatements, statements) => [...allStatements, ...statements], []);
-
-    return interpreter.exec(allStatements, ...args);
 }
 
 /**

--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -92,9 +92,20 @@ export class Environment {
     /**
      * Removes a variable from this environment's function scope.
      * @param name the name of the variable to remove (in the form of an `Identifier`)
+     * @param scope the scope to remove this variable from (defaults to "function")
      */
-    public remove(name: string): void {
-        this.function.delete(name.toLowerCase());
+    public remove(name: string, scope: Scope = Scope.Function): void {
+        let lowercaseName = name.toLowerCase();
+        switch (scope) {
+            case Scope.Module:
+                this.module.delete(lowercaseName);
+                break;
+            case Scope.Function:
+                this.function.delete(lowercaseName);
+                break;
+            default:
+                break;
+        }
     }
 
     /**
@@ -175,8 +186,8 @@ export class Environment {
      */
     public createSubEnvironment(): Environment {
         let newEnvironment = new Environment();
-        newEnvironment.global = this.global;
-        newEnvironment.module = this.module;
+        newEnvironment.global = new Map(this.global);
+        newEnvironment.module = new Map(this.module);
         newEnvironment.mPointer = this.mPointer;
         newEnvironment.mockObjects = this.mockObjects;
         newEnvironment.focusedNode = this.focusedNode;

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -28,7 +28,7 @@ import { Expr, Stmt } from "../parser";
 import { BrsError, TypeMismatch } from "../Error";
 
 import * as StdLib from "../stdlib";
-import { _brs_ } from "../extensions/mockComponent";
+import { _brs_ } from "../extensions";
 
 import { Scope, Environment, NotFound } from "./Environment";
 import { OutputProxy } from "./OutputProxy";

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -22,6 +22,6 @@ export * from "./File";
 export * from "./Json";
 export * from "./Math";
 export * from "./Print";
-export * from "./Run";
+export { Run } from "./Run";
 export * from "./String";
 export * from "./Type";

--- a/test/extensions/RunInScope.test.js
+++ b/test/extensions/RunInScope.test.js
@@ -1,0 +1,119 @@
+const brs = require("brs");
+const { Callable, BrsString, BrsInvalid, RoArray, RoAssociativeArray, ValueKind } = brs.types;
+const { RunInScope } = require("../../lib/extensions/RunInScope");
+const { Interpreter } = require("../../lib/interpreter");
+const { Scope } = require("../../lib/interpreter/Environment");
+const fs = require("fs");
+
+jest.mock("fs");
+
+describe("global Run function", () => {
+    let interpreter;
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        fs.readFileSync.mockRestore();
+    });
+
+    it("returns invalid for unrecognized devices", () => {
+        expect(RunInScope.call(interpreter, new BrsString("notADevice:/etc/hosts"))).toBe(
+            BrsInvalid.Instance
+        );
+    });
+
+    it("returns invalid for unreadable files", () => {
+        fs.readFileSync.mockImplementation(() => {
+            throw new Error("file not found");
+        });
+        expect(RunInScope.call(interpreter, new BrsString("notADevice:/etc/hosts"))).toBe(
+            BrsInvalid.Instance
+        );
+    });
+
+    it("returns invalid for lexing errors", () => {
+        fs.readFileSync.mockImplementation(() => `can't lex this`);
+        expect(RunInScope.call(interpreter, new BrsString("pkg:/errors/lex.brs"))).toBe(
+            BrsInvalid.Instance
+        );
+    });
+
+    it("returns invalid for parse errors", () => {
+        fs.readFileSync.mockImplementationOnce(() => `if return "parse error" exit while`);
+        expect(RunInScope.call(interpreter, new BrsString("pkg:/errors/parse.brs"))).toBe(
+            BrsInvalid.Instance
+        );
+    });
+
+    it("returns invalid for runtime errors", () => {
+        fs.readFileSync.mockImplementationOnce(() => `sub main(): _ = {}: _.crash(): end sub`);
+        expect(RunInScope.call(interpreter, new BrsString("pkg:/errors/exec.brs"))).toBe(
+            BrsInvalid.Instance
+        );
+    });
+
+    it("returns invalid when provided a not-array component", () => {
+        expect(RunInScope.call(interpreter, new RoAssociativeArray([]))).toBe(BrsInvalid.Instance);
+    });
+
+    it("returns invalid when provided an empty array of files", () => {
+        expect(RunInScope.call(interpreter, new RoArray([]))).toBe(BrsInvalid.Instance);
+    });
+
+    it("returns invalid when provided an array with non-strings", () => {
+        expect(RunInScope.call(interpreter, new RoArray([BrsInvalid.Instance]))).toBe(
+            BrsInvalid.Instance
+        );
+    });
+
+    it("allows main to be redefined", () => {
+        interpreter.environment.define(
+            Scope.Module,
+            "main",
+            new Callable("main", {
+                signature: {
+                    args: [],
+                    returns: ValueKind.Void,
+                },
+                impl: interpreter => {
+                    // just an empty main function - it just needs to exist for this test
+                    return BrsInvalid.Instance;
+                },
+            })
+        );
+
+        fs.readFileSync.mockImplementationOnce(
+            () => `function main(): return "hello!": end function`
+        );
+
+        expect(RunInScope.call(interpreter, new BrsString("pkg:/success/exec.brs"))).toEqual(
+            new BrsString("hello!")
+        );
+    });
+
+    it("can call functions declared in original scope", () => {
+        interpreter.environment.define(
+            Scope.Module,
+            "greet",
+            new Callable("greet", {
+                signature: {
+                    args: [],
+                    returns: ValueKind.String,
+                },
+                impl: interpreter => {
+                    return new BrsString("hello!");
+                },
+            })
+        );
+
+        fs.readFileSync.mockImplementationOnce(
+            () => `function main(): return greet(): end function`
+        );
+
+        expect(RunInScope.call(interpreter, new BrsString("pkg:/success/exec.brs"))).toEqual(
+            new BrsString("hello!")
+        );
+    });
+});


### PR DESCRIPTION
While the standard `Run` function allows arbitrary files to be executed, they're executed in their own empty scope!  That leads to a whole lot of repeated lexing, parsing, etc. of the `source/` tree when running unit tests, so we can expose a custom version of `Run` that keeps the previous values in-scope, deletes the previous `main` function, and otherwise executes the requested files the same way.