### PR TITLE
fix(parser): make if statements with 'not' work

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1316,7 +1316,7 @@ export class Parser {
         function prefixUnary(): Expression {
             if (match(Lexeme.Not, Lexeme.Minus)) {
                 let operator = previous();
-                let right = prefixUnary();
+                let right = expression();
                 return new Expr.Unary(operator, right);
             }
 

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1316,7 +1316,7 @@ export class Parser {
         function prefixUnary(): Expression {
             if (match(Lexeme.Not, Lexeme.Minus)) {
                 let operator = previous();
-                let right = expression();
+                let right = relational();
                 return new Expr.Unary(operator, right);
             }
 

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -103,7 +103,16 @@ describe("end to end syntax", () => {
             "6",
             "7",
             "8",
-            "not equal",
+            // testing if not
+            "not false",
+            "bar does not equal 'def'",
+            "if not with or variation 1",
+            "if not with or variation 2",
+            "if not with and",
+            "if not with two expressions variation 1",
+            "if not with two expressions variation 2",
+            "if not multiple times",
+            "if not with <> operator",
         ]);
     });
 

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -113,6 +113,9 @@ describe("end to end syntax", () => {
             "if not with two expressions variation 2",
             "if not multiple times",
             "if not with <> operator",
+            "foo is not > 1",
+            "foo is not < 2",
+            "foo is not < 2 and not > 2",
         ]);
     });
 

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -103,6 +103,7 @@ describe("end to end syntax", () => {
             "6",
             "7",
             "8",
+            "not equal"
         ]);
     });
 

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -103,7 +103,7 @@ describe("end to end syntax", () => {
             "6",
             "7",
             "8",
-            "not equal"
+            "not equal",
         ]);
     });
 

--- a/test/e2e/resources/conditionals.brs
+++ b/test/e2e/resources/conditionals.brs
@@ -54,7 +54,52 @@ aa = {}
 if foo > 5 then aa.value = ">5" else aa.value = 8
 print aa.value
 
+' if not with boolean
+if not true then
+    print "this will never print"
+end if
+
+if not false then
+    print "not false"
+end if
+
+' if not with an expression
 bar = "abc"
 if not bar = "def" then
-    print "not equal"
+    print "bar does not equal 'def'"
+end if
+
+' if not with or
+if not bar = "def" or false then
+    print "if not with or variation 1"
+end if
+
+if not bar = "abc" or true then
+    print "if not with or variation 2"
+end if
+
+' if not with and
+if not bar = "def" and true then
+    print "if not with and"
+end if
+
+' if not with two expressions
+foo = 1
+if not bar = "def" and foo = 1 then
+    print "if not with two expressions variation 1"
+end if
+
+if bar = "abc" and not foo = 2 then
+    print "if not with two expressions variation 2"
+end if
+
+' if not multiple times
+foo = 1
+if not bar = "def" and not foo = 2 then
+    print "if not multiple times"
+end if
+
+' if not with <> operator
+if not bar <> "abc" then
+    print "if not with <> operator"
 end if

--- a/test/e2e/resources/conditionals.brs
+++ b/test/e2e/resources/conditionals.brs
@@ -103,3 +103,21 @@ end if
 if not bar <> "abc" then
     print "if not with <> operator"
 end if
+
+' if not with > operator
+foo = 1
+if not foo > 1 then
+    print "foo is not > 1"
+end if
+
+' if not with < operator
+foo = 2
+if not foo < 2 then
+    print "foo is not < 2"
+end if
+
+' if not with < operator
+foo = 2
+if not foo < 2 and not foo > 2 then
+    print "foo is not < 2 and not > 2"
+end if

--- a/test/e2e/resources/conditionals.brs
+++ b/test/e2e/resources/conditionals.brs
@@ -53,3 +53,8 @@ end if
 aa = {}
 if foo > 5 then aa.value = ">5" else aa.value = 8
 print aa.value
+
+bar = "abc"
+if not bar = "def" then
+    print "not equal"
+end if


### PR DESCRIPTION
# Change Summary
This allows `if` statements with a logical `not` operator, and closes #329.