### PR TITLE
fix(stdlib): Allow formatJson to serialize boxed types

### DIFF
--- a/src/brsTypes/Boxing.ts
+++ b/src/brsTypes/Boxing.ts
@@ -9,10 +9,10 @@ export interface Unboxable {
     unbox(): BrsType;
 }
 
-export function isBoxable(value: BrsValue): value is BrsValue & Boxable {
+export function isBoxable(value: BrsType): value is BrsType & Boxable {
     return "box" in value;
 }
 
-export function isUnboxable(value: BrsValue): value is BrsValue & Unboxable {
+export function isUnboxable(value: BrsType): value is BrsType & Unboxable {
     return "unbox" in value;
 }

--- a/src/brsTypes/Boxing.ts
+++ b/src/brsTypes/Boxing.ts
@@ -2,17 +2,17 @@ import { BrsComponent } from "./components/BrsComponent";
 import { BrsValue, BrsType, ValueKind } from "./";
 
 export interface Boxable {
-    box(): BrsComponent;
+    box(): BrsType;
 }
 
 export interface Unboxable {
-    unbox(): BrsValue;
+    unbox(): BrsType;
 }
 
-export function isBoxable(value: BrsType): value is BrsType & Boxable {
+export function isBoxable(value: BrsValue): value is BrsValue & Boxable {
     return "box" in value;
 }
 
-export function isUnboxable(value: BrsType): value is BrsType & Unboxable {
+export function isUnboxable(value: BrsValue): value is BrsValue & Unboxable {
     return "unbox" in value;
 }

--- a/src/stdlib/Json.ts
+++ b/src/stdlib/Json.ts
@@ -14,6 +14,7 @@ import {
     ValueKind,
     StdlibArgument,
 } from "../brsTypes";
+import { isUnboxable } from "../brsTypes/Boxing";
 
 /**
  * Converts a value to its representation as a BrsType. If no such
@@ -106,6 +107,9 @@ function jsonOf(
                         return jsonOf(interpreter, el, visited);
                     })
                     .join(",")}]`;
+            }
+            if (isUnboxable(x)) {
+                return jsonOf(interpreter, x.unbox(), visited);
             }
             break;
         case ValueKind.Callable:

--- a/test/e2e/resources/stdlib/json.brs
+++ b/test/e2e/resources/stdlib/json.brs
@@ -11,6 +11,6 @@ print parseJson(formatJson({
     null: invalid,
     longinteger: 2147483650,
     integer: 2147483647,
-    float: 3.14,
+    float: createObject("roFloat", 3.14),
     boolean: false
 }))

--- a/test/stdlib/Json.test.js
+++ b/test/stdlib/Json.test.js
@@ -10,6 +10,7 @@ const {
     Int32,
     Int64,
     Uninitialized,
+    roInt,
 } = require("../../lib/brsTypes");
 
 const { allArgs } = require("../e2e/E2ETests");
@@ -88,6 +89,12 @@ describe("global JSON functions", () => {
         it("converts BRS integer to bare integer string", () => {
             expect(FormatJson.call(interpreter, Int32.fromString("2147483647"))).toEqual(
                 new BrsString("2147483647")
+            );
+        });
+
+        it("converts boxed BRS types to string representations", () => {
+            expect(FormatJson.call(interpreter, new roInt(new Int32(-1)))).toEqual(
+                new BrsString("-1")
             );
         });
 


### PR DESCRIPTION
`formatJson` was written far before boxed types were introduced, and it never gained support for them.  Thanks for catching this, @WilliamsMartinezGLB!

fixes #363