### PR TITLE
Allow mocking of "unknown" functions

### DIFF
--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -2,7 +2,6 @@ import { Identifier } from "../lexer";
 import { BrsType, RoAssociativeArray, Int32, BrsInvalid, RoSGNode, Callable } from "../brsTypes";
 import { ComponentDefinition } from "../componentprocessor";
 import { BrsError } from "../Error";
-// import { Interpreter } from ".";
 
 /** The logical region from a particular variable or function that defines where it may be accessed from. */
 export enum Scope {

--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -172,6 +172,15 @@ export class Environment {
                 variableToReturn = this.getMockFunction(lowercaseName);
             }
             return variableToReturn;
+        } else {
+            // Because brs hasn't implemented every built-in global function yet,
+            // allow mocking of functions that "don't exist" in source.
+            //
+            // TODO: remove this once all built-in global functions are implemented?
+            let mockedFunc = this.getMockFunction(lowercaseName);
+            if (mockedFunc) {
+                return mockedFunc;
+            }
         }
 
         throw new NotFound(`Undefined variable '${name.text}'`);

--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -1,6 +1,7 @@
 import { Identifier } from "../lexer";
 import { BrsType, RoAssociativeArray, Int32, BrsInvalid, RoSGNode, Callable } from "../brsTypes";
 import { ComponentDefinition } from "../componentprocessor";
+import { BrsError } from "../Error";
 
 /** The logical region from a particular variable or function that defines where it may be accessed from. */
 export enum Scope {
@@ -172,13 +173,20 @@ export class Environment {
                 variableToReturn = this.getMockFunction(lowercaseName);
             }
             return variableToReturn;
-        } else {
+        } else if (lowercaseName !== "main") {
             // Because brs hasn't implemented every built-in global function yet,
             // allow mocking of functions that "don't exist" in source.
             //
             // TODO: remove this once all built-in global functions are implemented?
+            console.log("NAME", lowercaseName)
             let mockedFunc = this.getMockFunction(lowercaseName);
             if (mockedFunc) {
+                console.error(
+                    new BrsError(
+                        `WARNING: using mocked function '${lowercaseName}', but no function with that name is found in-scope in source.`,
+                        name.location
+                    ).format()
+                );
                 return mockedFunc;
             }
         }

--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -2,6 +2,7 @@ import { Identifier } from "../lexer";
 import { BrsType, RoAssociativeArray, Int32, BrsInvalid, RoSGNode, Callable } from "../brsTypes";
 import { ComponentDefinition } from "../componentprocessor";
 import { BrsError } from "../Error";
+// import { Interpreter } from ".";
 
 /** The logical region from a particular variable or function that defines where it may be accessed from. */
 export enum Scope {
@@ -173,21 +174,25 @@ export class Environment {
                 variableToReturn = this.getMockFunction(lowercaseName);
             }
             return variableToReturn;
-        } else if (lowercaseName !== "main") {
+        } else {
             // Because brs hasn't implemented every built-in global function yet,
-            // allow mocking of functions that "don't exist" in source.
+            // allow mocking of functions that "don't exist" in source. This unblocks
+            // unit testing of code that calls the not-yet-implemented global functions.
             //
             // TODO: remove this once all built-in global functions are implemented?
-            console.log("NAME", lowercaseName)
-            let mockedFunc = this.getMockFunction(lowercaseName);
-            if (mockedFunc) {
-                console.error(
-                    new BrsError(
-                        `WARNING: using mocked function '${lowercaseName}', but no function with that name is found in-scope in source.`,
-                        name.location
-                    ).format()
-                );
-                return mockedFunc;
+
+            // Don't allow mocks of reserved functions like "init" and "main".
+            if (!name.isReserved) {
+                let mockedFunc = this.getMockFunction(lowercaseName);
+                if (mockedFunc !== BrsInvalid.Instance) {
+                    console.error(
+                        new BrsError(
+                            `WARNING: using mocked function '${lowercaseName}', but no function with that name is found in-scope in source.`,
+                            name.location
+                        ).format()
+                    );
+                    return mockedFunc;
+                }
             }
         }
 

--- a/test/e2e/BrsMock.test.js
+++ b/test/e2e/BrsMock.test.js
@@ -48,6 +48,7 @@ describe("end to end brightscript functions", () => {
     });
 
     test("mockFunctions.brs", async () => {
+        let consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
         await execute([resourceFile("mockFunctions.brs")], outputStreams);
 
         expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
@@ -56,6 +57,17 @@ describe("end to end brightscript functions", () => {
             "Named foo",
             "--inline foo--",
             "--inline foo--",
+            "doesn't exist in source yet here i am",
         ]);
+
+        // split the warning because the line number output is user-specific.
+        let warning = allArgs(consoleErrorSpy)
+            .filter(arg => arg !== "\n")[0]
+            .split("WARNING: ")[1];
+        expect(warning).toEqual(
+            "using mocked function 'thisfuncdoesnotexist', but no function with that name is found in-scope in source."
+        );
+
+        consoleErrorSpy.mockRestore();
     });
 });

--- a/test/e2e/resources/mockFunctions.brs
+++ b/test/e2e/resources/mockFunctions.brs
@@ -28,6 +28,13 @@ sub Main()
     end function)
 
     print foo() ' => "--inline foo--"
+
+    _brs_.mockFunction("thisFuncDoesNotExist", (function()
+        return "doesn't exist in source yet here i am"
+    end function))
+
+    ' Will trigger a console.error warning that it doesn't exist in source.
+    print thisFuncDoesNotExist() ' => "doesn't exist in source yet here i am"
 end sub
 
 function mockMe()


### PR DESCRIPTION
# Change Summary
This change allows us to mock functions that don't exist in source. This seems somewhat counter-intuitive: why would we let a test implement a function that doesn't exist in source, yet gets called from source code?

The reason is because `brs` doesn't have all the built-in global functions implemented yet, so this unblocks the testing of source code that calls one of those not-yet-implemented functions. The example I was running into was `tr` -- I wanted to test the code that called `tr`, but `tr` isn't implemented, and it also wasn't mockable, so I had no way to test it.

Also, maybe this would be useful for TDD?

Feel free to reject this if `tr` is a one-off situation or there's a better way. I wasn't sure how many other similar cases there were!