### PR TITLE
feat(stdlib): add RoSGNodeEvent

### DIFF
--- a/src/brsTypes/components/BrsComponent.ts
+++ b/src/brsTypes/components/BrsComponent.ts
@@ -29,12 +29,18 @@ export class BrsComponent {
                 new BrsInterface(interfaceName, methods)
             );
 
-            methods.forEach(m => this.methods.set((m.name || "").toLowerCase(), m));
+            this.appendMethods(methods);
         });
     }
 
+    /** Appends a method to the component. */
     protected appendMethod(index: string, method: Callable) {
         this.methods.set(index.toLowerCase(), method);
+    }
+
+    /** Given a list of methods, appends all of them to the component. */
+    protected appendMethods(methods: Callable[]) {
+        methods.forEach(m => this.methods.set((m.name || "").toLowerCase(), m));
     }
 
     getMethod(index: string): Callable | undefined {

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -575,7 +575,11 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             let field = this.fields.get(fieldname.value.toLowerCase());
             if (field instanceof Field) {
                 let event = new RoSGNodeEvent(this, fieldname, field);
-                field.addObserver(interpreter, interpreter.getCallableFunction(functionname.value), event);
+                field.addObserver(
+                    interpreter,
+                    interpreter.getCallableFunction(functionname.value),
+                    event
+                );
             }
             return BrsBoolean.True;
         },

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -25,9 +25,9 @@ interface BrsCallback {
     environment: Environment;
     callable: Callable;
     eventParams: {
-        fieldName: BrsString,
-        node: RoSGNode
-    }
+        fieldName: BrsString;
+        node: RoSGNode;
+    };
 }
 
 export type FieldModel = { name: string; type: string; value?: string };
@@ -62,15 +62,20 @@ export class Field {
         }
     }
 
-    addObserver(interpreter: Interpreter, callable: Callable, node: RoSGNode, fieldName: BrsString) {
+    addObserver(
+        interpreter: Interpreter,
+        callable: Callable,
+        node: RoSGNode,
+        fieldName: BrsString
+    ) {
         let brsCallback: BrsCallback = {
             interpreter,
             environment: interpreter.environment,
             callable,
             eventParams: {
                 node,
-                fieldName
-            }
+                fieldName,
+            },
         };
         this.observers.push(brsCallback);
     }

--- a/src/brsTypes/components/RoSGNodeEvent.ts
+++ b/src/brsTypes/components/RoSGNodeEvent.ts
@@ -3,21 +3,19 @@ import { ValueKind, BrsString, BrsValue, BrsBoolean } from "../BrsType";
 import { Callable } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { RoSGNode, Field } from "./RoSGNode";
+import { BrsType } from "..";
 
 export class RoSGNodeEvent extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
 
