### PR TITLE
fix(rsg): Make types initialize a little better

### DIFF
--- a/src/brsTypes/BrsType.ts
+++ b/src/brsTypes/BrsType.ts
@@ -121,7 +121,7 @@ export function getValueKindFromFieldType(type: string) {
         case "string":
             return ValueKind.String;
         case "function":
-            return ValueKind.Callable
+            return ValueKind.Callable;
         case "node":
         case "roarray":
         case "array":

--- a/src/brsTypes/BrsType.ts
+++ b/src/brsTypes/BrsType.ts
@@ -102,7 +102,8 @@ export namespace ValueKind {
 
 /**
  *  Converts a specified brightscript type in string into BrsType representation, with actual value
- *  Note: only supports native types so far.  Objects such as array/AA aren't handled at the moment.
+ *  Note: only native types are fully supported so far. Objects such as node/array/AA are created with default values,
+ *  instead of the value that gets passed in.
  *  @param {string} type data type of field
  *  @param {string} value optional value specified as string
  *  @returns {BrsType} BrsType value representation of the type

--- a/src/brsTypes/BrsType.ts
+++ b/src/brsTypes/BrsType.ts
@@ -5,6 +5,8 @@ import { Int32 } from "./Int32";
 import { Float } from "./Float";
 import { roBoolean } from "./components/RoBoolean";
 import { roInvalid } from "./components/RoInvalid";
+import { RoAssociativeArray } from "./components/RoAssociativeArray";
+import { RoArray } from "./components/RoArray";
 
 /** Set of values supported in BrightScript. */
 export enum ValueKind {
@@ -123,13 +125,13 @@ export function getBrsValueFromFieldType(type: string, value?: string): BrsType 
         case "float":
             returnValue = value ? new Float(Number.parseFloat(value)) : new Float(0);
             break;
-        case "roArray":
+        case "roarray":
         case "array":
-            returnValue = BrsInvalid.Instance;
+            returnValue = new RoArray([]);
             break;
-        case "roAssociativeArray":
+        case "roassociativearray":
         case "assocarray":
-            returnValue = BrsInvalid.Instance;
+            returnValue = new RoAssociativeArray([]);
             break;
         case "uri":
         case "str":

--- a/src/brsTypes/BrsType.ts
+++ b/src/brsTypes/BrsType.ts
@@ -101,6 +101,39 @@ export namespace ValueKind {
 }
 
 /**
+ * Converts the data type of a field to the appropriate value kind.
+ * @param type data type of field
+ */
+export function getValueKindFromFieldType(type: string) {
+    switch (type.toLowerCase()) {
+        case "bool":
+        case "boolean":
+            return ValueKind.Boolean;
+        case "int":
+        case "integer":
+            return ValueKind.Int32;
+        case "longinteger":
+            return ValueKind.Int64;
+        case "float":
+            return ValueKind.Float;
+        case "uri":
+        case "str":
+        case "string":
+            return ValueKind.String;
+        case "function":
+            return ValueKind.Callable
+        case "node":
+        case "roarray":
+        case "array":
+        case "roassociativearray":
+        case "assocarray":
+            return ValueKind.Object;
+        default:
+            return ValueKind.Invalid;
+    }
+}
+
+/**
  *  Converts a specified brightscript type in string into BrsType representation, with actual value
  *  Note: only native types are fully supported so far. Objects such as node/array/AA are created with default values,
  *  instead of the value that gets passed in.

--- a/src/brsTypes/components/RoAssociativeArray.ts
+++ b/src/brsTypes/components/RoAssociativeArray.ts
@@ -125,7 +125,7 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
             returns: ValueKind.Boolean,
         },
         impl: (interpreter: Interpreter, str: BrsString) => {
-            let deleted = this.elements.delete(str.value);
+            let deleted = this.elements.delete(str.value.toLowerCase());
             return BrsBoolean.from(deleted);
         },
     });

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -77,6 +77,7 @@ export class Field {
         this.hidden = false;
 
         let oldValue = this.value;
+        this.type = ValueKind.toString(value.kind);
         this.value = value;
         if (this.alwaysNotify || oldValue !== value) {
             this.observers.map(this.executeCallbacks.bind(this));
@@ -261,8 +262,13 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
         if (!field) {
             field = new Field(value, alwaysNotify);
-        } else if (field.getType() === valueType) {
-            //Fields are not overwritten if they haven't the same type
+        } else if (
+            field.getType() === ValueKind.toString(ValueKind.Invalid) ||
+            field.getType() === ValueKind.toString(ValueKind.Uninitialized) ||
+            field.getType() === valueType
+        ) {
+            // Fields are not overwritten if they haven't the same type.
+            // The exception is if the field's "type" is invalid or uninitialized.
             field.setValue(value);
         }
         this.fields.set(mapKey, field);

--- a/test/brsTypes/components/ArrayGrid.test.js
+++ b/test/brsTypes/components/ArrayGrid.test.js
@@ -9,27 +9,27 @@ describe("ArrayGrid", () => {
             expect(group.toString()).toEqual(
                 `<Component: roSGNode:ArrayGrid> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
     visible: true
     opacity: 1
-    translation: invalid
+    translation: <Component: roArray>
     rotation: 0
-    scale: invalid
-    scalerotatecenter: invalid
+    scale: <Component: roArray>
+    scalerotatecenter: <Component: roArray>
     childrenderorder: renderLast
     inheritparenttransform: true
     inheritparentopacity: true
-    clippingrect: invalid
+    clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
     rendertracking: disabled
     content: invalid
-    itemsize: invalid
-    itemspacing: invalid
+    itemsize: <Component: roArray>
+    itemspacing: <Component: roArray>
     numrows: 0
     numcolumns: 0
     focusrow: 0
@@ -49,10 +49,10 @@ describe("ArrayGrid", () => {
     wrapdividerheight: 36
     fixedlayout: false
     numrenderpasses: 1
-    rowheights: invalid
-    columnwidths: invalid
-    rowspacings: invalid
-    columnspacings: invalid
+    rowheights: <Component: roArray>
+    columnwidths: <Component: roArray>
+    rowspacings: <Component: roArray>
+    columnspacings: <Component: roArray>
     sectiondividerbitmapuri: 
     sectiondividerfont: invalid
     sectiondividertextcolor: 
@@ -61,7 +61,7 @@ describe("ArrayGrid", () => {
     sectiondividerheight: 0
     sectiondividerminwidth: 0
     sectiondividerleftoffset: 0
-    itemclippingrect: invalid
+    itemclippingrect: <Component: roArray>
     itemselected: 0
     itemfocused: 0
     itemunfocused: 0

--- a/test/brsTypes/components/ContentNode.test.js
+++ b/test/brsTypes/components/ContentNode.test.js
@@ -10,7 +10,7 @@ describe("ContentNode.js", () => {
             expect(node.toString()).toEqual(
                 `<Component: roSGNode:ContentNode> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
@@ -142,7 +142,7 @@ describe("ContentNode.js", () => {
                 expect(node.toString()).toEqual(
                     `<Component: roSGNode:ContentNode> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
@@ -160,7 +160,7 @@ describe("ContentNode.js", () => {
                 expect(node.toString()).toEqual(
                     `<Component: roSGNode:ContentNode> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
@@ -182,7 +182,7 @@ describe("ContentNode.js", () => {
                 expect(node.toString()).toEqual(
                     `<Component: roSGNode:ContentNode> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
@@ -205,7 +205,7 @@ describe("ContentNode.js", () => {
                 expect(node.toString()).toEqual(
                     `<Component: roSGNode:ContentNode> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
@@ -223,7 +223,7 @@ describe("ContentNode.js", () => {
                 expect(node.toString()).toEqual(
                     `<Component: roSGNode:ContentNode> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
@@ -241,7 +241,7 @@ describe("ContentNode.js", () => {
                 expect(node.toString()).toEqual(
                     `<Component: roSGNode:ContentNode> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 

--- a/test/brsTypes/components/Font.test.js
+++ b/test/brsTypes/components/Font.test.js
@@ -9,7 +9,7 @@ describe("Font", () => {
             expect(group.toString()).toEqual(
                 `<Component: roSGNode:Font> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 

--- a/test/brsTypes/components/Group.test.js
+++ b/test/brsTypes/components/Group.test.js
@@ -9,20 +9,20 @@ describe("Group", () => {
             expect(group.toString()).toEqual(
                 `<Component: roSGNode:Group> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
     visible: true
     opacity: 1
-    translation: invalid
+    translation: <Component: roArray>
     rotation: 0
-    scale: invalid
-    scalerotatecenter: invalid
+    scale: <Component: roArray>
+    scalerotatecenter: <Component: roArray>
     childrenderorder: renderLast
     inheritparenttransform: true
     inheritparentopacity: true
-    clippingrect: invalid
+    clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false

--- a/test/brsTypes/components/Label.test.js
+++ b/test/brsTypes/components/Label.test.js
@@ -9,20 +9,20 @@ describe("Label", () => {
             expect(group.toString()).toEqual(
                 `<Component: roSGNode:Label> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
     visible: true
     opacity: 1
-    translation: invalid
+    translation: <Component: roArray>
     rotation: 0
-    scale: invalid
-    scalerotatecenter: invalid
+    scale: <Component: roArray>
+    scalerotatecenter: <Component: roArray>
     childrenderorder: renderLast
     inheritparenttransform: true
     inheritparentopacity: true
-    clippingrect: invalid
+    clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false

--- a/test/brsTypes/components/LayoutGroup.test.js
+++ b/test/brsTypes/components/LayoutGroup.test.js
@@ -9,20 +9,20 @@ describe("LayoutGroup", () => {
             expect(group.toString()).toEqual(
                 `<Component: roSGNode:LayoutGroup> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
     visible: true
     opacity: 1
-    translation: invalid
+    translation: <Component: roArray>
     rotation: 0
-    scale: invalid
-    scalerotatecenter: invalid
+    scale: <Component: roArray>
+    scalerotatecenter: <Component: roArray>
     childrenderorder: renderLast
     inheritparenttransform: true
     inheritparentopacity: true
-    clippingrect: invalid
+    clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
@@ -30,7 +30,7 @@ describe("LayoutGroup", () => {
     layoutdirection: vert
     horizalignment: left
     vertalignment: top
-    itemspacings: invalid
+    itemspacings: <Component: roArray>
     additemspacingafterchild: true
 }`
             );

--- a/test/brsTypes/components/MarkupGrid.test.js
+++ b/test/brsTypes/components/MarkupGrid.test.js
@@ -9,27 +9,27 @@ describe("MarkupGrid", () => {
             expect(group.toString()).toEqual(
                 `<Component: roSGNode:MarkupGrid> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
     visible: true
     opacity: 1
-    translation: invalid
+    translation: <Component: roArray>
     rotation: 0
-    scale: invalid
-    scalerotatecenter: invalid
+    scale: <Component: roArray>
+    scalerotatecenter: <Component: roArray>
     childrenderorder: renderLast
     inheritparenttransform: true
     inheritparentopacity: true
-    clippingrect: invalid
+    clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
     rendertracking: disabled
     content: invalid
-    itemsize: invalid
-    itemspacing: invalid
+    itemsize: <Component: roArray>
+    itemspacing: <Component: roArray>
     numrows: 12
     numcolumns: 0
     focusrow: 0
@@ -49,10 +49,10 @@ describe("MarkupGrid", () => {
     wrapdividerheight: 0
     fixedlayout: false
     numrenderpasses: 1
-    rowheights: invalid
-    columnwidths: invalid
-    rowspacings: invalid
-    columnspacings: invalid
+    rowheights: <Component: roArray>
+    columnwidths: <Component: roArray>
+    rowspacings: <Component: roArray>
+    columnspacings: <Component: roArray>
     sectiondividerbitmapuri: 
     sectiondividerfont: invalid
     sectiondividertextcolor: 0xDDDDDDFF
@@ -61,7 +61,7 @@ describe("MarkupGrid", () => {
     sectiondividerheight: 40
     sectiondividerminwidth: 117
     sectiondividerleftoffset: 0
-    itemclippingrect: invalid
+    itemclippingrect: <Component: roArray>
     itemselected: 0
     itemfocused: 0
     itemunfocused: 0

--- a/test/brsTypes/components/Poster.test.js
+++ b/test/brsTypes/components/Poster.test.js
@@ -9,20 +9,20 @@ describe("Poster", () => {
             expect(group.toString()).toEqual(
                 `<Component: roSGNode:Poster> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
     visible: true
     opacity: 1
-    translation: invalid
+    translation: <Component: roArray>
     rotation: 0
-    scale: invalid
-    scalerotatecenter: invalid
+    scale: <Component: roArray>
+    scalerotatecenter: <Component: roArray>
     childrenderorder: renderLast
     inheritparenttransform: true
     inheritparentopacity: true
-    clippingrect: invalid
+    clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
@@ -37,7 +37,7 @@ describe("Poster", () => {
     loadstatus: noScale
     bitmapwidth: 0
     bitmapheight: 0
-    bitmapmargins: invalid
+    bitmapmargins: <Component: roAssociativeArray>
     blendcolor: 0xFFFFFFFF
     loadingbitmapuri: 
     loadingbitmapopacity: 1

--- a/test/brsTypes/components/Rectangle.test.js
+++ b/test/brsTypes/components/Rectangle.test.js
@@ -9,20 +9,20 @@ describe("Rectangle", () => {
             expect(group.toString()).toEqual(
                 `<Component: roSGNode:Rectangle> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
     visible: true
     opacity: 1
-    translation: invalid
+    translation: <Component: roArray>
     rotation: 0
-    scale: invalid
-    scalerotatecenter: invalid
+    scale: <Component: roArray>
+    scalerotatecenter: <Component: roArray>
     childrenderorder: renderLast
     inheritparenttransform: true
     inheritparentopacity: true
-    clippingrect: invalid
+    clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -25,7 +25,6 @@ describe("RoSGNode", () => {
                 { name: new BrsString("boolean"), value: BrsBoolean.True },
                 { name: new BrsString("string"), value: new BrsString("a string") },
                 { name: new BrsString("number"), value: new Int32(-1) },
-                { name: new BrsString("invalid"), value: BrsInvalid.Instance },
             ]);
             expect(node.toString()).toEqual(
                 `<Component: roSGNode:Node> =
@@ -40,7 +39,6 @@ describe("RoSGNode", () => {
     boolean: true
     string: a string
     number: -1
-    invalid: invalid
 }`
             );
         });
@@ -290,11 +288,6 @@ describe("RoSGNode", () => {
                     .get("change")
                     .getValue();
 
-                let change = node
-                    .getFields()
-                    .get("change")
-                    .getValue();
-
                 let items = node.getMethod("items");
                 expect(items).toBeTruthy();
 
@@ -393,6 +386,7 @@ describe("RoSGNode", () => {
                     { name: new BrsString("boolean"), value: BrsBoolean.True },
                     { name: new BrsString("string"), value: new BrsString("a string") },
                     { name: new BrsString("number"), value: new Int32(-1) },
+                    // should not add an invalid field
                     { name: new BrsString("invalid"), value: BrsInvalid.Instance },
                 ]);
 
@@ -401,7 +395,7 @@ describe("RoSGNode", () => {
 
                 let result = addFields.call(interpreter, fields);
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getFields().size).toEqual(10);
+                expect(node.getFields().size).toEqual(9);
             });
 
             it("doesn't add duplicated fields", () => {
@@ -419,11 +413,12 @@ describe("RoSGNode", () => {
                 let moreFields = new RoAssociativeArray([
                     { name: new BrsString("field1"), value: new BrsString("my string") },
                     { name: new BrsString("field2"), value: new Int32(-10) },
+                    // should not add an invalid field
                     { name: new BrsString("field3"), value: BrsInvalid.Instance },
                 ]);
                 result = addFields.call(interpreter, moreFields);
                 expect(result).toEqual(BrsBoolean.True);
-                expect(node.getFields().size).toEqual(7); //Only adds the non duplicated
+                expect(node.getFields().size).toEqual(6); //Only adds the non duplicated
             });
 
             it("only adds fields if passed as an associative array", () => {

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -30,7 +30,7 @@ describe("RoSGNode", () => {
             expect(node.toString()).toEqual(
                 `<Component: roSGNode:Node> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 
@@ -285,6 +285,10 @@ describe("RoSGNode", () => {
                     { name: new BrsString("letter1"), value: letter1 },
                     { name: new BrsString("letter2"), value: letter2 },
                 ]);
+                let change = node
+                    .getFields()
+                    .get("change")
+                    .getValue();
 
                 let change = node
                     .getFields()

--- a/test/brsTypes/components/RoSGNodeEvent.test.js
+++ b/test/brsTypes/components/RoSGNodeEvent.test.js
@@ -13,7 +13,8 @@ describe("RoSGNodeEvent", () => {
     ]);
     let fieldName = new BrsString("fieldName");
     let fieldValue = new BrsString("fieldValue");
-    let field = new Field(fieldValue, false);
+    console.log(Field);
+    let field = new Field(fieldValue, "string", false);
 
     describe("stringification", () => {
         it("prints out correctly", () => {

--- a/test/brsTypes/components/RoSGNodeEvent.test.js
+++ b/test/brsTypes/components/RoSGNodeEvent.test.js
@@ -13,7 +13,6 @@ describe("RoSGNodeEvent", () => {
     ]);
     let fieldName = new BrsString("fieldName");
     let fieldValue = new BrsString("fieldValue");
-    console.log(Field);
     let field = new Field(fieldValue, "string", false);
 
     describe("stringification", () => {

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -624,4 +624,17 @@ describe("end to end brightscript functions", () => {
             "subtitle.example.com",
         ]);
     });
+
+    test("components/scripts/ComponentFields.brs", async () => {
+        await execute(
+            [resourceFile("components", "scripts", "ComponentFields.brs")],
+            outputStreams
+        );
+
+        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+            "bar",
+            "invalid",
+            "Node",
+        ]);
+    });
 });

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -634,6 +634,7 @@ describe("end to end brightscript functions", () => {
         expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
             "bar",
             "invalid",
+            "invalid",
             "Node",
         ]);
     });

--- a/test/e2e/resources/components/scripts/ComponentFields.brs
+++ b/test/e2e/resources/components/scripts/ComponentFields.brs
@@ -1,0 +1,16 @@
+' Tests to make sure that we can add fields
+sub Main()
+    node = createObject("roSGNode", "Node")
+    node.addField("myAssocArray", "assocarray", false)
+
+    node.myAssocArray = {
+        foo: "bar"
+    }
+    print node.myAssocArray.foo ' => "bar"
+
+    node.addField("myNode", "node", false)
+    print node.myNode ' => invalid
+
+    node.myNode = createObject("roSGNode", "Node")
+    print node.myNode.subtype() ' => "Node"
+end sub

--- a/test/e2e/resources/components/scripts/ComponentFields.brs
+++ b/test/e2e/resources/components/scripts/ComponentFields.brs
@@ -11,6 +11,10 @@ sub Main()
     node.addField("myNode", "node", false)
     print node.myNode ' => invalid
 
+    ' set an incorrect value to the node
+    node.myNode = 123
+    print node.myNode ' => invalid
+
     node.myNode = createObject("roSGNode", "Node")
     print node.myNode.subtype() ' => "Node"
 end sub


### PR DESCRIPTION
# Change Summary
Before this change, when you had something like this:
```
node = createObject("RoSGNode", "Node")
node.addField("myArray", "assocarray")
node.myArray = { abcd: 1234 }
```
then `brs` would not allow the assignment of `node.myArray = { abcd: 1234 }`. This was because it was reading `node.myArray`'s value kind as `Invalid`, which didn't match the value kind that was being assigned (associative array is an `Object`), so `brs` didn't let the new value get set. This was only happening for arrays and associative arrays because of how `brs` created their initial types.

There were a lot of tests that had to be updated, sorry, I realize this changes a lot of test files!