### PR TITLE
Change promise rejection to console.error

### DIFF
--- a/src/parser/ComponentScopeResolver.ts
+++ b/src/parser/ComponentScopeResolver.ts
@@ -72,9 +72,10 @@ export class ComponentScopeResolver {
             let previousComponent = currentComponent;
             currentComponent = this.componentMap.get(currentComponent.extends);
             if (!currentComponent) {
-                return Promise.reject({
-                    message: `Cannot find extended component ${previousComponent.extends} defined on ${previousComponent.name}`,
-                });
+                console.error(
+                    `Cannot find extended component ${previousComponent.extends} defined on ${previousComponent.name}`,
+                );
+                return Promise.resolve();
             }
             yield this.parserLexerFn(currentComponent.scripts.map(c => c.uri));
         }

--- a/src/parser/ComponentScopeResolver.ts
+++ b/src/parser/ComponentScopeResolver.ts
@@ -73,7 +73,7 @@ export class ComponentScopeResolver {
             currentComponent = this.componentMap.get(currentComponent.extends);
             if (!currentComponent) {
                 console.error(
-                    `Cannot find extended component ${previousComponent.extends} defined on ${previousComponent.name}`,
+                    `Cannot find extended component ${previousComponent.extends} defined on ${previousComponent.name}`
                 );
                 return Promise.resolve();
             }


### PR DESCRIPTION
# Change Summary
This removes a `Promise.reject` that was polluting test case output with tons of these:
```
UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 38)
```

In its stead, we have a `console.error`. We _are_ doubling up on the `console.error`s, because we have one for essentially the same issue [over here](https://github.com/sjbarag/brs/blob/master/src/componentprocessor/index.ts#L157-L159), but that's still less verbose/cleaner than the promise rejection error.
