### PR TITLE
fix(test): Fix expected output for Timer components

### DIFF
--- a/test/brsTypes/components/Timer.test.js
+++ b/test/brsTypes/components/Timer.test.js
@@ -9,7 +9,7 @@ describe("Timer", () => {
             expect(timer.toString()).toEqual(
                 `<Component: roSGNode:Timer> =
 {
-    change: <UNINITIALIZED>
+    change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
     id: 


### PR DESCRIPTION
This changed as part of #432, which likely didn't include the changes that added Timer (#450).  No worries!