### PR TITLE
fix(parser): Parse scripts included in components

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,10 +44,7 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
         if (component.scripts.length < 1) return;
         try {
             component.scripts = component.scripts.map((script: ComponentScript) => {
-                script.uri = path.join(
-                    options.root ? options.root : executionOptions.root,
-                    new URL(script.uri).pathname
-                );
+                script.uri = path.join(executionOptions.root, new URL(script.uri).pathname);
                 return script;
             });
         } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
         try {
             component.scripts = component.scripts.map((script: ComponentScript) => {
                 script.uri = path.join(
-                    options.root ? options.root : __dirname,
+                    options.root ? options.root : executionOptions.root,
                     new URL(script.uri).pathname
                 );
                 return script;


### PR DESCRIPTION
Scripts in components weren't parsed because they couldn't be found, `__dirname` references the path of the actual js script and not the brightscript project were we want to run the tests.

Fixes: #389 
