### PR TITLE
fix(interp): Automatically box `as object` function parameters

### DIFF
--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -937,7 +937,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         // evaluate the function to call (it could be the result of another function call)
         const callee = this.evaluate(expression.callee);
         // evaluate all of the arguments as well (they could also be function calls)
-        const args = expression.args.map(this.evaluate, this);
+        let args = expression.args.map(this.evaluate, this);
 
         if (!isBrsCallable(callee)) {
             return this.addError(
@@ -955,6 +955,16 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         if (satisfiedSignature) {
             try {
                 let mPointer = this._environment.getRootM();
+
+                let signature = satisfiedSignature.signature;
+                args = args.map((arg, index) => {
+                    // any arguments of type "object" must be automatically boxed
+                    if (signature.args[index].type.kind === ValueKind.Object && isBoxable(arg)) {
+                        return arg.box();
+                    }
+
+                    return arg;
+                });
 
                 if (
                     expression.callee instanceof Expr.DottedGet ||

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -123,7 +123,7 @@ describe("end to end standard libary", () => {
         await execute([resourceFile("stdlib", "global-utilities.brs")], outputStreams);
 
         expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
-            "<Interface: ifAssociativeArray>",
+            "<Interface: ifFloat>",
         ]);
     });
 });

--- a/test/e2e/resources/stdlib/global-utilities.brs
+++ b/test/e2e/resources/stdlib/global-utilities.brs
@@ -1,3 +1,3 @@
 sub main()
-    print getInterface({}, "ifAssociativeArray");
+    print getInterface(1.123, "ifFloat");
 end sub

--- a/test/interpreter/Call.test.js
+++ b/test/interpreter/Call.test.js
@@ -100,6 +100,30 @@ describe("interpreter calls", () => {
         expect(result.value).toEqual(new roInt(new Int32(5)).value);
     });
 
+    it("automatically boxes arguments when appropriate", () => {
+        const ast = [
+            new Stmt.Assignment(
+                { equals: token(Lexeme.Equals, "=") },
+                identifier("result"),
+                new Stmt.Expression(
+                    new Expr.Call(
+                        new Expr.Variable(identifier("GetInterface")),
+                        token(Lexeme.RightParen, ")"),
+                        [
+                            new Expr.Literal(new BrsString("primitive")), // brsString doesn't implement ifString, but roString does!
+                            new Expr.Literal(new BrsString("ifString")),
+                        ]
+                    )
+                )
+            ),
+        ];
+
+        interpreter.exec(ast);
+
+        let result = interpreter.environment.get(identifier("result"));
+        expect(result.kind).toBe(ValueKind.Interface);
+    });
+
     it("errors when not enough arguments provided", () => {
         const call = new Stmt.Expression(
             new Expr.Call(


### PR DESCRIPTION
Just like with https://github.com/sjbarag/brs/issues/359, function parameters must *also* get automatically boxed.