### PR TITLE
Reordering child node parsing in component

### DIFF
--- a/src/componentprocessor/index.ts
+++ b/src/componentprocessor/index.ts
@@ -133,7 +133,7 @@ async function processXmlTree(
             while (baseNode) {
                 let baseNodeDef = nodeDefMap.get(baseNode);
                 if (baseNodeDef) {
-                    nodeDef.children = [...nodeDef.children, ...getChildren(baseNodeDef.xmlNode!)];
+                    nodeDef.children = [...getChildren(baseNodeDef.xmlNode!), ...nodeDef.children];
                     baseNode = baseNodeDef.xmlNode!.attr.extends;
                 }
             }


### PR DESCRIPTION
Reordered the child node parsing and added a unit test to support correct parse order.