### PR TITLE
Fix path.join bug in test when run on windows.

### DIFF
--- a/test/componentprocessor/componentprocessor.test.js
+++ b/test/componentprocessor/componentprocessor.test.js
@@ -98,7 +98,7 @@ describe.only("component parsing support", () => {
 
                 const expectedPrefix = "pkg:/test/componentprocessor/resources/scripts/";
                 let expectedScripts = ["extendedComponent.brs", "utility.brs"].map(scriptName =>
-                    path.join(expectedPrefix, scriptName)
+                    path.posix.join(expectedPrefix, scriptName)
                 );
                 let actualScripts = parsedExtendedComp.scripts.map(script => script.uri);
                 expect(actualScripts).toEqual(expectedScripts);


### PR DESCRIPTION
Fix a test that fails on windows devices due to using `path.join`. The test passes now by using `path.posix.join` instead as suggested in #393