-    constructor(readonly node: RoSGNode, readonly fieldName: BrsString, readonly field: Field) {
+    constructor(readonly node: RoSGNode, readonly fieldName: BrsString, readonly fieldValue: BrsType) {
         super("roSGNodeEvent");
         this.appendMethods([this.getdata, this.getfield, this.getrosgnode, this.getnode]);
     }
 
-    equalTo(event: RoSGNodeEvent) {
-        return BrsBoolean.from(
-            event.field === this.field &&
-                event.fieldName.equalTo(this.fieldName).toBoolean() &&
-                event.node.equalTo(this.node).toBoolean()
-        );
+    equalTo(other: BrsType) {
+        // RBI doesn't allow events to be compared.
+        return BrsBoolean.False;
     }
 
     toString() {
@@ -31,7 +29,7 @@ export class RoSGNodeEvent extends BrsComponent implements BrsValue {
             returns: ValueKind.Dynamic,
         },
         impl: (interpreter: Interpreter) => {
-            return this.field.getValue();
+            return this.fieldValue;
         },
     });
 

--- a/src/brsTypes/components/RoSGNodeEvent.ts
+++ b/src/brsTypes/components/RoSGNodeEvent.ts
@@ -8,7 +8,11 @@ import { BrsType } from "..";
 export class RoSGNodeEvent extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
 
-    constructor(readonly node: RoSGNode, readonly fieldName: BrsString, readonly fieldValue: BrsType) {
+    constructor(
+        readonly node: RoSGNode,
+        readonly fieldName: BrsString,
+        readonly fieldValue: BrsType
+    ) {
         super("roSGNodeEvent");
         this.appendMethods([this.getdata, this.getfield, this.getrosgnode, this.getnode]);
     }

--- a/src/brsTypes/components/RoSGNodeEvent.ts
+++ b/src/brsTypes/components/RoSGNodeEvent.ts
@@ -1,0 +1,70 @@
+import { BrsComponent } from "./BrsComponent";
+import { ValueKind, BrsString, BrsValue, BrsBoolean } from "../BrsType";
+import { Callable } from "../Callable";
+import { Interpreter } from "../../interpreter";
+import { RoSGNode, Field } from "./RoSGNode";
+
+export class RoSGNodeEvent extends BrsComponent implements BrsValue {
+    readonly kind = ValueKind.Object;
+
+    constructor(readonly node: RoSGNode, readonly fieldName: BrsString, readonly field: Field) {
+        super("roSGNodeEvent");
+        this.appendMethods([this.getdata, this.getfield, this.getrosgnode, this.getnode]);
+    }
+
+    equalTo(event: RoSGNodeEvent) {
+        return BrsBoolean.from(
+            event.field === this.field &&
+                event.fieldName.equalTo(this.fieldName).toBoolean() &&
+                event.node.equalTo(this.node).toBoolean()
+        );
+    }
+
+    toString() {
+        return "<Component: roSGNodeEvent>";
+    }
+
+    /** Retrieves the new field value at the time of the change. */
+    private getdata = new Callable("getdata", {
+        signature: {
+            args: [],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (interpreter: Interpreter) => {
+            return this.field.getValue();
+        },
+    });
+
+    /** Retrieves the name of the field that changed. */
+    private getfield = new Callable("getfield", {
+        signature: {
+            args: [],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (interpreter: Interpreter) => {
+            return this.fieldName;
+        },
+    });
+
+    /** Retrieves a pointer to the node. This can be used for nodes without an ID. */
+    private getrosgnode = new Callable("getrosgnode", {
+        signature: {
+            args: [],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (interpreter: Interpreter) => {
+            return this.node;
+        },
+    });
+
+    /** Retrieves the ID of the node that changed. */
+    private getnode = new Callable("getnode", {
+        signature: {
+            args: [],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (interpreter: Interpreter) => {
+            return this.node.get(new BrsString("id"));
+        },
+    });
+}

--- a/src/brsTypes/index.ts
+++ b/src/brsTypes/index.ts
@@ -41,6 +41,7 @@ export * from "./components/RoDouble";
 export * from "./components/RoFloat";
 export * from "./components/RoInt";
 export * from "./components/RoInvalid";
+export * from "./components/RoSGNodeEvent";
 export * from "./components/RoSGNode";
 export * from "./components/Group";
 export * from "./components/LayoutGroup";

--- a/test/brsTypes/components/RoSGNodeEvent.test.js
+++ b/test/brsTypes/components/RoSGNodeEvent.test.js
@@ -17,14 +17,14 @@ describe("RoSGNodeEvent", () => {
 
     describe("stringification", () => {
         it("prints out correctly", () => {
-            let event = new RoSGNodeEvent(node, fieldName, field);
+            let event = new RoSGNodeEvent(node, fieldName, fieldValue);
             expect(event.toString()).toEqual(`<Component: roSGNodeEvent>`);
         });
     });
 
     describe("getdata", () => {
         it("returns the field value", () => {
-            let event = new RoSGNodeEvent(node, fieldName, field);
+            let event = new RoSGNodeEvent(node, fieldName, fieldValue);
             let getData = event.getMethod("getdata");
 
             expect(getData.call(interpreter)).toEqual(fieldValue);
@@ -33,7 +33,7 @@ describe("RoSGNodeEvent", () => {
 
     describe("getfield", () => {
         it("returns the field name", () => {
-            let event = new RoSGNodeEvent(node, fieldName, field);
+            let event = new RoSGNodeEvent(node, fieldName, fieldValue);
             let getField = event.getMethod("getfield");
 
             expect(getField.call(interpreter)).toEqual(fieldName);
@@ -42,7 +42,7 @@ describe("RoSGNodeEvent", () => {
 
     describe("getrosgnode", () => {
         it("returns a pointer to the node", () => {
-            let event = new RoSGNodeEvent(node, fieldName, field);
+            let event = new RoSGNodeEvent(node, fieldName, fieldValue);
             let getRosgnode = event.getMethod("getrosgnode");
 
             expect(getRosgnode.call(interpreter)).toEqual(node);
@@ -51,7 +51,7 @@ describe("RoSGNodeEvent", () => {
 
     describe("getnode", () => {
         it("returns the node id", () => {
-            let event = new RoSGNodeEvent(node, fieldName, field);
+            let event = new RoSGNodeEvent(node, fieldName, fieldValue);
             let getNode = event.getMethod("getnode");
 
             expect(getNode.call(interpreter)).toEqual(nodeId);

--- a/test/brsTypes/components/RoSGNodeEvent.test.js
+++ b/test/brsTypes/components/RoSGNodeEvent.test.js
@@ -1,0 +1,58 @@
+const brs = require("brs");
+const { RoSGNode, Field, RoSGNodeEvent, BrsString } = brs.types;
+const { Interpreter } = require("../../../lib/interpreter");
+
+describe("RoSGNodeEvent", () => {
+    let interpreter = new Interpreter();
+    let nodeId = new BrsString("node-id");
+    let node = new RoSGNode([{
+        name: new BrsString("id"),
+        value: nodeId
+    }]);
+    let fieldName = new BrsString("fieldName");
+    let fieldValue = new BrsString("fieldValue");
+    let field = new Field(fieldValue, false);
+
+    describe("stringification", () => {
+        it("prints out correctly", () => {
+            let event = new RoSGNodeEvent(node, fieldName, field);
+            expect(event.toString()).toEqual(`<Component: roSGNodeEvent>`);
+        });
+    });
+
+    describe("getdata", () => {
+        it("returns the field value", () => {
+            let event = new RoSGNodeEvent(node, fieldName, field);
+            let getData = event.getMethod("getdata");
+
+            expect(getData.call(interpreter)).toEqual(fieldValue);
+        });
+    });
+
+    describe("getfield", () => {
+        it("returns the field name", () => {
+            let event = new RoSGNodeEvent(node, fieldName, field);
+            let getField = event.getMethod("getfield");
+
+            expect(getField.call(interpreter)).toEqual(fieldName);
+        });
+    });
+
+    describe("getrosgnode", () => {
+        it("returns a pointer to the node", () => {
+            let event = new RoSGNodeEvent(node, fieldName, field);
+            let getRosgnode = event.getMethod("getrosgnode");
+
+            expect(getRosgnode.call(interpreter)).toEqual(node);
+        });
+    });
+
+    describe("getnode", () => {
+        it("returns the node id", () => {
+            let event = new RoSGNodeEvent(node, fieldName, field);
+            let getNode = event.getMethod("getnode");
+
+            expect(getNode.call(interpreter)).toEqual(nodeId);
+        });
+    });
+});

--- a/test/brsTypes/components/RoSGNodeEvent.test.js
+++ b/test/brsTypes/components/RoSGNodeEvent.test.js
@@ -5,10 +5,12 @@ const { Interpreter } = require("../../../lib/interpreter");
 describe("RoSGNodeEvent", () => {
     let interpreter = new Interpreter();
     let nodeId = new BrsString("node-id");
-    let node = new RoSGNode([{
-        name: new BrsString("id"),
-        value: nodeId
-    }]);
+    let node = new RoSGNode([
+        {
+            name: new BrsString("id"),
+            value: nodeId,
+        },
+    ]);
     let fieldName = new BrsString("fieldName");
     let fieldValue = new BrsString("fieldValue");
     let field = new Field(fieldValue, false);

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -571,7 +571,7 @@ describe("end to end brightscript functions", () => {
             "FieldChangeComponent",
             "child: event.getNode()",
             "id-field-change",
-            
+
             // changing a field multiple times
             "child: current event:",
             "123",

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -571,6 +571,14 @@ describe("end to end brightscript functions", () => {
             "FieldChangeComponent",
             "child: event.getNode()",
             "id-field-change",
+            
+            // changing a field multiple times
+            "child: current event:",
+            "123",
+            "child: previous event:",
+            "123",
+            "child: current event:",
+            "456",
         ]);
     });
 

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -538,13 +538,14 @@ describe("end to end brightscript functions", () => {
         ]);
     });
 
-    test("components/scripts/FieldChangeRunner.brs", async () => {
+    test("components/scripts/FieldChangeMain.brs", async () => {
         await execute(
-            [resourceFile("components", "scripts", "FieldChangeRunner.brs")],
+            [resourceFile("components", "scripts", "FieldChangeMain.brs")],
             outputStreams
         );
 
         expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+            // inheritance/overrides
             "runner: node childHandled text field value before modifying:",
             "childHandled initial",
             "child: text field changed. new value:",
@@ -557,6 +558,19 @@ describe("end to end brightscript functions", () => {
             "parentHandled modified",
             "runner: node parentHandled text field value after modifying:",
             "parentHandled modified",
+
+            // onChange with an event
+            "runner: modifying intField",
+            "child: event",
+            "<Component: roSGNodeEvent>",
+            "child: event.getData()",
+            "123",
+            "child: event.getField()",
+            "intField",
+            "child: event.getRoSGNode().subtype()",
+            "FieldChangeComponent",
+            "child: event.getNode()",
+            "id-field-change",
         ]);
     });
 

--- a/test/e2e/resources/components/FieldChangeComponent.xml
+++ b/test/e2e/resources/components/FieldChangeComponent.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component name="FieldChangeComponent" extends="FieldChangeParent" >
     <script type="text/brightscript" uri="pkg:/components/scripts/FieldChangeComponent.brs" />
+    <interface>
+        <field id="intField" type="int" onChange="onFieldChangeWithEvent" value="0" />
+    </interface>
 </component>

--- a/test/e2e/resources/components/FieldChangeComponent.xml
+++ b/test/e2e/resources/components/FieldChangeComponent.xml
@@ -3,5 +3,6 @@
     <script type="text/brightscript" uri="pkg:/components/scripts/FieldChangeComponent.brs" />
     <interface>
         <field id="intField" type="int" onChange="onFieldChangeWithEvent" value="0" />
+        <field id="multipleTimesField" type="int" onChange="onFieldChangeMultipleTimes" value="0" alwaysNotify="true" />
     </interface>
 </component>

--- a/test/e2e/resources/components/scripts/FieldChangeComponent.brs
+++ b/test/e2e/resources/components/scripts/FieldChangeComponent.brs
@@ -21,3 +21,14 @@ sub onFieldChangeWithEvent(event as object)
     print "child: event.getNode()"
     print event.getNode() ' => "id-field-change"
 end sub
+
+function onFieldChangeMultipleTimes(event as object)
+    if m.event <> invalid
+        print "child: previous event:"
+        print m.event.getData()
+    end if
+
+    print "child: current event:"
+    print event.getData()
+    m.event = event
+end function

--- a/test/e2e/resources/components/scripts/FieldChangeComponent.brs
+++ b/test/e2e/resources/components/scripts/FieldChangeComponent.brs
@@ -4,3 +4,20 @@ end sub
 sub onChildHandledFieldChange()
     print "child: text field changed. new value:" m.top.childHandledTextField
 end sub
+
+sub onFieldChangeWithEvent(event as object)
+    print "child: event"
+    print event
+
+    print "child: event.getData()"
+    print event.getData() ' => 123
+
+    print "child: event.getField()"
+    print event.getField() ' => "intField"
+
+    print "child: event.getRoSGNode().subtype()"
+    print event.getRoSGNode().subtype() ' => "FieldChangeComponent"
+
+    print "child: event.getNode()"
+    print event.getNode() ' => "id-field-change"
+end sub

--- a/test/e2e/resources/components/scripts/FieldChangeMain.brs
+++ b/test/e2e/resources/components/scripts/FieldChangeMain.brs
@@ -11,4 +11,7 @@ sub Main()
     node.id = "id-field-change"
     print "runner: modifying intField"
     node.intField = 123
+
+    node.multipleTimesField = 123
+    node.multipleTimesField = 456
 end sub

--- a/test/e2e/resources/components/scripts/FieldChangeMain.brs
+++ b/test/e2e/resources/components/scripts/FieldChangeMain.brs
@@ -7,4 +7,8 @@ sub Main()
     print "runner: node parentHandled text field value before modifying:" node.parentHandledTextField
     node.parentHandledTextField = "parentHandled modified"
     print "runner: node parentHandled text field value after modifying:" node.parentHandledTextField
+
+    node.id = "id-field-change"
+    print "runner: modifying intField"
+    node.intField = 123
 end sub


### PR DESCRIPTION
# Change Summary
This implements `RoSGNodeEvent`. Also, when we implemented `onChange` callbacks in #424, I forgot that those callbacks could optionally receive an event. This PR fixes that, so that now `onChange` can receive the event.