### PR TITLE
fix(stdlib): component node type bug

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -79,8 +79,8 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         { name: "id", type: "string" },
     ];
 
-    constructor(initializedFields: AAMember[], readonly type: string = "Node") {
-        super(type);
+    constructor(initializedFields: AAMember[], readonly nodeSubtype: string = "Node") {
+        super("Node");
 
         // All nodes start have some built-in fields when created.
         this.registerDefaultFields(this.defaultFields);
@@ -136,7 +136,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     }
 
     toString(parent?: BrsType): string {
-        let componentName = "roSGNode:" + this.type;
+        let componentName = "roSGNode:" + this.nodeSubtype;
 
         if (parent) {
             return `<Component: ${componentName}>`;
@@ -1067,7 +1067,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             returns: ValueKind.String,
         },
         impl: (interpreter: Interpreter) => {
-            return new BrsString(this.type);
+            return new BrsString(this.nodeSubtype);
         },
     });
 

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -381,12 +381,16 @@ describe("end to end brightscript functions", () => {
 
         expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
             "group node type:",
+            "Node",
+            "group node subtype:",
             "Group",
             "group node visible:",
             "true",
             "group node opacity:",
             "1",
             "extended group node type:",
+            "Node",
+            "extended group node subtype:",
             "ExtendedGroup",
             "extended group node visible:",
             "true",
@@ -403,6 +407,8 @@ describe("end to end brightscript functions", () => {
 
         expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
             "layoutGroup node type:",
+            "Node",
+            "layoutGroup node subtype:",
             "LayoutGroup",
             "layoutGroup node layoutDirection:",
             "vert",
@@ -421,6 +427,8 @@ describe("end to end brightscript functions", () => {
 
         expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
             "rectangle node type:",
+            "Node",
+            "rectangle node subtype:",
             "Rectangle",
             "rectangle node width:",
             "0",
@@ -439,6 +447,8 @@ describe("end to end brightscript functions", () => {
 
         expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
             "label node type:",
+            "Node",
+            "label node subtype:",
             "Label",
             "label node horizAlign:",
             "left",
@@ -459,6 +469,8 @@ describe("end to end brightscript functions", () => {
 
         expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
             "font node type:",
+            "Node",
+            "font node subtype:",
             "Font",
             "font node uri:",
             "",
@@ -479,6 +491,8 @@ describe("end to end brightscript functions", () => {
 
         expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
             "poster node type:",
+            "Node",
+            "poster node subtype:",
             "Poster",
             "poster node width:",
             "0",

--- a/test/e2e/resources/components/Font.brs
+++ b/test/e2e/resources/components/Font.brs
@@ -1,6 +1,7 @@
 sub Main()
     font = createObject("roSGNode", "Font")
     print "font node type:" type(font)
+    print "font node subtype:" font.subtype()
     print "font node uri:" font.uri
     print "font node size:" font.size
     print "font node fallbackGlyph:" font.fallbackGlyph

--- a/test/e2e/resources/components/Group.brs
+++ b/test/e2e/resources/components/Group.brs
@@ -1,11 +1,13 @@
 sub Main()
     groupNode = createObject("roSGNode", "Group")
     print "group node type:" type(groupNode)                                       ' => Group
+    print "group node subtype:" groupNode.subtype()
     print "group node visible:" groupNode.visible                                  ' => true
     print "group node opacity:" groupNode.opacity                                  ' => 1
 
     extendedGroupNode = createObject("roSGNode", "ExtendedGroup")
     print "extended group node type:" type(extendedGroupNode)                      ' => ExtendedGroup
+    print "extended group node subtype:" extendedGroupNode.subtype()
     print "extended group node visible:" extendedGroupNode.visible                 ' => true
     print "extended group node opacity:" extendedGroupNode.opacity                 ' => 1
 

--- a/test/e2e/resources/components/Label.brs
+++ b/test/e2e/resources/components/Label.brs
@@ -1,6 +1,7 @@
 sub Main()
     label = createObject("roSGNode", "Label")
     print "label node type:" type(label)
+    print "label node subtype:" label.subtype()
     print "label node horizAlign:" label.horizAlign
     print "label node numLines:" label.numLines
 

--- a/test/e2e/resources/components/LayoutGroup.brs
+++ b/test/e2e/resources/components/LayoutGroup.brs
@@ -1,6 +1,7 @@
 sub Main()
     layoutGroup = createObject("roSGNode", "LayoutGroup")
     print "layoutGroup node type:" type(layoutGroup)                                       ' => Group
+    print "layoutGroup node subtype:" layoutGroup.subtype()
     print "layoutGroup node layoutDirection:" layoutGroup.layoutDirection
     print "layoutGroup node horizAlignment:" layoutGroup.horizAlignment
 

--- a/test/e2e/resources/components/LayoutGroup.brs
+++ b/test/e2e/resources/components/LayoutGroup.brs
@@ -1,6 +1,6 @@
 sub Main()
     layoutGroup = createObject("roSGNode", "LayoutGroup")
-    print "layoutGroup node type:" type(layoutGroup)                                       ' => Group
+    print "layoutGroup node type:" type(layoutGroup)
     print "layoutGroup node subtype:" layoutGroup.subtype()
     print "layoutGroup node layoutDirection:" layoutGroup.layoutDirection
     print "layoutGroup node horizAlignment:" layoutGroup.horizAlignment

--- a/test/e2e/resources/components/Poster.brs
+++ b/test/e2e/resources/components/Poster.brs
@@ -1,6 +1,6 @@
 sub Main()
     poster = createObject("roSGNode", "Poster")
-    print "poster node type:" type(poster)                                       ' => Group
+    print "poster node type:" type(poster)
     print "poster node subtype:" poster.subtype()
     print "poster node width:" poster.width
     print "poster node height:" poster.height

--- a/test/e2e/resources/components/Poster.brs
+++ b/test/e2e/resources/components/Poster.brs
@@ -1,6 +1,7 @@
 sub Main()
     poster = createObject("roSGNode", "Poster")
     print "poster node type:" type(poster)                                       ' => Group
+    print "poster node subtype:" poster.subtype()
     print "poster node width:" poster.width
     print "poster node height:" poster.height
 

--- a/test/e2e/resources/components/Rectangle.brs
+++ b/test/e2e/resources/components/Rectangle.brs
@@ -1,6 +1,7 @@
 sub Main()
     rect = createObject("roSGNode", "Rectangle")
     print "rectangle node type:" type(rect)                                       ' => Group
+    print "rectangle node subtype:" rect.subtype()
     print "rectangle node width:" rect.width
     print "rectangle node height:" rect.height
 

--- a/test/e2e/resources/components/Rectangle.brs
+++ b/test/e2e/resources/components/Rectangle.brs
@@ -1,6 +1,6 @@
 sub Main()
     rect = createObject("roSGNode", "Rectangle")
-    print "rectangle node type:" type(rect)                                       ' => Group
+    print "rectangle node type:" type(rect)
     print "rectangle node subtype:" rect.subtype()
     print "rectangle node width:" rect.width
     print "rectangle node height:" rect.height


### PR DESCRIPTION
# Change Summary
This fixes a bug where the wrong value is used for `type(component)`.
Expected outcome:
```
group = createObject("roSGNode", "Group")
type(group) ' => "Node"
group.subtype() ' => "Group"
```
Actual outcome:
```
group = createObject("roSGNode", "Group")
type(group) ' => "Group"
group.subtype() ' => "Group"
```