### PR TITLE
chore(output): Target ES2017

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         /* Basic Options */
-        "target": "es2016" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
+        "target": "es2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
         "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
         // "lib": [],                             /* Specify library files to be included in the compilation:  */
         // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
Node 10 is now the oldest supported release, and all versions of node 10 support 100% of the ES2017 spec per https://node.green/#ES2017!  May as well output newer JavaScript :shrug: