### PR TITLE
fix(err): Silence "Something terrible happened" errors

### DIFF
--- a/src/Error.ts
+++ b/src/Error.ts
@@ -28,7 +28,7 @@ export class BrsError extends Error {
             formattedLocation = `${location.file}(${location.start.line},${location.start.column},${location.end.line},${location.end.line})`;
         }
 
-        return `${formattedLocation}: ${this.message}`;
+        return `${formattedLocation}: ${this.message}\n`;
     }
 }
 

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -222,8 +222,9 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             } else {
                 throw err;
             }
+        } finally {
+            return results;
         }
-        return results;
     }
 
     getCallableFunction(functionName: string): Callable | undefined {

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -176,9 +176,6 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             this._environment = newEnv;
             return func(this);
         } catch (err) {
-            if (!(err instanceof BrsError)) {
-                throw `Runtime error encountered in BRS implementation: ${err}`;
-            }
             throw err;
         } finally {
             this._environment = originalEnvironment;

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -997,9 +997,8 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 });
             } catch (reason) {
                 if (!(reason instanceof Stmt.BlockEnd)) {
-                    throw new Error(
-                        "Something terrible happened and we didn't throw a `BlockEnd` instance."
-                    );
+                    // re-throw interpreter errors
+                    throw reason;
                 }
 
                 let returnedValue = (reason as Stmt.ReturnValue).value;

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -177,7 +177,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             return func(this);
         } catch (err) {
             if (!(err instanceof BrsError)) {
-                console.error("Runtime error encountered in BRS implementation: ", err);
+                throw `Runtime error encountered in BRS implementation: ${err}`;
             }
             throw err;
         } finally {
@@ -225,9 +225,8 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             } else {
                 throw err;
             }
-        } finally {
-            return results;
         }
+        return results;
     }
 
     getCallableFunction(functionName: string): Callable | undefined {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -32,4 +32,34 @@ describe("cli", () => {
         });
         expect(stdout.trim()).toEqual("hi from foo()");
     });
+
+    it("throws syntax errors once", async () => {
+        let filename = "errors/syntax-error.brs";
+        let stderr = await runWithErrors(filename);
+        expect(stderr.split(filename).length).toEqual(3);
+    });
+
+    it("throws eval errors once", async () => {
+        let filename = "errors/uninitialized-object.brs";
+        let stderr = await runWithErrors(filename);
+        expect(stderr.split(filename).length).toEqual(2);
+    });
+
 });
+
+async function runWithErrors(filename) {
+    let command = [
+        "node",
+        path.join(process.cwd(), "bin", "cli.js"),
+        filename,
+    ].join(" ");
+
+    try {
+        await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        return Promise.reject(`Script ran without error: ${filename}`);
+    } catch (err) {
+        return err.stderr || '';
+    }
+}

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -33,28 +33,27 @@ describe("cli", () => {
         expect(stdout.trim()).toEqual("hi from foo()");
     });
 
-    it("throws syntax errors once", async () => {
+    it("prints syntax errors once", async () => {
         let filename = "errors/syntax-error.brs";
-        let stderr = await runWithErrors(filename);
-        expect(stderr.split(filename).length).toEqual(3);
+        let command = ["node", path.join(process.cwd(), "bin", "cli.js"), filename].join(" ");
+        try {
+            await exec(command, {
+                cwd: path.join(__dirname, "resources"),
+            });
+            throw `Script ran without error: ${filename}`;
+        } catch (err) {
+            let errors = err.stderr.split(filename).filter((line) => line !== "");
+            expect(errors.length).toEqual(2);
+        }
     });
 
-    it("throws eval errors once", async () => {
+    it("prints eval errors once", async () => {
         let filename = "errors/uninitialized-object.brs";
-        let stderr = await runWithErrors(filename);
-        expect(stderr.split(filename).length).toEqual(2);
-    });
-});
-
-async function runWithErrors(filename) {
-    let command = ["node", path.join(process.cwd(), "bin", "cli.js"), filename].join(" ");
-
-    try {
-        await exec(command, {
+        let command = ["node", path.join(process.cwd(), "bin", "cli.js"), filename].join(" ");
+        let { stderr } = await exec(command, {
             cwd: path.join(__dirname, "resources"),
         });
-        return Promise.reject(`Script ran without error: ${filename}`);
-    } catch (err) {
-        return err.stderr || "";
-    }
-}
+        let errors = stderr.split(filename).filter((line) => line !== "");
+        expect(errors.length).toEqual(1);
+    });
+});

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -44,15 +44,10 @@ describe("cli", () => {
         let stderr = await runWithErrors(filename);
         expect(stderr.split(filename).length).toEqual(2);
     });
