### PR TITLE
feat(rsg, components): Flatten functions through component inheritence chain

### DIFF
--- a/src/componentprocessor/index.ts
+++ b/src/componentprocessor/index.ts
@@ -66,6 +66,10 @@ export class ComponentDefinition {
             return Promise.reject(this);
         }
     }
+
+    public get extends(): string {
+        return this.xmlNode ? this.xmlNode.attr.extends : "";
+    }
 }
 
 export async function getComponentDefinitionMap(rootDir: string) {
@@ -143,7 +147,6 @@ async function processXmlTree(
                 let baseNodeDef = nodeDefMap.get(baseNode);
                 if (baseNodeDef) {
                     nodeDef.children = [...getChildren(baseNodeDef.xmlNode!), ...nodeDef.children];
-                    nodeDef.scripts = [...getScripts(baseNodeDef.xmlNode!), ...nodeDef.scripts];
                     baseNode = baseNodeDef.xmlNode!.attr.extends;
                 }
             }

--- a/src/parser/ComponentScopeResolver.ts
+++ b/src/parser/ComponentScopeResolver.ts
@@ -1,0 +1,76 @@
+import { ComponentDefinition } from "../componentprocessor";
+import * as Stmt from "./Statement";
+import { statement } from "@babel/template";
+
+export class ComponentScopeResolver {
+    /**
+     * @param componentMap Component definition map to reference for function resolution.
+     * @param parserLexerFn Function used to parse statements out of given components
+     */
+    constructor(
+        readonly componentMap: Map<string, ComponentDefinition>,
+        readonly parserLexerFn: (filenames: string[]) => Promise<Stmt.Statement[]> // TODO: Remove and just build here?
+    ) {}
+
+    /**
+     * Resolves the component functions in scope based on the extends hierarchy.
+     * @param component Instance of the component to resolve function scope for.
+     * @returns All statements in scope for the resolved component
+     */
+    public async resolve(component: ComponentDefinition): Promise<Stmt.Statement[]> {
+        return Promise.all(this.getStatements(component)).then(this.flatten);
+    }
+
+    /**
+     * Takes a sequence of statement collections and flattens them into a
+     * single statement collection. This function assumes that the components
+     * given in the statement map are in order of hierarchy with the furthest
+     * inheriting component first.
+     * @param statementMap Statement collections broken up by component.
+     * @returns A collection of statements that have been flattened based on hierarchy.
+     */
+    private flatten(statementMap: Stmt.Statement[][]): Stmt.Statement[] {
+        let statements = statementMap.shift() || [];
+        let statementMemo = new Set(
+            statements.filter((_): _ is Stmt.Function => true).map(statement => statement.name.text)
+        );
+        while (statementMap.length > 0) {
+            let extendedFns = statementMap.shift() || [];
+            statements = statements.concat(
+                extendedFns
+                    .filter((_): _ is Stmt.Function => true)
+                    .filter(statement => {
+                        let haveFnName = statementMemo.has(statement.name.text);
+                        if (!haveFnName) {
+                            statementMemo.add(statement.name.text);
+                        }
+                        return !haveFnName;
+                    })
+            );
+        }
+        return statements;
+    }
+
+    /**
+     * Generator function that walks the component hierarchy and produces an
+     * ordered list of component statement collections.
+     * @param component Component to begin statement aggregation chain.
+     * @returns An ordered array of component statement arrays.
+     */
+    private *getStatements(component: ComponentDefinition) {
+        yield this.parserLexerFn(component.scripts.map(c => c.uri));
+        let currentComponent: ComponentDefinition | undefined = component;
+        while (currentComponent.extends) {
+            let previousComponent = currentComponent;
+            currentComponent = this.componentMap.get(currentComponent.extends);
+            if (!currentComponent) {
+                return Promise.reject({
+                    message: `Cannot find extended component ${previousComponent.extends} defined on ${previousComponent.name}`,
+                });
+            }
+            yield this.parserLexerFn(currentComponent.scripts.map(c => c.uri));
+        }
+
+        return Promise.resolve();
+    }
+}

--- a/src/parser/ComponentScopeResolver.ts
+++ b/src/parser/ComponentScopeResolver.ts
@@ -3,6 +3,8 @@ import * as Stmt from "./Statement";
 import { statement } from "@babel/template";
 
 export class ComponentScopeResolver {
+    private readonly excludedNames: string[] = ["init"];
+
     /**
      * @param componentMap Component definition map to reference for function resolution.
      * @param parserLexerFn Function used to parse statements out of given components
@@ -18,7 +20,7 @@ export class ComponentScopeResolver {
      * @returns All statements in scope for the resolved component
      */
     public async resolve(component: ComponentDefinition): Promise<Stmt.Statement[]> {
-        return Promise.all(this.getStatements(component)).then(this.flatten);
+        return Promise.all(this.getStatements(component)).then(this.flatten.bind(this));
     }
 
     /**
@@ -40,11 +42,12 @@ export class ComponentScopeResolver {
                 extendedFns
                     .filter((_): _ is Stmt.Function => true)
                     .filter(statement => {
-                        let haveFnName = statementMemo.has(statement.name.text);
+                        let statementName = statement.name.text;
+                        let haveFnName = statementMemo.has(statementName);
                         if (!haveFnName) {
-                            statementMemo.add(statement.name.text);
+                            statementMemo.add(statementName);
                         }
-                        return !haveFnName;
+                        return !haveFnName && !this.excludedNames.includes(statementName);
                     })
             );
         }

--- a/src/parser/ComponentScopeResolver.ts
+++ b/src/parser/ComponentScopeResolver.ts
@@ -1,6 +1,5 @@
 import { ComponentDefinition } from "../componentprocessor";
 import * as Stmt from "./Statement";
-import { statement } from "@babel/template";
 
 export class ComponentScopeResolver {
     private readonly excludedNames: string[] = ["init"];

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -4,3 +4,4 @@ import * as Statement from "./Statement";
 export { Parser } from "./Parser";
 export * from "./ParseError";
 export { Expression as Expr, Statement as Stmt };
+export { ComponentScopeResolver } from "./ComponentScopeResolver";

--- a/test/componentprocessor/componentprocessor.test.js
+++ b/test/componentprocessor/componentprocessor.test.js
@@ -97,11 +97,9 @@ describe.only("component parsing support", () => {
                 expect(parsedExtendedComp.scripts.length).toBeGreaterThan(0);
 
                 const expectedPrefix = "pkg:/test/componentprocessor/resources/scripts/";
-                let expectedScripts = [
-                    "baseComponent.brs",
-                    "extendedComponent.brs",
-                    "utility.brs",
-                ].map(scriptName => path.join(expectedPrefix, scriptName));
+                let expectedScripts = ["extendedComponent.brs", "utility.brs"].map(scriptName =>
+                    path.join(expectedPrefix, scriptName)
+                );
                 let actualScripts = parsedExtendedComp.scripts.map(script => script.uri);
                 expect(actualScripts).toEqual(expectedScripts);
             });

--- a/test/e2e/resources/components/scripts/BaseWidget.brs
+++ b/test/e2e/resources/components/scripts/BaseWidget.brs
@@ -1,3 +1,2 @@
-' TODO: Uncomment when init logic has been implemented
-' sub init()
-' end sub
+sub init()
+end sub

--- a/test/e2e/resources/components/scripts/NormalWidget.brs
+++ b/test/e2e/resources/components/scripts/NormalWidget.brs
@@ -1,3 +1,2 @@
-' TODO: Uncomment when init logic has been implemented
-' sub init()
-' end sub
+sub init()
+end sub

--- a/test/interpreter/Interpreter.test.js
+++ b/test/interpreter/Interpreter.test.js
@@ -49,7 +49,7 @@ describe("integration tests", () => {
 
         let baseComp = interpreter.environment.nodeDefMap.get("BaseComponent");
         expect(baseComp).not.toBeUndefined();
-        expect(baseComp.environment.module.size).toEqual(0);
+        expect(baseComp.environment.module.size).toEqual(1);
 
         let extendedComp = interpreter.environment.nodeDefMap.get("ExtendedComponent");
         expect(extendedComp).not.toBeUndefined();

--- a/test/interpreter/resources/scripts/baseComponent.brs
+++ b/test/interpreter/resources/scripts/baseComponent.brs
@@ -1,5 +1,4 @@
-' TODO: Uncomment when init logic has been implemented
-' sub init()
-'     ?"base component"
-'     x = 5
-' end sub
+sub init()
+    ?"base component"
+    x = 5
+end sub

--- a/test/parser/ComponentScopeResolver.test.js
+++ b/test/parser/ComponentScopeResolver.test.js
@@ -80,4 +80,14 @@ describe("ComponentScopeResolver", () => {
         let testStatementCount = testStatement.func.body.statements.length;
         expect(testStatementCount).toEqual(2);
     });
+
+    it("doesn't copy init into scope", async () => {
+        let componentToResolve = componentMap.get("ExtendedComponent");
+        let componentScopeResolver = new brs.parser.ComponentScopeResolver(componentMap, parseFn);
+        let statements = await componentScopeResolver.resolve(componentToResolve);
+        expect(statements).toBeDefined();
+
+        let statementNames = statements.map(s => s.name.text);
+        expect(statementNames).not.toContain("init");
+    });
 });

--- a/test/parser/ComponentScopeResolver.test.js
+++ b/test/parser/ComponentScopeResolver.test.js
@@ -1,0 +1,83 @@
+const brs = require("brs");
+const path = require("path");
+const { getComponentDefinitionMap } = require("../../lib/componentprocessor");
+const { defaultExecutionOptions } = require("../../lib/interpreter");
+const LexerParser = require("../../lib/LexerParser");
+
+jest.mock("fast-glob");
+jest.mock("fs");
+const fg = require("fast-glob");
+const fs = require("fs");
+
+const realFs = jest.requireActual("fs");
+
+describe("ComponentScopeResolver", () => {
+    let parseFn, componentMap;
+
+    beforeEach(async () => {
+        fg.sync.mockImplementation(() => {
+            return [
+                "baseComponent.xml",
+                "extendedComponent.xml",
+                "baseComponentTwoScripts.xml",
+                "extendedComponent2.xml",
+                "scripts/baseComponent.brs",
+                "scripts/extendedComponenet.brs",
+                "scripts/utilityBase.brs",
+                "scripts/utilityExtended.brs",
+            ];
+        });
+        fs.readFile.mockImplementation((filename, _, cb) => {
+            resourcePath = path.join(__dirname, "resources", filename);
+            realFs.readFile(resourcePath, "utf8", (err, contents) => {
+                cb(/* no error */ null, contents);
+            });
+        });
+
+        parseFn = LexerParser.getLexerParserFn(new Map(), defaultExecutionOptions);
+
+        componentMap = await getComponentDefinitionMap("/doesnt/matter");
+        componentMap.forEach(comp => {
+            comp.scripts = comp.scripts.map(script => {
+                script.uri = path.join("scripts/", path.parse(script.uri).base);
+                return script;
+            });
+        });
+    });
+
+    afterEach(() => {
+        fg.sync.mockRestore();
+        fs.readFile.mockRestore();
+    });
+
+    test("resolving function scope across two components", async () => {
+        let componentToResolve = componentMap.get("ExtendedComponent");
+        let componentScopeResolver = new brs.parser.ComponentScopeResolver(componentMap, parseFn);
+        let statements = await componentScopeResolver.resolve(componentToResolve);
+        expect(statements).toBeDefined();
+        expect(statements.length).toBe(2);
+
+        let statementNames = statements.map(s => s.name.text);
+        expect(statementNames).toEqual(["test", "test2"]);
+
+        let testStatement = statements.find(s => s.name.text === "test");
+        let testStatementCount = testStatement.func.body.statements.length;
+        expect(testStatementCount).toEqual(2);
+    });
+
+    test("resolving function scope with multiple scripts", async () => {
+        let componentToResolve = componentMap.get("ExtendedComponent2");
+        let componentScopeResolver = new brs.parser.ComponentScopeResolver(componentMap, parseFn);
+        let statements = await componentScopeResolver.resolve(componentToResolve);
+        expect(statements).toBeDefined();
+        expect(statements.length).toBe(5);
+
+        let statementNames = statements.map(s => s.name.text);
+        // Statements are in a specific order
+        expect(statementNames).toEqual(["test", "util1", "util_y", "test2", "util_x"]);
+
+        let testStatement = statements.find(s => s.name.text === "util1");
+        let testStatementCount = testStatement.func.body.statements.length;
+        expect(testStatementCount).toEqual(2);
+    });
+});

