### PR TITLE
chore(deps): Replace node 8 tests with node 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,6 @@ jobs:
       - store_test_results:
           path: reports/jest
 
-  "Node 8":
-    <<: *build-lint-test
-    docker:
-      - image: circleci/node:8
-
   "Node 10":
     <<: *build-lint-test
     docker:
@@ -41,6 +36,11 @@ jobs:
     <<: *build-lint-test
     docker:
       - image: circleci/node:12
+
+  "Node 14":
+    <<: *build-lint-test
+    docker:
+      - image: circleci/node:14
 
   "Publish nightly build":
     working_directory: ~/circleci
@@ -62,9 +62,9 @@ workflows:
   version: 2
   "Node - supported versions":
     jobs:
-      - "Node 8"
       - "Node 10"
       - "Node 12"
+      - "Node 14"
 
   "Nightly build":
     triggers:
@@ -75,12 +75,12 @@ workflows:
               only:
                 - master
     jobs:
-      - "Node 8"
       - "Node 10"
       - "Node 12"
+      - "Node 14"
       - "Publish nightly build":
           requires:
-            - "Node 8"
             - "Node 10"
             - "Node 12"
+            - "Node 14"
 


### PR DESCRIPTION
Node 8 has reached end-of-support, and node 14 now exists!

fixes #435 