### PR TITLE
feat(parse): Allow `.` before indexed property access

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1326,34 +1326,44 @@ export class Parser {
         function call(): Expression {
             let expr = primary();
 
+            function indexedGet() {
+                while (match(Lexeme.Newline));
+
+                let index = expression();
+
+                while (match(Lexeme.Newline));
+                let closingSquare = consume(
+                    "Expected ']' after array or object index",
+                    Lexeme.RightSquare
+                );
+
+                expr = new Expr.IndexedGet(expr, index, closingSquare);
+            }
+
+            function dottedGet() {}
+
             while (true) {
                 if (match(Lexeme.LeftParen)) {
                     expr = finishCall(expr);
                 } else if (match(Lexeme.LeftSquare)) {
-                    while (match(Lexeme.Newline));
-
-                    let index = expression();
-
-                    while (match(Lexeme.Newline));
-                    let closingSquare = consume(
-                        "Expected ']' after array or object index",
-                        Lexeme.RightSquare
-                    );
-
-                    expr = new Expr.IndexedGet(expr, index, closingSquare);
+                    indexedGet();
                 } else if (match(Lexeme.Dot)) {
-                    while (match(Lexeme.Newline));
+                    if (match(Lexeme.LeftSquare)) {
+                        indexedGet();
+                    } else {
+                        while (match(Lexeme.Newline));
 
-                    let name = consume(
-                        "Expected property name after '.'",
-                        Lexeme.Identifier,
-                        ...allowedProperties
-                    );
+                        let name = consume(
+                            "Expected property name after '.'",
+                            Lexeme.Identifier,
+                            ...allowedProperties
+                        );
 
-                    // force it into an identifier so the AST makes some sense
-                    name.kind = Lexeme.Identifier;
+                        // force it into an identifier so the AST makes some sense
+                        name.kind = Lexeme.Identifier;
 
-                    expr = new Expr.DottedGet(expr, name as Identifier);
+                        expr = new Expr.DottedGet(expr, name as Identifier);
+                    }
                 } else {
                     break;
                 }

--- a/test/e2e/resources/arrays.brs
+++ b/test/e2e/resources/arrays.brs
@@ -16,7 +16,7 @@ print twoDimensional[3][2]
 ' add n^4
 twoDimensional[4] = [ 1, 16, 81 ]
 
-print twoDimensional[4][1]
+print twoDimensional[4].[1]
 
 ' modify oneDimensional[0]
 oneDimensional[0] += " bar"

--- a/test/e2e/resources/associative-arrays.brs
+++ b/test/e2e/resources/associative-arrays.brs
@@ -25,4 +25,4 @@ print twoDimensional.secondLayer.level
 
 ' add property to `empty` to be really silly
 empty.isEmpty = oneDimensional.isOneDimensional and false
-print empty.isEmpty
+print empty.["isEmpty"]

--- a/test/parser/expression/Indexing.test.js
+++ b/test/parser/expression/Indexing.test.js
@@ -45,6 +45,44 @@ describe("parser indexing", () => {
             expect(statements).toMatchSnapshot();
         });
 
+        describe("dotted and bracketed", () => {
+            test("single dot", () => {
+                let { statements, errors } = parser.parse([
+                    identifier("_"),
+                    token(Lexeme.Equal, "="),
+                    identifier("foo"),
+                    token(Lexeme.Dot, "."),
+                    token(Lexeme.LeftSquare, "["),
+                    token(Lexeme.Integer, "2", new Int32(2)),
+                    token(Lexeme.RightSquare, "]"),
+                    EOF,
+                ]);
+
+                expect(errors).toEqual([]);
+                expect(statements).toBeDefined();
+                expect(statements).not.toBeNull();
+                expect(statements).toMatchSnapshot();
+            });
+
+            test("multiple dots", () => {
+                let { statements, errors } = parser.parse([
+                    identifier("_"),
+                    token(Lexeme.Equal, "="),
+                    identifier("foo"),
+                    token(Lexeme.Dot, "."),
+                    token(Lexeme.Dot, "."),
+                    token(Lexeme.Dot, "."),
+                    token(Lexeme.LeftSquare, "["),
+                    token(Lexeme.Integer, "2", new Int32(2)),
+                    token(Lexeme.RightSquare, "]"),
+                    EOF,
+                ]);
+
+                expect(errors.length).toBe(1);
+                expect(errors[0]).toHaveProperty("message", "Expected property name after '.'");
+            });
+        });
+
         test("location tracking", () => {
             /**
              *    0   0   0   1

--- a/test/parser/expression/__snapshots__/Indexing.test.js.snap
+++ b/test/parser/expression/__snapshots__/Indexing.test.js.snap
@@ -536,3 +536,96 @@ Array [
   },
 ]
 `;
+
+exports[`parser indexing one level dotted and bracketed single dot 1`] = `
+Array [
+  Assignment {
+    "name": Object {
+      "isReserved": false,
+      "kind": "Identifier",
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "text": "_",
+    },
+    "tokens": Object {
+      "equals": Object {
+        "isReserved": false,
+        "kind": "Equal",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "=",
+      },
+    },
+    "value": IndexedGet {
+      "closingSquare": Object {
+        "isReserved": false,
+        "kind": "RightSquare",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "]",
+      },
+      "index": Literal {
+        "_location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "value": Int32 {
+          "kind": 4,
+          "value": 2,
+        },
+      },
+      "obj": Variable {
+        "name": Object {
+          "isReserved": false,
+          "kind": "Identifier",
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": -9,
+              "line": -9,
+            },
+            "start": Object {
+              "column": -9,
+              "line": -9,
+            },
+          },
+          "text": "foo",
+        },
+      },
+    },
+  },
+]
+`;


### PR DESCRIPTION
While I've never personally used this syntax, the reference BrightScript implementation seems to support a single dot before an indexed property access, i.e.:

```brightscript
a = { foo: 5 }
print a.["foo"] ' => 5

b = [ 1, 2, 4, 8 ]
print b.[1] ' => 2
```
fixes #332