### PR TITLE
feat(stdlib): Add _brs_.process.argv to mirror node's process.argv

### DIFF
--- a/src/extensions/Process.ts
+++ b/src/extensions/Process.ts
@@ -1,0 +1,8 @@
+import { RoAssociativeArray, BrsString, RoArray } from "../brsTypes";
+
+export const Process = new RoAssociativeArray([
+    {
+        name: new BrsString("argv"),
+        value: new RoArray(process.argv.map(arg => new BrsString(arg))),
+    },
+]);

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -1,8 +1,10 @@
 import { RoAssociativeArray, BrsString } from "../brsTypes";
 import { mockComponent } from "./mockComponent";
 import { RunInScope } from "./RunInScope";
+import { Process } from "./Process";
 
 export const _brs_ = new RoAssociativeArray([
     { name: new BrsString("mockComponent"), value: mockComponent },
     { name: new BrsString("runInScope"), value: RunInScope },
+    { name: new BrsString("process"), value: Process },
 ]);

--- a/test/e2e/BrsNamespace.test.js
+++ b/test/e2e/BrsNamespace.test.js
@@ -1,0 +1,28 @@
+const { execute } = require("../../lib");
+
+const { createMockStreams, resourceFile, allArgs } = require("./E2ETests");
+
+describe("end to end brightscript functions", () => {
+    let outputStreams;
+
+    beforeAll(() => {
+        outputStreams = createMockStreams();
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("_brs_-namespace.brs", async () => {
+        await execute([resourceFile("stdlib", "_brs_-namespace.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+            "_brs_.process.argv is non-empty: ",
+            "true",
+        ]);
+    });
+});

--- a/test/e2e/MultiFile.test.js
+++ b/test/e2e/MultiFile.test.js
@@ -1,4 +1,4 @@
-const { execute } = require("../../lib/");
+const { execute } = require("../../lib");
 
 const { createMockStreams, resourceFile, allArgs } = require("./E2ETests");
 

--- a/test/e2e/resources/stdlib/_brs_-namespace.brs
+++ b/test/e2e/resources/stdlib/_brs_-namespace.brs
@@ -1,0 +1,3 @@
+sub main()
+    print "_brs_.process.argv is non-empty: " _brs_.process.argv.count() > 0
+end sub

--- a/test/extensions/Process.test.js
+++ b/test/extensions/Process.test.js
@@ -1,0 +1,11 @@
+const brs = require("brs");
+const { BrsString } = brs.types;
+const { Process: brsProcess } = require("../../lib/extensions/Process");
+
+describe("_brs_.process", () => {
+    it("mirrors node's process.argv", () => {
+        let brsArgv = brsProcess.get(new BrsString("argv"));
+        expect(brsArgv).toBeDefined();
+        expect(brsArgv.getValue().map(arg => arg.value)).toEqual(process.argv);
+    });
+});


### PR DESCRIPTION
It's currently impossible to access `argv` from a BrightScript file executed with `brs`!  While it's also impossible via the reference BrightScript implementation, there's basically no concept of argv there -- instead they accept an associative array of arguments from the OS that implements RBI.

Piping `process.argv` into `brs` should enable more interactive uses of BrightScript outside of the reference implementation.  While we _could_ theoretically parse `argv` into an associative array similar to [minimist](https://github.com/substack/minimist)'s output, it's probably best to leave that to BrightScript implementations for now.