--- a/test/parser/resources/baseComponent.xml
+++ b/test/parser/resources/baseComponent.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="BaseComponent">
+<script type="text/brightscript" uri="pkg:/test/parser/resources/scripts/baseComponent.brs" />
+</component>

--- a/test/parser/resources/baseComponentTwoScripts.xml
+++ b/test/parser/resources/baseComponentTwoScripts.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="BaseComponentTwoScripts">
+<script type="text/brightscript" uri="pkg:/test/parser/resources/scripts/baseComponent.brs" />
+<script type="text/brightscript" uri="pkg:/test/parser/resources/scripts/utilityBase.brs" />
+</component>

--- a/test/parser/resources/extendedComponent.xml
+++ b/test/parser/resources/extendedComponent.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="ExtendedComponent" extends="BaseComponent">
+<script type="text/brightscript" uri="pkg:/test/parser/resources/scripts/extendedComponent.brs" />
+</component>

--- a/test/parser/resources/extendedComponent2.xml
+++ b/test/parser/resources/extendedComponent2.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="ExtendedComponent2" extends="BaseComponentTwoScripts">
+<script type="text/brightscript" uri="pkg:/test/parser/resources/scripts/extendedComponent.brs" />
+<script type="text/brightscript" uri="pkg:/test/parser/resources/scripts/utilityExtended.brs" />
+</component>

