### PR TITLE
fix(interp): Automatically box return values for 'as object' return types

### DIFF
--- a/src/brsTypes/Boxing.ts
+++ b/src/brsTypes/Boxing.ts
@@ -1,6 +1,5 @@
 import { BrsComponent } from "./components/BrsComponent";
 import { BrsValue, BrsType, ValueKind } from "./";
-import { RoString } from "./components/RoString";
 
 export interface Boxable {
     box(): BrsComponent;

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -1013,6 +1013,14 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
                 if (
                     returnedValue &&
+                    isBoxable(returnedValue) &&
+                    satisfiedSignature.signature.returns === ValueKind.Object
+                ) {
+                    returnedValue = returnedValue.box();
+                }
+
+                if (
+                    returnedValue &&
                     satisfiedSignature.signature.returns !== ValueKind.Dynamic &&
                     satisfiedSignature.signature.returns !== returnedValue.kind
                 ) {

--- a/test/e2e/Functions.test.js
+++ b/test/e2e/Functions.test.js
@@ -49,6 +49,9 @@ describe("end to end functions", () => {
             "2",
             "whileLoopReturn:",
             "3",
+            "boxedReturnType:",
+            "roFloat",
+            "3.14159",
         ]);
     });
 

--- a/test/e2e/resources/function/return.brs
+++ b/test/e2e/resources/function/return.brs
@@ -28,9 +28,17 @@ function whileLoopReturn(stopAt as integer)
     end while
 end function
 
+function boxedReturnType() as object
+    return 3.14159
+end function
+
 ' ----- then execute them -----
 print staticReturn()
 print conditionalReturn(true)
 print conditionalReturn(false)
 print forLoopReturn(2)
 print whileLoopReturn(3)
+
+boxed = boxedReturnType()
+print "boxedReturnType:"
+print type(boxed) boxed ' => RoFloat 3.14159

--- a/test/interpreter/Call.test.js
+++ b/test/interpreter/Call.test.js
@@ -3,7 +3,7 @@ const Stmt = require("../../lib/parser/Statement");
 const { Interpreter } = require("../../lib/interpreter");
 const brs = require("brs");
 const { Lexeme } = brs.lexer;
-const { BrsString, Int32, ValueKind } = brs.types;
+const { BrsString, Int32, roInt, ValueKind } = brs.types;
 
 const { token, identifier } = require("../parser/ParserTests");
 
@@ -60,6 +60,44 @@ describe("interpreter calls", () => {
         let foo = interpreter.environment.get(identifier("foo"));
         expect(foo.kind).toBe(ValueKind.Object);
         expect(foo.get(new BrsString("id"))).toEqual(new BrsString("this is an ID"));
+    });
+
+    it("automatically boxes return values when appropriate", () => {
+        const ast = [
+            new Stmt.Function(
+                identifier("foo"),
+                new Expr.Function(
+                    [],
+                    ValueKind.Object,
+                    new Stmt.Block(
+                        [
+                            new Stmt.Return(
+                                { return: token(Lexeme.Return, "return") },
+                                new Expr.Literal(new Int32(5))
+                            ),
+                        ],
+                        token(Lexeme.Newline, "\n")
+                    )
+                )
+            ),
+            new Stmt.Assignment(
+                { equals: token(Lexeme.Equals, "=") },
+                identifier("result"),
+                new Stmt.Expression(
+                    new Expr.Call(
+                        new Expr.Variable(identifier("foo")),
+                        token(Lexeme.RightParen, ")"),
+                        [] // no args required
+                    )
+                )
+            ),
+        ];
+
+        interpreter.exec(ast);
+
+        let result = interpreter.environment.get(identifier("result"));
+        expect(result.kind).toBe(ValueKind.Object);
+        expect(result.value).toEqual(new roInt(new Int32(5)).value);
     });
 
     it("errors when not enough arguments provided", () => {


### PR DESCRIPTION
RBI will automatically box an intrinsic value when it's returned from a function that declares an `as object` return type.  This makes the function behave quite similarly to an `as dynamic` function, in that it can seemingly return any value.  The only difference is that `as dynamic` won't automatically box something like `return false` into an `roBoolean`, while the `as object` variant will!

fixes #359