### PR TITLE
bug(interp): Allow Float parameters passed into function signatures expecting Double

### DIFF
--- a/src/brsTypes/Callable.ts
+++ b/src/brsTypes/Callable.ts
@@ -5,6 +5,7 @@ import { Scope } from "../interpreter/Environment";
 import { Location } from "../lexer";
 import { Int32 } from "./Int32";
 import { Float } from "./Float";
+import { Double } from "./Double";
 
 /** An argument to a BrightScript `function` or `sub`. */
 export interface Argument {
@@ -270,6 +271,14 @@ export class Callable implements Brs.BrsValue {
                 received.kind === Brs.ValueKind.Float
             ) {
                 args[index] = new Int32(received.getValue());
+                return;
+            }
+
+            if (
+                expected.type.kind === Brs.ValueKind.Double &&
+                received.kind === Brs.ValueKind.Float
+            ) {
+                args[index] = new Double(received.getValue());
                 return;
             }
 

--- a/test/brsTypes/Callable.test.js
+++ b/test/brsTypes/Callable.test.js
@@ -146,7 +146,7 @@ describe("Callable", () => {
         });
 
         it("allows float to be passed to a double argument", () => {
-            const hasArgs = new BrsTypes.Callable("acceptsAnything", {
+            const hasArgs = new BrsTypes.Callable("acceptsDouble", {
                 signature: {
                     args: [new BrsTypes.StdlibArgument("doubleArg", BrsTypes.ValueKind.Double)],
                     returns: BrsTypes.String,

--- a/test/brsTypes/Callable.test.js
+++ b/test/brsTypes/Callable.test.js
@@ -145,6 +145,22 @@ describe("Callable", () => {
             ).toEqual([]);
         });
 
+        it("allows float to be passed to a double argument", () => {
+            const hasArgs = new BrsTypes.Callable("acceptsAnything", {
+                signature: {
+                    args: [new BrsTypes.StdlibArgument("doubleArg", BrsTypes.ValueKind.Double)],
+                    returns: BrsTypes.String,
+                },
+                impl: () => {},
+            });
+
+            expect(
+                hasArgs
+                    .getAllSignatureMismatches([new BrsTypes.Float(1.5)])
+                    .map(mm => mm.mismatches)[0]
+            ).toEqual([]);
+        });
+
         it("allows integer to be passed to a float argument", () => {
             const hasArgs = new BrsTypes.Callable("acceptsAnything", {
                 signature: {


### PR DESCRIPTION
I based this off the [changes made to convert float -> int](https://github.com/underwoo16/brs/blob/7add6ce4dd9826226ea3e1d1ff70f5174aafecff/src/brsTypes/Callable.ts#L262) from this PR: https://github.com/sjbarag/brs/pull/291

fixes https://github.com/sjbarag/brs/issues/384