### PR TITLE
feat(build,ci): Automatically publish tagged commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,22 @@ jobs:
     docker:
       - image: circleci/node:14
 
+  "Publish release":
+    working_directory: ~/circleci
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.com/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run:
+          name: Install dependencies
+          command: yarn
+      - run:
+          name: Publish
+          command: yarn publish
+
   "Publish nightly build":
     working_directory: ~/circleci
     docker:
@@ -65,6 +81,23 @@ workflows:
       - "Node 10"
       - "Node 12"
       - "Node 14"
+
+  "Publish tagged build":
+    jobs:
+      - "Node 10":
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)?/
+            branches:
+              ignore: /.*/
+      - "Publish release":
+          requires:
+            - "Node 10"
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)?/
+            branches:
+              ignore: /.*/
 
   "Nightly build":
     triggers:


### PR DESCRIPTION
New non-nighly releases currently rely on @sjbarag to `yarn version` and `yarn publish` locally.  No need for that anymore!  Now anyone with write permission can run:

```
yarn version
git push --follow-tags upstream/master
```

Or, you know, run that through a pull-request and add the appropriate tag after merging.