### PR TITLE
Fix bug where child fields are always treated as strings

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -1189,9 +1189,18 @@ function addChildren(interpreter: Interpreter, node: RoSGNode, typeDef: Componen
         if (newChild instanceof RoSGNode && appendChild) {
             appendChild.call(interpreter, newChild);
             let setField = newChild.getMethod("setfield");
-            for (let [key, value] of Object.entries(child.fields)) {
-                if (setField) {
-                    setField.call(interpreter, new BrsString(key), new BrsString(value));
+            if (setField) {
+                let nodeFields = newChild.getFields();
+                for (let [key, value] of Object.entries(child.fields)) {
+                    let field = nodeFields.get(key);
+                    if (field) {
+                        setField.call(
+                            interpreter,
+                            new BrsString(key),
+                            // use the field type to construct the field value
+                            getBrsValueFromFieldType(field.getType(), value)
+                        );
+                    }
                 }
             }
         }

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -392,6 +392,8 @@ describe("end to end brightscript functions", () => {
             "true",
             "extended group node opacity:",
             "1",
+            "group as child node rotation:",
+            "0.2",
         ]);
     });
 });

--- a/test/e2e/resources/components/Group.brs
+++ b/test/e2e/resources/components/Group.brs
@@ -8,4 +8,8 @@ sub Main()
     print "extended group node type:" type(extendedGroupNode)                      ' => ExtendedGroup
     print "extended group node visible:" extendedGroupNode.visible                 ' => true
     print "extended group node opacity:" extendedGroupNode.opacity                 ' => 1
+
+    parentOfGroup = createObject("roSGNode", "GroupAsChild")
+    groupAsChild = parentOfGroup.findNode("childgroup")
+    print "group as child node rotation:" groupAsChild.rotation
 end sub

--- a/test/e2e/resources/components/GroupAsChild.xml
+++ b/test/e2e/resources/components/GroupAsChild.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="GroupAsChild">
+    <children>
+        <Group id="childgroup" rotation="0.2" />
+    </children>
+</component>


### PR DESCRIPTION
# Change summary
I noticed that when you referenced a component as a child and tried to set its fields, it only worked when they were strings. For example:
```
<component name="foo">
  <children>
    <Group
        id="group"
        childRenderOrder="renderLast"
        opacity="0.2"
    />
  <children>
</component>
```
```
foo = createObject("roSGNode", "foo")
group = foo.findNode("group")
print group.childRenderOrder    ' => "renderLast"
print group.opacity                     ' => "1.0" (or whatever default is)
```

This PR fixes that case by finding and using the type of the field being set.