### PR TITLE
fix(rsg): Prevent infinite loop when a node extends an unknown component

### DIFF
--- a/src/componentprocessor/index.ts
+++ b/src/componentprocessor/index.ts
@@ -148,6 +148,14 @@ async function processXmlTree(
                 if (baseNodeDef) {
                     nodeDef.children = [...nodeDef.children];
                     baseNode = baseNodeDef.xmlNode!.attr.extends;
+                } else {
+                    // The reference implementation doesn't allow extensions of unknown node subtypes, but
+                    // BRS hasn't implemented every node type in the reference implementation!  For now,
+                    // let's warn when we detect unknown subtypes.
+                    console.error(
+                        `XML component '${nodeDef.name}' extends unknown component '${baseNode}'. Ignoring extension.`
+                    );
+                    break;
                 }
             }
         }

--- a/test/componentprocessor/componentprocessor.test.js
+++ b/test/componentprocessor/componentprocessor.test.js
@@ -103,6 +103,21 @@ describe.only("component parsing support", () => {
                 let actualScripts = parsedExtendedComp.scripts.map(script => script.uri);
                 expect(actualScripts).toEqual(expectedScripts);
             });
+
+            it("ignores extensions of unknown node subtypes", async () => {
+                fg.sync.mockImplementation(() => {
+                    return ["unknownExtensionComponent.xml"];
+                });
+
+                jest.spyOn(global.console, "error").mockImplementation();
+                try {
+                    let map = await getComponentDefinitionMap("/doesnt/matter");
+                    let invalidExtensionComponent = map.get("UnknownExtensionComponent");
+                    expect(invalidExtensionComponent).toBeDefined();
+                } finally {
+                    global.console.error.mockRestore();
+                }
+            });
         });
     });
 });

--- a/test/componentprocessor/resources/unknownExtensionComponent.xml
+++ b/test/componentprocessor/resources/unknownExtensionComponent.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    A component that extends an intentionally non-existent base component.
+    Used to ensure that we fall back to a basic 'Node' when attempting to
+    extend a component that hasn't uyet been implemented in BRS.
+-->
+<component name="UnknownExtensionComponent" extends="DoesNotExist"/>


### PR DESCRIPTION
Long-term we probably don't want to warn-and-fall-back for components that extend something we don't recognize.  The reference implementation considers that a compilation failure, but since we don't yet know about every component in the reference implementation we can't make that assertion!