### PR TITLE
fixes RoAssociativeArray.items() implementation (#370)

### DIFF
--- a/src/brsTypes/components/RoAssociativeArray.ts
+++ b/src/brsTypes/components/RoAssociativeArray.ts
@@ -205,7 +205,20 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
             returns: ValueKind.Object,
         },
         impl: (interpreter: Interpreter) => {
-            return new RoArray(this.getValues());
+            return new RoArray(
+                this.getElements().map((key: BrsString) => {
+                    return new RoAssociativeArray([
+                        {
+                            name: new BrsString("key"),
+                            value: key,
+                        },
+                        {
+                            name: new BrsString("value"),
+                            value: this.get(key),
+                        },
+                    ]);
+                })
+            );
         },
     });
 

--- a/test/brsTypes/components/RoAssociativeArray.test.js
+++ b/test/brsTypes/components/RoAssociativeArray.test.js
@@ -274,7 +274,7 @@ describe("RoAssociativeArray", () => {
             });
         });
 
-        describe("items", () => {
+        describe.only("items", () => {
             it("returns an array of values from the associative array in lexicographical order", () => {
                 let cletter = new BrsString("c");
                 let letter1 = new BrsString("a");
@@ -289,7 +289,12 @@ describe("RoAssociativeArray", () => {
                 let items = aa.getMethod("items");
                 expect(items).toBeTruthy();
                 let result = items.call(interpreter);
-                expect(result.elements).toEqual(new RoArray([letter1, letter2, cletter]).elements);
+                expect(result.elements[0].elements.get("key")).toEqual(new BrsString("cletter"));
+                expect(result.elements[0].elements.get("value")).toEqual(new BrsString("c"));
+                expect(result.elements[1].elements.get("key")).toEqual(new BrsString("letter1"));
+                expect(result.elements[1].elements.get("value")).toEqual(new BrsString("a"));
+                expect(result.elements[2].elements.get("key")).toEqual(new BrsString("letter2"));
+                expect(result.elements[2].elements.get("value")).toEqual(new BrsString("b"));
             });
 
             it("returns an empty array from an empty associative array", () => {

--- a/test/brsTypes/components/RoAssociativeArray.test.js
+++ b/test/brsTypes/components/RoAssociativeArray.test.js
@@ -274,7 +274,7 @@ describe("RoAssociativeArray", () => {
             });
         });
 
-        describe.only("items", () => {
+        describe("items", () => {
             it("returns an array of values from the associative array in lexicographical order", () => {
                 let cletter = new BrsString("c");
                 let letter1 = new BrsString("a");

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -55,6 +55,10 @@ describe("end to end brightscript functions", () => {
             "true",
             "can check for existence: ",
             "true",
+            "items() example key: ",
+            "bar",
+            "items() example value: ",
+            "5",
             "can empty itself: ",
             "true",
         ]);

--- a/test/e2e/resources/components/roAssociativeArray.brs
+++ b/test/e2e/resources/components/roAssociativeArray.brs
@@ -12,6 +12,8 @@ sub main()
     print "can look up elements: " aa.lookup("foo") = "foo"     ' => true
     print "can look up elements (brackets): " aa["foo"] = "foo" ' => true
     print "can check for existence: " aa.doesExist("bar")       ' => true
+    print "items() example key: " aa.items()[0].key             ' => bar
+    print "items() example value: " aa.items()[0].value         ' => 5
 
     aa.clear()
     print "can empty itself: " aa.isEmpty()                     ' => true


### PR DESCRIPTION
This fixes issue #370, where RoAssociativeArray.items() wasn't implemented to match the API spec.  Previously it returned an array of key names while the official spec calls for an array of key/value pairs.  

https://developer.roku.com/docs/references/brightscript/interfaces/ifassociativearray.md#items-as-object

Verified E2E test on a Roku device.  

fixes #370