-
 });
 
 async function runWithErrors(filename) {
-    let command = [
-        "node",
-        path.join(process.cwd(), "bin", "cli.js"),
-        filename,
-    ].join(" ");
+    let command = ["node", path.join(process.cwd(), "bin", "cli.js"), filename].join(" ");
 
     try {
         await exec(command, {
@@ -60,6 +55,6 @@ async function runWithErrors(filename) {
         });
         return Promise.reject(`Script ran without error: ${filename}`);
     } catch (err) {
-        return err.stderr || '';
+        return err.stderr || "";
     }
 }

--- a/test/cli/resources/errors/syntax-error.brs
+++ b/test/cli/resources/errors/syntax-error.brs
@@ -1,0 +1,4 @@
+sub main()
+    if a <> invalid
+    end
+end sub

--- a/test/cli/resources/errors/uninitialized-object.brs
+++ b/test/cli/resources/errors/uninitialized-object.brs
@@ -1,0 +1,3 @@
+sub main()
+    a.b()
+end sub

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -332,7 +332,7 @@ describe("end to end brightscript functions", () => {
         ]);
 
         let warning = allArgs(consoleWarningSpy)
-            .filter(arg => arg !== "\n")[0]
+            .filter((arg) => arg !== "\n")[0]
             .split("Warning: ")[1]
             .trim();
         expect(warning).toEqual(`"nonImplementedSub" was not found in scope.`);

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -318,6 +318,8 @@ describe("end to end brightscript functions", () => {
     });
 
     test("components/componentExtension.brs", async () => {
+        let consoleWarningSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
         await execute([resourceFile("components", "componentExtension.brs")], outputStreams);
 
         expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
@@ -328,6 +330,14 @@ describe("end to end brightscript functions", () => {
             "ExtendedComponent init",
             "ExtendedComponent start",
         ]);
+
+        let warning = allArgs(consoleWarningSpy)
+            .filter(arg => arg !== "\n")[0]
+            .split("Warning: ")[1].trim();
+        expect(warning).toEqual(
+            `"nonImplementedSub" was not found in scope.`
+        );
+        consoleWarningSpy.mockRestore();
     });
 
     test("components/roIntrinsics.brs", async () => {

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -333,10 +333,9 @@ describe("end to end brightscript functions", () => {
 
         let warning = allArgs(consoleWarningSpy)
             .filter(arg => arg !== "\n")[0]
-            .split("Warning: ")[1].trim();
-        expect(warning).toEqual(
-            `"nonImplementedSub" was not found in scope.`
-        );
+            .split("Warning: ")[1]
+            .trim();
+        expect(warning).toEqual(`"nonImplementedSub" was not found in scope.`);
         consoleWarningSpy.mockRestore();
     });
 

--- a/test/e2e/BrsMock.test.js
+++ b/test/e2e/BrsMock.test.js
@@ -66,7 +66,7 @@ describe("end to end brightscript functions", () => {
         // split the warning because the line number output is user-specific.
         let warning = allArgs(consoleErrorSpy)
             .filter((arg) => arg !== "\n")[0]
-            .split("WARNING: ")[1];
+            .split("WARNING: ")[1].trim();
         expect(warning).toEqual(
             "using mocked function 'thisfuncdoesnotexist', but no function with that name is found in-scope in source."
         );

--- a/test/e2e/BrsMock.test.js
+++ b/test/e2e/BrsMock.test.js
@@ -66,7 +66,8 @@ describe("end to end brightscript functions", () => {
         // split the warning because the line number output is user-specific.
         let warning = allArgs(consoleErrorSpy)
             .filter((arg) => arg !== "\n")[0]
-            .split("WARNING: ")[1].trim();
+            .split("WARNING: ")[1]
+            .trim();
         expect(warning).toEqual(
             "using mocked function 'thisfuncdoesnotexist', but no function with that name is found in-scope in source."
         );

--- a/test/extensions/RunInScope.test.js
+++ b/test/extensions/RunInScope.test.js
@@ -51,11 +51,13 @@ describe("global Run function", () => {
         }
     });
 
-    it("returns invalid for runtime errors", () => {
+    it("throws an exception for runtime errors", () => {
         fs.readFileSync.mockImplementationOnce(() => `sub main(): _ = {}: _.crash(): end sub`);
-        expect(RunInScope.call(interpreter, new BrsString("pkg:/errors/exec.brs"))).toBe(
-            BrsInvalid.Instance
-        );
+        try {
+            RunInScope.call(interpreter, new BrsString("pkg:/errors/exec.brs"))
+        } catch (err) {
+            expect(err.message).toBe("'crash' is not a function and cannot be called.");
+        }
     });
 
     it("returns invalid when provided a not-array component", () => {

--- a/test/extensions/RunInScope.test.js
+++ b/test/extensions/RunInScope.test.js
@@ -51,13 +51,11 @@ describe("global Run function", () => {
         }
     });
 
-    it("throws an exception for runtime errors", () => {
+    it("returns invalid for runtime errors", () => {
         fs.readFileSync.mockImplementationOnce(() => `sub main(): _ = {}: _.crash(): end sub`);
-        try {
-            RunInScope.call(interpreter, new BrsString("pkg:/errors/exec.brs"));
-        } catch (err) {
-            expect(err.message).toBe("'crash' is not a function and cannot be called.");
-        }
+        expect(RunInScope.call(interpreter, new BrsString("pkg:/errors/exec.brs"))).toBe(
+            BrsInvalid.Instance
+        );
     });
 
     it("returns invalid when provided a not-array component", () => {

--- a/test/extensions/RunInScope.test.js
+++ b/test/extensions/RunInScope.test.js
@@ -54,7 +54,7 @@ describe("global Run function", () => {
     it("throws an exception for runtime errors", () => {
         fs.readFileSync.mockImplementationOnce(() => `sub main(): _ = {}: _.crash(): end sub`);
         try {
-            RunInScope.call(interpreter, new BrsString("pkg:/errors/exec.brs"))
+            RunInScope.call(interpreter, new BrsString("pkg:/errors/exec.brs"));
         } catch (err) {
             expect(err.message).toBe("'crash' is not a function and cannot be called.");
         }


### PR DESCRIPTION
Just rethrow error: BrsErrors will be silent, other exceptions will be shown.
Ensure errors aren't logged multiple times.

Fixes #444 