### PR TITLE
fix(manifest): Fix parsing of numbers in manifest

### DIFF
--- a/src/preprocessor/Manifest.ts
+++ b/src/preprocessor/Manifest.ts
@@ -89,7 +89,8 @@ export function parseManifest(contents: string) {
                 return [key, false];
             }
 
-            let maybeNumber = Number.parseInt(value);
+            let maybeNumber = Number(value);
+
             // if it's not a number, it's just a string
             if (Number.isNaN(maybeNumber)) {
                 return [key, value];

--- a/test/preprocessor/Manifest.test.js
+++ b/test/preprocessor/Manifest.test.js
@@ -56,7 +56,10 @@ describe("manifest support", () => {
 
         it("parses key-value pairs", () => {
             fs.readFile.mockImplementation((filename, encoding, cb) =>
-                cb(/* no error */ null, ["foo=bar=baz", "lorem=true", "five=5"].join("\n"))
+                cb(
+                    /* no error */ null,
+                    ["foo=bar=baz", "lorem=true", "five=5", "six=6.000", "version=1.2.3"].join("\n")
+                )
             );
 
             return expect(getManifest("/has/a/manifest")).resolves.toEqual(
@@ -64,6 +67,8 @@ describe("manifest support", () => {
                     ["foo", "bar=baz"],
                     ["lorem", true],
                     ["five", 5],
+                    ["six", 6],
+                    ["version", "1.2.3"],
                 ])
             );
         });


### PR DESCRIPTION
We were previously not handling number parsing properly, with two nasty side-effects:

1. Floating-point values were truncated to integer values only (e.g. `"3.14" => 3`)
2. Strings that began with numbers were parsed as numbers and also truncated (e.g. `"1.2.3.4.5" => 1`)

Both of these stemmed from my misreading of the docs for `parseInt`; what I actually wanted was the `Number()` function followed by `Number.isNaN()`!