--- a/test/parser/resources/scripts/baseComponent.brs
+++ b/test/parser/resources/scripts/baseComponent.brs
@@ -1,0 +1,6 @@
+sub test()
+    ?"one statement"
+end sub
+
+sub test2()
+end sub

--- a/test/parser/resources/scripts/baseComponent.brs
+++ b/test/parser/resources/scripts/baseComponent.brs
@@ -1,3 +1,7 @@
+sub init()
+    ?"I shouldn't be copied into scope"
+end sub
+
 sub test()
     ?"one statement"
 end sub

--- a/test/parser/resources/scripts/extendedComponent.brs
+++ b/test/parser/resources/scripts/extendedComponent.brs
@@ -1,0 +1,4 @@
+sub test()
+    ?"one statement"
+    ?"two statements"
+end sub

--- a/test/parser/resources/scripts/utilityBase.brs
+++ b/test/parser/resources/scripts/utilityBase.brs
@@ -1,0 +1,8 @@
+sub util1()
+    ?"statement 1"
+    ?"statement 2"
+    ?"statement 3"
+end sub
+
+sub util_x()
+end sub

--- a/test/parser/resources/scripts/utilityExtended.brs
+++ b/test/parser/resources/scripts/utilityExtended.brs
@@ -1,0 +1,7 @@
+sub util1()
+    ?"statement 1"
+    ?"statement 2"
+end sub
+
+sub util_y()
+end sub


### PR DESCRIPTION
Sorry that this PR is only one commit. Was battling with git to only submit the new additions. Was having trouble due to different commit history.

This PR adds scope resolution for components. Each component will now have an environment with all functions resolved from its extended components. The simple rule with the Roku environment based on our experiments was basically each component is consolidated into a "tier". The tiers then resolve starting from the component that is being created and moving up through the `extends` chain.

This PR does not include calling `init()` currently and will be in the next PR. However we can again have `init()` defined in more than one extending component.