### PR TITLE
fix(stdlib): escape from value in string replace

### DIFF
--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -252,8 +252,9 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
                 return this.intrinsic;
             }
 
+            let escapedFrom = from.value.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&");
             return new BrsString(
-                this.intrinsic.value.replace(new RegExp(from.value, "g"), to.value)
+                this.intrinsic.value.replace(new RegExp(escapedFrom, "g"), to.value)
             );
         },
     });

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -252,7 +252,9 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
                 return this.intrinsic;
             }
 
-            let escapedFrom = from.value.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&");
+            // From Mozilla's guide to escaping regex:
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+            let escapedFrom = from.value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
             return new BrsString(
                 this.intrinsic.value.replace(new RegExp(escapedFrom, "g"), to.value)
             );

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -284,6 +284,18 @@ describe("RoString", () => {
                     )
                 ).toEqual(new BrsString("tossed salad and scrambled eggs"));
             });
+
+            it("escapes strings with reserved regex characters", () => {
+                let s = new RoString(new BrsString("oh baby {1}"));
+                replace = s.getMethod("replace");
+                expect(
+                    replace.call(
+                        interpreter,
+                        new BrsString("{1}"),
+                        new BrsString("I hear the blues a-callin'")
+                    )
+                ).toEqual(new BrsString("oh baby I hear the blues a-callin'"));
+            });
         });
 
         describe("trim", () => {


### PR DESCRIPTION
# Change Summary
Before, we weren't escaping the `from` value in `string.replace`, which meant that `brs` was throwing an error due to an invalid `RegExp`. This PR adds an escape.