### PR TITLE
fix(interp,stdlib): getCallableFunction ignores non-implemented functions

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -393,7 +393,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                     let functionToCall = subInterpreter.getCallableFunction(functionname.value);
                     if (!functionToCall) {
                         interpreter.stderr.write(
-                            `Attempted to call non-implemented function ${functionname}`
+                            `Ignoring attempt to call non-implemented function ${functionname}`
                         );
                         return BrsInvalid.Instance;
                     }

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -391,6 +391,12 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             if (componentDef && functionname.value in componentDef.functions) {
                 return interpreter.inSubEnv(subInterpreter => {
                     let functionToCall = subInterpreter.getCallableFunction(functionname.value);
+                    if (!functionToCall) {
+                        interpreter.stderr.write(
+                            `Attempted to call non-implemented function ${functionname}`
+                        );
+                        return BrsInvalid.Instance;
+                    }
 
                     // Determine whether the function should get arguments are not.
                     if (functionToCall.getFirstSatisfiedSignature([functionargs])) {
@@ -626,12 +632,12 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         impl: (interpreter: Interpreter, fieldname: BrsString, functionname: BrsString) => {
             let field = this.fields.get(fieldname.value.toLowerCase());
             if (field instanceof Field) {
-                field.addObserver(
-                    interpreter,
-                    interpreter.getCallableFunction(functionname.value),
-                    this,
-                    fieldname
-                );
+                let callableFunction = interpreter.getCallableFunction(functionname.value);
+                if (callableFunction) {
+                    field.addObserver(interpreter, callableFunction, this, fieldname);
+                } else {
+                    return BrsBoolean.False;
+                }
             }
             return BrsBoolean.True;
         },

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -253,7 +253,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             return maybeCallback;
         }
 
-        console.warn(`${functionName} was not found in scope`);
+        console.warn(`Warning: "${functionName}" was not found in scope.`);
         return;
     }
 

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -230,7 +230,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         }
     }
 
-    getCallableFunction(functionName: string): Callable {
+    getCallableFunction(functionName: string): Callable | undefined {
         let callbackVariable = new Expr.Variable({
             kind: Lexeme.Identifier,
             text: functionName,
@@ -247,12 +247,14 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 file: "(internal)",
             },
         });
+
         let maybeCallback = this.evaluate(callbackVariable);
         if (maybeCallback.kind === ValueKind.Callable) {
             return maybeCallback;
         }
 
-        throw new NotFound(`${functionName} was not found in scope`);
+        console.warn(`${functionName} was not found in scope`);
+        return;
     }
 
     /**

--- a/test/e2e/resources/components/BaseComponent.xml
+++ b/test/e2e/resources/components/BaseComponent.xml
@@ -2,6 +2,7 @@
 <component name="BaseComponent">
     <script type="text/brightscript" uri="pkg:/components/scripts/BaseComponent.brs" />
     <interface>
+        <field id="nonImplementedField" type="boolean" onChange="nonImplementedSub" />
     </interface>
     <children>
         <BaseChild />

--- a/test/e2e/resources/components/BaseComponent.xml
+++ b/test/e2e/resources/components/BaseComponent.xml
@@ -2,6 +2,7 @@
 <component name="BaseComponent">
     <script type="text/brightscript" uri="pkg:/components/scripts/BaseComponent.brs" />
     <interface>
+        <!-- This field is used to validate that we properly handle callbacks that aren't implemented. -->
         <field id="nonImplementedField" type="boolean" onChange="nonImplementedSub" />
     </interface>
     <children>


### PR DESCRIPTION
Currently, when `getCallableFunction` attempts to resolve a callable field defined on a component's interface, if it is unable to resolve the given function (i.e. it's not implemented in the given component), an exception will be thrown and execution halted. BrightScript, however, silently fails whenever such a situation is encountered, permitting execution to proceed.

This change updates `brs` to mirror the BrightScript behavior such that a warning is logged to stdout, but execution is allowed to proceed, whenever a non-implemented callable field is encountered.

This change resolves https://github.com/sjbarag/brs/issues/448.