### PR TITLE
chore(deps): Upgrade to prettier 2.x

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -23,7 +23,7 @@ program
                 await brs.execute(brsFiles, { root: program.root });
             } catch (err) {
                 if (err.messages && err.messages.length) {
-                    err.messages.forEach(message => console.error(message));
+                    err.messages.forEach((message) => console.error(message));
                 } else {
                     console.error(err.message);
                 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint-staged": ">=8",
     "lolex": "^3.0.0",
     "npm-run-all": "^4.1.2",
-    "prettier": "^1.17.0",
+    "prettier": "2",
     "rimraf": "^2.6.2",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.18.0",

--- a/src/Error.ts
+++ b/src/Error.ts
@@ -90,7 +90,7 @@ export function logConsoleError(err: BrsError) {
  * @returns function that writes to given write stream.
  */
 export function getLoggerUsing(errorStream: NodeJS.WriteStream): (err: BrsError) => boolean {
-    return err => errorStream.write(err.format());
+    return (err) => errorStream.write(err.format());
 }
 
 /**

--- a/src/LexerParser.ts
+++ b/src/LexerParser.ts
@@ -21,7 +21,7 @@ export function getLexerParserFn(
     const executionOptions = Object.assign(defaultExecutionOptions, options);
     return async function parse(filenames: string[]): Promise<Stmt.Statement[]> {
         let parsedFiles = await pSettle(
-            filenames.map(async filename => {
+            filenames.map(async (filename) => {
                 let contents;
                 try {
                     contents = await readFile(filename, "utf-8");
@@ -34,7 +34,7 @@ export function getLexerParserFn(
                 let lexer = new Lexer();
                 let preprocessor = new PP.Preprocessor();
                 let parser = new Parser();
-                [lexer, preprocessor, parser].forEach(emitter =>
+                [lexer, preprocessor, parser].forEach((emitter) =>
                     emitter.onError(BrsError.getLoggerUsing(executionOptions.stderr))
                 );
 
@@ -64,17 +64,17 @@ export function getLexerParserFn(
         );
 
         // don't execute anything if there were reading, lexing, or parsing errors
-        if (parsedFiles.some(file => file.isRejected)) {
+        if (parsedFiles.some((file) => file.isRejected)) {
             return Promise.reject({
                 messages: parsedFiles
-                    .filter(file => file.isRejected)
-                    .map(rejection => rejection.reason.message),
+                    .filter((file) => file.isRejected)
+                    .map((rejection) => rejection.reason.message),
             });
         }
 
         // combine statements from all files into one array
         return parsedFiles
-            .map(file => file.value || [])
+            .map((file) => file.value || [])
             .reduce((allStatements, fileStatements) => [...allStatements, ...fileStatements], []);
     };
 }

--- a/src/brsTypes/BrsInterface.ts
+++ b/src/brsTypes/BrsInterface.ts
@@ -11,7 +11,7 @@ export class BrsInterface implements BrsValue {
     readonly methodNames: Set<string>;
 
     constructor(readonly name: string, methods: Callable[]) {
-        this.methodNames = new Set(methods.filter(m => m.name).map(m => m.name!));
+        this.methodNames = new Set(methods.filter((m) => m.name).map((m) => m.name!));
     }
 
     toString(): string {

--- a/src/brsTypes/Callable.ts
+++ b/src/brsTypes/Callable.ts
@@ -161,7 +161,7 @@ export class Callable implements Brs.BrsValue {
 
         let mutableArgs = args.slice();
 
-        return interpreter.inSubEnv(subInterpreter => {
+        return interpreter.inSubEnv((subInterpreter) => {
             // first, we need to evaluate all of the parameter default values
             // and define them in a new environment
             signature.args.forEach((param, index) => {
@@ -218,12 +218,12 @@ export class Callable implements Brs.BrsValue {
 
     getFirstSatisfiedSignature(args: Brs.BrsType[]): SignatureAndImplementation | undefined {
         return this.signatures.filter(
-            sigAndImpl => this.getSignatureMismatches(sigAndImpl.signature, args).length === 0
+            (sigAndImpl) => this.getSignatureMismatches(sigAndImpl.signature, args).length === 0
         )[0];
     }
 
     getAllSignatureMismatches(args: Brs.BrsType[]): SignatureAndMismatches[] {
-        return this.signatures.map(sigAndImpl => ({
+        return this.signatures.map((sigAndImpl) => ({
             signature: sigAndImpl.signature,
             mismatches: this.getSignatureMismatches(sigAndImpl.signature, args),
         }));
@@ -231,7 +231,7 @@ export class Callable implements Brs.BrsValue {
 
     private getSignatureMismatches(sig: Signature, args: Brs.BrsType[]): SignatureMismatch[] {
         let reasons: SignatureMismatch[] = [];
-        let requiredArgCount = sig.args.filter(arg => !arg.defaultValue).length;
+        let requiredArgCount = sig.args.filter((arg) => !arg.defaultValue).length;
 
         if (args.length < requiredArgCount) {
             reasons.push({

--- a/src/brsTypes/Int64.ts
+++ b/src/brsTypes/Int64.ts
@@ -84,11 +84,7 @@ export class Int64 implements Numeric, Comparable {
         switch (rhs.kind) {
             case ValueKind.Int32:
             case ValueKind.Int64:
-                return new Float(
-                    this.getValue()
-                        .divide(rhs.getValue())
-                        .toNumber()
-                );
+                return new Float(this.getValue().divide(rhs.getValue()).toNumber());
             case ValueKind.Float:
                 return new Float(this.getValue().toNumber() / rhs.getValue());
             case ValueKind.Double:

--- a/src/brsTypes/components/BrsComponent.ts
+++ b/src/brsTypes/components/BrsComponent.ts
@@ -39,7 +39,7 @@ export class BrsComponent {
 
     /** Given a list of methods, appends all of them to the component. */
     protected appendMethods(methods: Callable[]) {
-        methods.forEach(m => this.methods.set((m.name || "").toLowerCase(), m));
+        methods.forEach((m) => this.methods.set((m.name || "").toLowerCase(), m));
     }
 
     getMethod(index: string): Callable | undefined {

--- a/src/brsTypes/components/ContentNode.ts
+++ b/src/brsTypes/components/ContentNode.ts
@@ -113,7 +113,7 @@ export class ContentNode extends RoSGNode {
      * The reason to keep track is because metadata fields should print out in all caps.
      */
     private metaDataFields = new Set<string>(
-        this.defaultFields.map(field => field.name.toLowerCase())
+        this.defaultFields.map((field) => field.name.toLowerCase())
     );
 
     constructor(readonly name: string = "ContentNode") {
@@ -157,7 +157,7 @@ export class ContentNode extends RoSGNode {
         return this.getVisibleFields()
             .map(([key, value]) => key)
             .sort()
-            .map(key => new BrsString(key));
+            .map((key) => new BrsString(key));
     }
 
     /** @override */

--- a/src/brsTypes/components/RoArray.ts
+++ b/src/brsTypes/components/RoArray.ts
@@ -180,7 +180,7 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
 
             this.elements = [
                 ...this.elements,
-                ...array.elements.filter(element => !!element), // don't copy "holes" where no value exists
+                ...array.elements.filter((element) => !!element), // don't copy "holes" where no value exists
             ];
 
             return BrsInvalid.Instance;
@@ -194,7 +194,7 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
         },
         impl: (interpreter: Interpreter, separator: BrsString) => {
             if (
-                this.elements.some(function(element) {
+                this.elements.some(function (element) {
                     return !(element instanceof BrsString);
                 })
             ) {
@@ -214,7 +214,7 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             if (flags.toString().match(/([^ir])/g) != null) {
                 interpreter.stderr.write("roArray.Sort: Flags contains invalid option(s).\n");
             } else {
-                this.elements = this.elements.sort(function(a, b) {
+                this.elements = this.elements.sort(function (a, b) {
                     var compare = 0;
                     if (a !== undefined && b !== undefined) {
                         if (a instanceof RoArray && b instanceof RoAssociativeArray) {
@@ -266,7 +266,7 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             if (flags.toString().match(/([^ir])/g) != null) {
                 interpreter.stderr.write("roArray.SortBy: Flags contains invalid option(s).\n");
             } else {
-                this.elements = this.elements.sort(function(a, b) {
+                this.elements = this.elements.sort(function (a, b) {
                     var compare = 0;
                     if (a instanceof RoAssociativeArray && b instanceof RoAssociativeArray) {
                         if (

--- a/src/brsTypes/components/RoAssociativeArray.ts
+++ b/src/brsTypes/components/RoAssociativeArray.ts
@@ -20,7 +20,7 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
 
     constructor(elements: AAMember[]) {
         super("roAssociativeArray");
-        elements.forEach(member =>
+        elements.forEach((member) =>
             this.elements.set(member.name.value.toLowerCase(), member.value)
         );
 
@@ -66,7 +66,7 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
     getElements() {
         return Array.from(this.elements.keys())
             .sort()
-            .map(key => new BrsString(key));
+            .map((key) => new BrsString(key));
     }
 
     getValues() {

--- a/src/brsTypes/components/RoRegex.ts
+++ b/src/brsTypes/components/RoRegex.ts
@@ -90,7 +90,7 @@ export class RoRegex extends BrsComponent implements BrsValue {
             const result = this.jsRegex.exec(str.value);
             let arr: BrsString[] = [];
             if (result !== null) {
-                arr = result.map(match => new BrsString(match || ""));
+                arr = result.map((match) => new BrsString(match || ""));
             }
 
             return new RoArray(arr);
@@ -140,7 +140,7 @@ export class RoRegex extends BrsComponent implements BrsValue {
         },
         impl: (interpreter: Interpreter, str: BrsString) => {
             let items = this.jsRegex[Symbol.split](str.value);
-            let brsItems = items.map(item => new BrsString(item));
+            let brsItems = items.map((item) => new BrsString(item));
             return new RoArray(brsItems);
         },
     });

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -194,7 +194,7 @@ export class Field {
         // Every time a callback happens, a new event is created.
         let event = new RoSGNodeEvent(eventParams.node, eventParams.fieldName, this.value);
 
-        interpreter.inSubEnv(subInterpreter => {
+        interpreter.inSubEnv((subInterpreter) => {
             // Check whether the callback is expecting an event parameter.
             if (callable.getFirstSatisfiedSignature([event])) {
                 callable.call(subInterpreter, event);
@@ -299,7 +299,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     getElements() {
         return Array.from(this.fields.keys())
             .sort()
-            .map(key => new BrsString(key));
+            .map((key) => new BrsString(key));
     }
 
     getValues() {
@@ -479,7 +479,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
             // Only allow public functions (defined in the interface) to be called.
             if (componentDef && functionname.value in componentDef.functions) {
-                return interpreter.inSubEnv(subInterpreter => {
+                return interpreter.inSubEnv((subInterpreter) => {
                     let functionToCall = subInterpreter.getCallableFunction(functionname.value);
                     if (!functionToCall) {
                         interpreter.stderr.write(
@@ -953,7 +953,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             if (child_nodes instanceof RoArray) {
                 let childNodesElements = child_nodes.getElements();
                 if (childNodesElements.length !== 0) {
-                    childNodesElements.forEach(childNode => {
+                    childNodesElements.forEach((childNode) => {
                         this.removeChildByReference(childNode);
                     });
                     return BrsBoolean.True;
@@ -981,7 +981,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
             if (numChildrenValue > 0) {
                 let removedChildren = this.children.splice(indexValue, numChildrenValue);
-                removedChildren.forEach(node => {
+                removedChildren.forEach((node) => {
                     node.removeParent();
                 });
                 return BrsBoolean.True;
@@ -1022,7 +1022,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             if (child_nodes instanceof RoArray) {
                 let childNodesElements = child_nodes.getElements();
                 if (childNodesElements.length !== 0) {
-                    childNodesElements.forEach(childNode => {
+                    childNodesElements.forEach((childNode) => {
                         if (childNode instanceof RoSGNode) {
                             // Remove if it exists to reappend
                             this.removeChildByReference(childNode);
@@ -1078,7 +1078,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                 let indexValue = index.getValue();
                 let childNodesElements = child_nodes.getElements();
                 if (childNodesElements.length !== 0) {
-                    childNodesElements.forEach(childNode => {
+                    childNodesElements.forEach((childNode) => {
                         if (!this.replaceChildAtIndex(childNode, new Int32(indexValue))) {
                             this.removeChildByReference(childNode);
                         }
@@ -1108,7 +1108,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                 let indexValue = index.getValue();
                 let childNodesElements = child_nodes.getElements();
                 if (childNodesElements.length !== 0) {
-                    childNodesElements.forEach(childNode => {
+                    childNodesElements.forEach((childNode) => {
                         this.insertChildAtIndex(childNode, new Int32(indexValue));
                         indexValue += 1;
                     });
@@ -1285,7 +1285,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
     /* Takes a list of models and creates fields with default values, and adds them to this.fields. */
     protected registerDefaultFields(fields: FieldModel[]) {
-        fields.forEach(field => {
+        fields.forEach((field) => {
             let value = getBrsValueFromFieldType(field.type, field.value);
             let fieldType = FieldKind.fromString(field.type);
             if (fieldType) {
@@ -1304,7 +1304,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
      * then Roku logs an error, because Node does not have a property called "thisisnotanodefield".
      */
     protected registerInitializedFields(fields: AAMember[]) {
-        fields.forEach(field => {
+        fields.forEach((field) => {
             let fieldType = FieldKind.fromBrsType(field.value);
             if (fieldType) {
                 this.fields.set(
@@ -1359,18 +1359,18 @@ export function createNodeByType(interpreter: Interpreter, type: BrsString): RoS
         while (typeDef) {
             let init: BrsType;
 
-            interpreter.inSubEnv(subInterpreter => {
+            interpreter.inSubEnv((subInterpreter) => {
                 addChildren(subInterpreter, node!, typeDef!);
                 addFields(subInterpreter, node!, typeDef!);
                 return BrsInvalid.Instance;
             }, currentEnv);
 
-            interpreter.inSubEnv(subInterpreter => {
+            interpreter.inSubEnv((subInterpreter) => {
                 init = subInterpreter.getInitMethod();
                 return BrsInvalid.Instance;
             }, typeDef.environment);
 
-            interpreter.inSubEnv(subInterpreter => {
+            interpreter.inSubEnv((subInterpreter) => {
                 let mPointer = subInterpreter.environment.getM();
                 mPointer.set(new BrsString("top"), node!);
                 mPointer.set(new BrsString("global"), mGlobal);
@@ -1433,7 +1433,7 @@ function addChildren(
     let children = typeDef.children;
     let appendChild = node.getMethod("appendchild");
 
-    children.forEach(child => {
+    children.forEach((child) => {
         let newChild = createNodeByType(interpreter, new BrsString(child.name));
         if (newChild instanceof RoSGNode && appendChild) {
             appendChild.call(interpreter, newChild);

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -112,7 +112,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.String,
         },
-        impl: _interpreter => this.intrinsic,
+        impl: (_interpreter) => this.intrinsic,
     });
 
     /** Appends the first len characters of s to the end of the string. */
@@ -138,7 +138,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.Int32,
         },
-        impl: _interpreter => {
+        impl: (_interpreter) => {
             return new Int32(this.intrinsic.value.length);
         },
     });
@@ -270,7 +270,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.String,
         },
-        impl: _interpreter => {
+        impl: (_interpreter) => {
             return new BrsString(this.intrinsic.value.trim());
         },
     });
@@ -281,7 +281,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.Int32,
         },
-        impl: _interpreter => {
+        impl: (_interpreter) => {
             let int = Math.trunc(Number.parseFloat(this.intrinsic.value));
 
             if (Number.isNaN(int)) {
@@ -299,7 +299,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.Float,
         },
-        impl: _interpreter => {
+        impl: (_interpreter) => {
             let float = Number.parseFloat(this.intrinsic.value);
 
             if (Number.isNaN(float)) {
@@ -320,7 +320,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [new StdlibArgument("delim", ValueKind.String)],
             returns: ValueKind.Object,
         },
-        impl: _interpreter => {
+        impl: (_interpreter) => {
             _interpreter.stderr.write(
                 "WARNING: tokenize not yet implemented, because it returns an RoList.  Returning `invalid`."
             );
@@ -347,7 +347,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
                 parts = this.intrinsic.value.split(separator.value);
             }
 
-            return new RoArray(parts.map(part => new BrsString(part)));
+            return new RoArray(parts.map((part) => new BrsString(part)));
         },
     });
 
@@ -360,7 +360,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.String,
         },
-        impl: _interpreter => {
+        impl: (_interpreter) => {
             return new BrsString(this.intrinsic.value.replace(/(['"<>&])/g, "\\$1"));
         },
     });
@@ -371,18 +371,13 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.String,
         },
-        impl: _interpreter => {
+        impl: (_interpreter) => {
             return new BrsString(
                 // encoding courtesy of
                 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#Description
                 encodeURIComponent(this.intrinsic.value).replace(
                     /[!'()*]/g,
-                    c =>
-                        "%" +
-                        c
-                            .charCodeAt(0)
-                            .toString(16)
-                            .toUpperCase()
+                    (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase()
                 )
             );
         },
@@ -394,7 +389,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.String,
         },
-        impl: _interpreter => {
+        impl: (_interpreter) => {
             return new BrsString(decodeURIComponent(this.intrinsic.value));
         },
     });
@@ -408,7 +403,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.String,
         },
-        impl: _interpreter => {
+        impl: (_interpreter) => {
             return new BrsString(encodeURI(this.intrinsic.value));
         },
     });
@@ -422,7 +417,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.String,
         },
-        impl: _interpreter => {
+        impl: (_interpreter) => {
             return new BrsString(decodeURI(this.intrinsic.value));
         },
     });
@@ -436,7 +431,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.String,
         },
-        impl: _interpreter => {
+        impl: (_interpreter) => {
             return new BrsString(encodeURIComponent(this.intrinsic.value));
         },
     });
@@ -446,7 +441,7 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.String,
         },
-        impl: _interpreter => {
+        impl: (_interpreter) => {
             return new BrsString(decodeURIComponent(this.intrinsic.value));
         },
     });
@@ -456,6 +451,6 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             args: [],
             returns: ValueKind.String,
         },
-        impl: _interpreter => this.intrinsic,
+        impl: (_interpreter) => this.intrinsic,
     });
 }

--- a/src/componentprocessor/index.ts
+++ b/src/componentprocessor/index.ts
@@ -86,8 +86,8 @@ export async function getComponentDefinitionMap(rootDir: string) {
     const componentsPattern = rootDir + "/components/**/*.xml";
     const xmlFiles: string[] = fg.sync(componentsPattern, {});
 
-    let defs = xmlFiles.map(file => new ComponentDefinition(file));
-    let parsedPromises = defs.map(async def => def.parse());
+    let defs = xmlFiles.map((file) => new ComponentDefinition(file));
+    let parsedPromises = defs.map(async (def) => def.parse());
 
     return processXmlTree(pSettle(parsedPromises));
 }
@@ -99,7 +99,7 @@ async function processXmlTree(
     let nodeDefMap = new Map<string, ComponentDefinition>();
 
     // create map of just ComponentDefinition objects
-    nodeDefs.map(item => {
+    nodeDefs.map((item) => {
         if (item.isFulfilled && !item.isRejected) {
             nodeDefMap.set(item.value!.name!, item.value!);
         }
@@ -109,7 +109,7 @@ async function processXmlTree(
     // the component backwards from most extended component first
     let inheritanceStack: ComponentDefinition[] = [];
 
-    nodeDefMap.forEach(nodeDef => {
+    nodeDefMap.forEach((nodeDef) => {
         if (nodeDef && nodeDef.processed === false) {
             let xmlNode = nodeDef.xmlNode;
             inheritanceStack.push(nodeDef);
@@ -151,7 +151,7 @@ async function processXmlTree(
         }
     });
 
-    nodeDefMap.forEach(nodeDef => {
+    nodeDefMap.forEach((nodeDef) => {
         let xmlNode = nodeDef.xmlNode;
         if (xmlNode) {
             nodeDef.children = getChildren(xmlNode);
@@ -197,7 +197,7 @@ function processInterface(
         return { fields, functions };
     }
 
-    iface.eachChild(child => {
+    iface.eachChild((child) => {
         if (child.name === "field") {
             fields[child.attr.id] = {
                 type: child.attr.type,
@@ -244,7 +244,7 @@ function getChildren(node: XmlDocument): ComponentNode[] {
  * @param children The array where parsed children will be added
  */
 function parseChildren(element: XmlElement, children: ComponentNode[]): void {
-    element.eachChild(child => {
+    element.eachChild((child) => {
         let childComponent: ComponentNode = {
             name: child.name,
             fields: child.attr,
@@ -264,7 +264,7 @@ function getScripts(node: XmlDocument): ComponentScript[] {
     let componentScripts: ComponentScript[] = [];
 
     // TODO: Verify if uri is valid
-    scripts.map(script => {
+    scripts.map((script) => {
         if (script.attr) {
             componentScripts.push({
                 type: script.attr.type,

--- a/src/extensions/Process.ts
+++ b/src/extensions/Process.ts
@@ -3,6 +3,6 @@ import { RoAssociativeArray, BrsString, RoArray } from "../brsTypes";
 export const Process = new RoAssociativeArray([
     {
         name: new BrsString("argv"),
-        value: new RoArray(process.argv.map(arg => new BrsString(arg))),
+        value: new RoArray(process.argv.map((arg) => new BrsString(arg))),
     },
 ]);

--- a/src/extensions/RunInScope.ts
+++ b/src/extensions/RunInScope.ts
@@ -27,18 +27,18 @@ import { Scope } from "../interpreter/Environment";
  * @returns the value returned by the executed file(s) if no errors are detected, otherwise `invalid`
  */
 function runFilesInScope(interpreter: Interpreter, filenames: BrsString[], args: BrsType[]) {
-    let volumes = filenames.map(filename => getVolumeByPath(interpreter, filename.value));
-    let pathsToFiles = filenames.map(filename =>
+    let volumes = filenames.map((filename) => getVolumeByPath(interpreter, filename.value));
+    let pathsToFiles = filenames.map((filename) =>
         path.join(interpreter.options.root, getPath(filename.value))
     );
 
     // if the file-to-run doesn't exist, RBI returns invalid
-    if (!volumes.every(volume => volume != null)) {
+    if (!volumes.every((volume) => volume != null)) {
         return BrsInvalid.Instance;
     }
 
     let ast = brs.lexParseSync(pathsToFiles, interpreter.options);
-    return interpreter.inSubEnv(subInterpreter => {
+    return interpreter.inSubEnv((subInterpreter) => {
         // remove the original `main` function so we can execute the new file
         subInterpreter.environment.remove("main", Scope.Module);
         return subInterpreter.exec(ast, ...args)[0] || BrsInvalid.Instance;

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,11 +82,11 @@ export function lexParseSync(filenames: string[], options: Partial<ExecutionOpti
     let manifest = PP.getManifestSync(executionOptions.root);
 
     return filenames
-        .map(filename => {
+        .map((filename) => {
             let lexer = new Lexer();
             let preprocessor = new PP.Preprocessor();
             let parser = new Parser();
-            [lexer, preprocessor, parser].forEach(emitter =>
+            [lexer, preprocessor, parser].forEach((emitter) =>
                 emitter.onError(BrsError.getLoggerUsing(executionOptions.stderr))
             );
 
@@ -119,13 +119,13 @@ export function repl() {
         output: process.stdout,
     });
     rl.setPrompt("brs> ");
-    rl.on("line", line => {
+    rl.on("line", (line) => {
         if (line.toLowerCase() === "quit" || line.toLowerCase() === "exit") {
             process.exit();
         }
         let results = run(line, defaultExecutionOptions, replInterpreter);
         if (results) {
-            results.map(result => {
+            results.map((result) => {
                 if (result !== BrsTypes.BrsInvalid.Instance) {
                     console.log(result.toString());
                 }

--- a/src/interpreter/AstPrinter.ts
+++ b/src/interpreter/AstPrinter.ts
@@ -72,7 +72,7 @@ export class AstPrinter implements Expr.Visitor<string> {
         this.indent++;
         let out = [
             `(${name}\n`,
-            expressions.map(e => `${"  ".repeat(this.indent)}${e.accept(this)}\n`).join(""),
+            expressions.map((e) => `${"  ".repeat(this.indent)}${e.accept(this)}\n`).join(""),
             `${"  ".repeat(this.indent - 1)})`,
         ].join("");
         this.indent--;

--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -160,7 +160,7 @@ export class Environment {
             return this.mPointer;
         }
 
-        let source = [this.function, this.module, this.global].find(scope =>
+        let source = [this.function, this.module, this.global].find((scope) =>
             scope.has(lowercaseName)
         );
 
@@ -215,7 +215,7 @@ export class Environment {
         let lowercaseName = name.text.toLowerCase();
         return (
             scopeFilter
-                .map(scopeName => {
+                .map((scopeName) => {
                     switch (scopeName) {
                         case Scope.Global:
                             return this.global;
@@ -225,7 +225,7 @@ export class Environment {
                             return this.function;
                     }
                 })
-                .find(scope => scope.has(lowercaseName)) != null
+                .find((scope) => scope.has(lowercaseName)) != null
         );
     }
 

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -115,13 +115,13 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
         let componentScopeResolver = new ComponentScopeResolver(componentMap, parseFn);
         await pSettle(
-            Array.from(componentMap).map(async componentKV => {
+            Array.from(componentMap).map(async (componentKV) => {
                 let [_, component] = componentKV;
                 component.environment = interpreter.environment.createSubEnvironment(
                     /* includeModuleScope */ false
                 );
                 let statements = await componentScopeResolver.resolve(component);
-                interpreter.inSubEnv(subInterpreter => {
+                interpreter.inSubEnv((subInterpreter) => {
                     let componentMPointer = new RoAssociativeArray([]);
                     subInterpreter.environment.setM(componentMPointer);
                     subInterpreter.environment.setRootM(componentMPointer);
@@ -145,8 +145,8 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         this.options = options;
 
         Object.keys(StdLib)
-            .map(name => (StdLib as any)[name])
-            .filter(func => func instanceof Callable)
+            .map((name) => (StdLib as any)[name])
+            .filter((func) => func instanceof Callable)
             .filter((func: Callable) => {
                 if (!func.name) {
                     throw new Error("Unnamed standard library function detected!");
@@ -187,7 +187,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     }
 
     exec(statements: ReadonlyArray<Stmt.Statement>, ...args: BrsType[]) {
-        let results = statements.map(statement => this.execute(statement));
+        let results = statements.map((statement) => this.execute(statement));
         try {
             let mainVariable = new Expr.Variable({
                 kind: Lexeme.Identifier,
@@ -214,7 +214,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                         new Expr.Call(
                             mainVariable,
                             mainVariable.name,
-                            args.map(arg => new Expr.Literal(arg, mainVariable.location))
+                            args.map((arg) => new Expr.Literal(arg, mainVariable.location))
                         )
                     ),
                 ];
@@ -916,7 +916,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     }
 
     visitBlock(block: Stmt.Block): BrsType {
-        block.statements.forEach(statement => this.execute(statement));
+        block.statements.forEach((statement) => this.execute(statement));
         return BrsInvalid.Instance;
     }
 
@@ -991,7 +991,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                     }
                 }
 
-                return this.inSubEnv(subInterpreter => {
+                return this.inSubEnv((subInterpreter) => {
                     subInterpreter.environment.setM(mPointer);
                     return callee.call(this, ...args);
                 });
@@ -1060,7 +1060,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 let messageParts = [];
 
                 let args = sig.args
-                    .map(a => {
+                    .map((a) => {
                         let requiredArg = `${a.name.text} as ${ValueKind.toString(a.type.kind)}`;
                         if (a.defaultValue) {
                             return `[${requiredArg}]`;
@@ -1074,7 +1074,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 );
                 messageParts.push(
                     ...mismatches
-                        .map(mm => {
+                        .map((mm) => {
                             switch (mm.reason) {
                                 case MismatchReason.TooFewArguments:
                                     return `* ${functionName} requires at least ${mm.expected} arguments, but received ${mm.received}.`;
@@ -1084,10 +1084,10 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                                     return `* Argument '${mm.argName}' must be of type ${mm.expected}, but received ${mm.received}.`;
                             }
                         })
-                        .map(line => `    ${line}`)
+                        .map((line) => `    ${line}`)
                 );
 
-                return messageParts.map(line => `    ${line}`).join("\n");
+                return messageParts.map((line) => `    ${line}`).join("\n");
             }
 
             let mismatchedSignatures = callee.getAllSignatureMismatches(args);
@@ -1285,7 +1285,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             );
         }
 
-        target.getElements().every(element => {
+        target.getElements().every((element) => {
             this.environment.define(Scope.Function, statement.item.text!, element);
 
             // execute the block
@@ -1309,11 +1309,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     }
 
     visitWhile(statement: Stmt.While): BrsType {
-        while (
-            this.evaluate(statement.condition)
-                .equalTo(BrsBoolean.True)
-                .toBoolean()
-        ) {
+        while (this.evaluate(statement.condition).equalTo(BrsBoolean.True).toBoolean()) {
             try {
                 this.execute(statement.body);
             } catch (reason) {
@@ -1330,20 +1326,12 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     }
 
     visitIf(statement: Stmt.If): BrsType {
-        if (
-            this.evaluate(statement.condition)
-                .equalTo(BrsBoolean.True)
-                .toBoolean()
-        ) {
+        if (this.evaluate(statement.condition).equalTo(BrsBoolean.True).toBoolean()) {
             this.execute(statement.thenBranch);
             return BrsInvalid.Instance;
         } else {
             for (const elseIf of statement.elseIfs || []) {
-                if (
-                    this.evaluate(elseIf.condition)
-                        .equalTo(BrsBoolean.True)
-                        .toBoolean()
-                ) {
+                if (this.evaluate(elseIf.condition).equalTo(BrsBoolean.True).toBoolean()) {
                     this.execute(elseIf.thenBranch);
                     return BrsInvalid.Instance;
                 }
@@ -1366,12 +1354,12 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     }
 
     visitArrayLiteral(expression: Expr.ArrayLiteral): RoArray {
-        return new RoArray(expression.elements.map(expr => this.evaluate(expr)));
+        return new RoArray(expression.elements.map((expr) => this.evaluate(expr)));
     }
 
     visitAALiteral(expression: Expr.AALiteral): BrsType {
         return new RoAssociativeArray(
-            expression.elements.map(member => ({
+            expression.elements.map((member) => ({
                 name: member.name,
                 value: this.evaluate(member.value),
             }))

--- a/src/parser/ComponentScopeResolver.ts
+++ b/src/parser/ComponentScopeResolver.ts
@@ -34,14 +34,16 @@ export class ComponentScopeResolver {
     private flatten(statementMap: Stmt.Statement[][]): Stmt.Statement[] {
         let statements = statementMap.shift() || [];
         let statementMemo = new Set(
-            statements.filter((_): _ is Stmt.Function => true).map(statement => statement.name.text)
+            statements
+                .filter((_): _ is Stmt.Function => true)
+                .map((statement) => statement.name.text)
         );
         while (statementMap.length > 0) {
             let extendedFns = statementMap.shift() || [];
             statements = statements.concat(
                 extendedFns
                     .filter((_): _ is Stmt.Function => true)
-                    .filter(statement => {
+                    .filter((statement) => {
                         let statementName = statement.name.text;
                         let haveFnName = statementMemo.has(statementName);
                         if (!haveFnName) {
@@ -61,7 +63,7 @@ export class ComponentScopeResolver {
      * @returns An ordered array of component statement arrays.
      */
     private *getStatements(component: ComponentDefinition) {
-        yield this.parserLexerFn(component.scripts.map(c => c.uri));
+        yield this.parserLexerFn(component.scripts.map((c) => c.uri));
         let currentComponent: ComponentDefinition | undefined = component;
         while (currentComponent.extends) {
             // If this is a built-in component, then no work is needed and we can return.
@@ -77,7 +79,7 @@ export class ComponentScopeResolver {
                 );
                 return Promise.resolve();
             }
-            yield this.parserLexerFn(currentComponent.scripts.map(c => c.uri));
+            yield this.parserLexerFn(currentComponent.scripts.map((c) => c.uri));
         }
 
         return Promise.resolve();

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -135,7 +135,7 @@ const disallowedIdentifiers = new Set(
         Lexeme.True,
         Lexeme.Type,
         Lexeme.While,
-    ].map(x => Lexeme[x].toLowerCase())
+    ].map((x) => Lexeme[x].toLowerCase())
 );
 
 /** The results of a Parser's parsing pass. */
@@ -1467,8 +1467,9 @@ export class Parser {
                         } else {
                             throw addError(
                                 peek(),
-                                `Expected identifier or string as associative array key, but received '${peek()
-                                    .text || ""}'`
+                                `Expected identifier or string as associative array key, but received '${
+                                    peek().text || ""
+                                }'`
                             );
                         }
 
@@ -1548,7 +1549,7 @@ export class Parser {
 
         function consume(message: string, ...lexemes: Lexeme[]): Token {
             let foundLexeme = lexemes
-                .map(lexeme => peek().kind === lexeme)
+                .map((lexeme) => peek().kind === lexeme)
                 .reduce((foundAny, foundCurrent) => foundAny || foundCurrent, false);
 
             if (foundLexeme) {
@@ -1584,7 +1585,7 @@ export class Parser {
                 return false;
             }
 
-            return lexemes.some(lexeme => peek().kind === lexeme);
+            return lexemes.some((lexeme) => peek().kind === lexeme);
         }
 
         function checkNext(...lexemes: Lexeme[]) {
@@ -1592,7 +1593,7 @@ export class Parser {
                 return false;
             }
 
-            return lexemes.some(lexeme => peekNext().kind === lexeme);
+            return lexemes.some((lexeme) => peekNext().kind === lexeme);
         }
 
         function isAtEnd() {

--- a/src/preprocessor/Manifest.ts
+++ b/src/preprocessor/Manifest.ts
@@ -59,7 +59,7 @@ export function parseManifest(contents: string) {
         // for each line
         .split("\n")
         // remove leading/trailing whitespace
-        .map(line => line.trim())
+        .map((line) => line.trim())
         // separate keys and values
         .map((line, index) => {
             // skip empty lines and comments
@@ -70,8 +70,9 @@ export function parseManifest(contents: string) {
             let equals = line.indexOf("=");
             if (equals === -1) {
                 throw new Error(
-                    `[manifest:${index +
-                        1}] No '=' detected.  Manifest attributes must be of the form 'key=value'.`
+                    `[manifest:${
+                        index + 1
+                    }] No '=' detected.  Manifest attributes must be of the form 'key=value'.`
                 );
             }
             return [line.slice(0, equals), line.slice(equals + 1)];
@@ -123,9 +124,9 @@ export function getBsConst(manifest: Manifest): Map<string, boolean> {
         // for each key-value pair
         .split(";")
         // ignore empty key-value pairs
-        .filter(keyValuePair => !!keyValuePair)
+        .filter((keyValuePair) => !!keyValuePair)
         // separate keys and values
-        .map(keyValuePair => {
+        .map((keyValuePair) => {
             let equals = keyValuePair.indexOf("=");
             if (equals === -1) {
                 throw new Error(

--- a/src/preprocessor/Parser.ts
+++ b/src/preprocessor/Parser.ts
@@ -204,7 +204,7 @@ export class Parser {
 
         function consume(message: string, ...lexemes: Lexeme[]): Token {
             let foundLexeme = lexemes
-                .map(lexeme => peek().kind === lexeme)
+                .map((lexeme) => peek().kind === lexeme)
                 .reduce((foundAny, foundCurrent) => foundAny || foundCurrent, false);
 
             if (foundLexeme) {
@@ -225,7 +225,7 @@ export class Parser {
                 return false;
             }
 
-            return lexemes.some(lexeme => peek().kind === lexeme);
+            return lexemes.some((lexeme) => peek().kind === lexeme);
         }
 
         function isAtEnd() {

--- a/src/preprocessor/Preprocessor.ts
+++ b/src/preprocessor/Preprocessor.ts
@@ -47,7 +47,7 @@ export class Preprocessor implements CC.Visitor {
         this.constants = new Map(bsConst);
         return {
             processedTokens: chunks
-                .map(chunk => chunk.accept(this))
+                .map((chunk) => chunk.accept(this))
                 .reduce(
                     (allTokens: Token[], chunkTokens: Token[]) => [...allTokens, ...chunkTokens],
                     []
@@ -132,13 +132,13 @@ export class Preprocessor implements CC.Visitor {
     visitIf(chunk: CC.If): Token[] {
         if (this.evaluateCondition(chunk.condition)) {
             return chunk.thenChunks
-                .map(chunk => chunk.accept(this))
+                .map((chunk) => chunk.accept(this))
                 .reduce((allTokens, chunkTokens: Token[]) => [...allTokens, ...chunkTokens], []);
         } else {
             for (const elseIf of chunk.elseIfs) {
                 if (this.evaluateCondition(elseIf.condition)) {
                     return elseIf.thenChunks
-                        .map(chunk => chunk.accept(this))
+                        .map((chunk) => chunk.accept(this))
                         .reduce(
                             (allTokens, chunkTokens: Token[]) => [...allTokens, ...chunkTokens],
                             []
@@ -149,7 +149,7 @@ export class Preprocessor implements CC.Visitor {
 
         if (chunk.elseChunks) {
             return chunk.elseChunks
-                .map(chunk => chunk.accept(this))
+                .map((chunk) => chunk.accept(this))
                 .reduce((allTokens, chunkTokens: Token[]) => [...allTokens, ...chunkTokens], []);
         }
 

--- a/src/preprocessor/index.ts
+++ b/src/preprocessor/index.ts
@@ -36,8 +36,8 @@ export class Preprocessor {
 
     constructor() {
         // plumb errors from the internal parser and preprocessor out to the public interface for convenience
-        this.parser.events.on("err", err => this.events.emit("err", err));
-        this._preprocessor.events.on("err", err => this.events.emit("err", err));
+        this.parser.events.on("err", (err) => this.events.emit("err", err));
+        this._preprocessor.events.on("err", (err) => this.events.emit("err", err));
     }
 
     /**

--- a/src/stdlib/File.ts
+++ b/src/stdlib/File.ts
@@ -198,7 +198,7 @@ export const ListDir = new Callable("ListDir", {
 
         const memfsPath = getPath(path.value);
         try {
-            let subPaths = volume.readdirSync(memfsPath).map(s => new BrsString(s));
+            let subPaths = volume.readdirSync(memfsPath).map((s) => new BrsString(s));
             return new RoArray(subPaths);
         } catch (err) {
             return new RoArray([]);

--- a/src/stdlib/GlobalUtilities.ts
+++ b/src/stdlib/GlobalUtilities.ts
@@ -50,7 +50,7 @@ export const FindMemberFunction = new Callable("FindMemberFunction", {
     },
     impl: (interpreter, object: BrsComponent, funName: BrsString): BrsInterface | BrsInvalid => {
         let iface: BrsType = BrsInvalid.Instance;
-        object.interfaces.forEach(interfaceName => {
+        object.interfaces.forEach((interfaceName) => {
             if (interfaceName.methodNames.has(funName.value.toLowerCase())) {
                 iface = interfaceName;
             }

--- a/src/stdlib/Run.ts
+++ b/src/stdlib/Run.ts
@@ -26,13 +26,13 @@ import { BrsComponent } from "../brsTypes/components/BrsComponent";
  * @returns the value returned by the executed file(s) if no errors are detected, otherwise `invalid`
  */
 function runFiles(interpreter: Interpreter, filenames: BrsString[], args: BrsType[]) {
-    let volumes = filenames.map(filename => getVolumeByPath(interpreter, filename.value));
-    let pathsToFiles = filenames.map(filename =>
+    let volumes = filenames.map((filename) => getVolumeByPath(interpreter, filename.value));
+    let pathsToFiles = filenames.map((filename) =>
         path.join(interpreter.options.root, getPath(filename.value))
     );
 
     // if the file-to-run doesn't exist, RBI returns invalid
-    if (!volumes.every(volume => volume != null)) {
+    if (!volumes.every((volume) => volume != null)) {
         return BrsInvalid.Instance;
     }
 

--- a/test/brsTypes/Boolean.test.js
+++ b/test/brsTypes/Boolean.test.js
@@ -12,7 +12,7 @@ describe("Boolean", () => {
             BrsTypes.BrsInvalid.Instance,
         ];
 
-        notTrue.forEach(other =>
+        notTrue.forEach((other) =>
             expect(BrsTypes.BrsBoolean.True.equalTo(other)).toBe(BrsTypes.BrsBoolean.False)
         );
 
@@ -32,7 +32,7 @@ describe("Boolean", () => {
             BrsTypes.BrsInvalid.Instance,
         ];
 
-        notFalse.forEach(other =>
+        notFalse.forEach((other) =>
             expect(BrsTypes.BrsBoolean.False.equalTo(other)).toBe(BrsTypes.BrsBoolean.False)
         );
 
@@ -53,7 +53,7 @@ describe("Boolean", () => {
             BrsTypes.BrsInvalid.Instance,
         ];
 
-        allTypes.forEach(other => {
+        allTypes.forEach((other) => {
             expect(BrsTypes.BrsBoolean.True.lessThan(other)).toBe(BrsTypes.BrsBoolean.False);
             expect(BrsTypes.BrsBoolean.False.lessThan(other)).toBe(BrsTypes.BrsBoolean.False);
         });
@@ -71,7 +71,7 @@ describe("Boolean", () => {
             BrsTypes.BrsInvalid.Instance,
         ];
 
-        allTypes.forEach(other => {
+        allTypes.forEach((other) => {
             expect(BrsTypes.BrsBoolean.True.greaterThan(other)).toBe(BrsTypes.BrsBoolean.False);
             expect(BrsTypes.BrsBoolean.False.greaterThan(other)).toBe(BrsTypes.BrsBoolean.False);
         });

--- a/test/brsTypes/Callable.test.js
+++ b/test/brsTypes/Callable.test.js
@@ -14,7 +14,7 @@ describe("Callable", () => {
             LCase,
         ];
 
-        brsValues.forEach(other => expect(UCase.lessThan(other)).toBe(BrsTypes.BrsBoolean.False));
+        brsValues.forEach((other) => expect(UCase.lessThan(other)).toBe(BrsTypes.BrsBoolean.False));
     });
 
     it("is greater than nothing", () => {
@@ -29,7 +29,7 @@ describe("Callable", () => {
             LCase,
         ];
 
-        brsValues.forEach(other =>
+        brsValues.forEach((other) =>
             expect(UCase.greaterThan(other)).toBe(BrsTypes.BrsBoolean.False)
         );
     });
@@ -46,7 +46,7 @@ describe("Callable", () => {
             LCase,
         ];
 
-        notEqual.forEach(other => expect(UCase.equalTo(other)).toBe(BrsTypes.BrsBoolean.False));
+        notEqual.forEach((other) => expect(UCase.equalTo(other)).toBe(BrsTypes.BrsBoolean.False));
 
         expect(UCase.equalTo(UCase)).toBe(BrsTypes.BrsBoolean.True);
     });
@@ -62,7 +62,7 @@ describe("Callable", () => {
             });
 
             expect(
-                hasArgs.getAllSignatureMismatches([]).map(mm => mm.mismatches)[0]
+                hasArgs.getAllSignatureMismatches([]).map((mm) => mm.mismatches)[0]
             ).toContainEqual({
                 reason: BrsTypes.MismatchReason.TooFewArguments,
                 expected: "1",
@@ -82,7 +82,7 @@ describe("Callable", () => {
             expect(
                 noArgs
                     .getAllSignatureMismatches([new BrsTypes.BrsString("foo")])
-                    .map(mm => mm.mismatches)[0]
+                    .map((mm) => mm.mismatches)[0]
             ).toContainEqual({
                 reason: BrsTypes.MismatchReason.TooManyArguments,
                 expected: "0",
@@ -105,7 +105,7 @@ describe("Callable", () => {
                 impl: () => {},
             });
 
-            expect(hasArgs.getAllSignatureMismatches([]).map(mm => mm.mismatches)[0]).toEqual([]);
+            expect(hasArgs.getAllSignatureMismatches([]).map((mm) => mm.mismatches)[0]).toEqual([]);
         });
 
         it("detects argument mismatches", () => {
@@ -120,7 +120,7 @@ describe("Callable", () => {
             expect(
                 hasArgs
                     .getAllSignatureMismatches([BrsTypes.BrsBoolean.False])
-                    .map(mm => mm.mismatches)[0]
+                    .map((mm) => mm.mismatches)[0]
             ).toContainEqual({
                 reason: BrsTypes.MismatchReason.ArgumentTypeMismatch,
                 expected: "String",
@@ -141,7 +141,7 @@ describe("Callable", () => {
             expect(
                 hasArgs
                     .getAllSignatureMismatches([new BrsTypes.Float(1.5)])
-                    .map(mm => mm.mismatches)[0]
+                    .map((mm) => mm.mismatches)[0]
             ).toEqual([]);
         });
 
@@ -157,7 +157,7 @@ describe("Callable", () => {
             expect(
                 hasArgs
                     .getAllSignatureMismatches([new BrsTypes.Float(1.5)])
-                    .map(mm => mm.mismatches)[0]
+                    .map((mm) => mm.mismatches)[0]
             ).toEqual([]);
         });
 
@@ -173,7 +173,7 @@ describe("Callable", () => {
             expect(
                 hasArgs
                     .getAllSignatureMismatches([new BrsTypes.Int32(4)])
-                    .map(mm => mm.mismatches)[0]
+                    .map((mm) => mm.mismatches)[0]
             ).toEqual([]);
         });
 
@@ -195,7 +195,7 @@ describe("Callable", () => {
                         BrsTypes.BrsBoolean.False,
                         BrsTypes.BrsInvalid.Instance,
                     ])
-                    .map(mm => mm.mismatches)[0]
+                    .map((mm) => mm.mismatches)[0]
             ).toEqual([]);
         });
     });

--- a/test/brsTypes/Double.test.js
+++ b/test/brsTypes/Double.test.js
@@ -286,7 +286,7 @@ describe("Double", () => {
 
         it("returns false for all other types", () => {
             let nonNumbers = [new BrsString("hello"), BrsBoolean.True, BrsInvalid.Instance];
-            nonNumbers.forEach(rhs => expect(lhs.lessThan(rhs)).toBe(BrsBoolean.False));
+            nonNumbers.forEach((rhs) => expect(lhs.lessThan(rhs)).toBe(BrsBoolean.False));
         });
     });
 
@@ -328,7 +328,7 @@ describe("Double", () => {
 
         it("returns false for all other types", () => {
             let nonNumbers = [new BrsString("hello"), BrsBoolean.True, BrsInvalid.Instance];
-            nonNumbers.forEach(rhs => expect(lhs.greaterThan(rhs)).toBe(BrsBoolean.False));
+            nonNumbers.forEach((rhs) => expect(lhs.greaterThan(rhs)).toBe(BrsBoolean.False));
         });
     });
 
@@ -370,7 +370,7 @@ describe("Double", () => {
 
         it("returns false for all other types", () => {
             let nonNumbers = [new BrsString("hello"), BrsBoolean.True, BrsInvalid.Instance];
-            nonNumbers.forEach(rhs => expect(lhs.equalTo(rhs)).toBe(BrsBoolean.False));
+            nonNumbers.forEach((rhs) => expect(lhs.equalTo(rhs)).toBe(BrsBoolean.False));
         });
     });
 

--- a/test/brsTypes/Float.test.js
+++ b/test/brsTypes/Float.test.js
@@ -286,7 +286,7 @@ describe("Float", () => {
 
         it("returns false for all other types", () => {
             let nonNumbers = [new BrsString("hello"), BrsBoolean.True, BrsInvalid.Instance];
-            nonNumbers.forEach(rhs => expect(lhs.lessThan(rhs)).toBe(BrsBoolean.False));
+            nonNumbers.forEach((rhs) => expect(lhs.lessThan(rhs)).toBe(BrsBoolean.False));
         });
     });
 
@@ -328,7 +328,7 @@ describe("Float", () => {
 
         it("returns false for all other types", () => {
             let nonNumbers = [new BrsString("hello"), BrsBoolean.True, BrsInvalid.Instance];
-            nonNumbers.forEach(rhs => expect(lhs.greaterThan(rhs)).toBe(BrsBoolean.False));
+            nonNumbers.forEach((rhs) => expect(lhs.greaterThan(rhs)).toBe(BrsBoolean.False));
         });
     });
 
@@ -370,7 +370,7 @@ describe("Float", () => {
 
         it("returns false for all other types", () => {
             let nonNumbers = [new BrsString("hello"), BrsBoolean.True, BrsInvalid.Instance];
-            nonNumbers.forEach(rhs => expect(lhs.equalTo(rhs)).toBe(BrsBoolean.False));
+            nonNumbers.forEach((rhs) => expect(lhs.equalTo(rhs)).toBe(BrsBoolean.False));
         });
     });
 

--- a/test/brsTypes/Int32.test.js
+++ b/test/brsTypes/Int32.test.js
@@ -291,7 +291,7 @@ describe("Int32", () => {
 
         it("returns false for all other types", () => {
             let nonNumbers = [new BrsString("hello"), BrsBoolean.True, BrsInvalid.Instance];
-            nonNumbers.forEach(rhs => expect(lhs.lessThan(rhs)).toBe(BrsBoolean.False));
+            nonNumbers.forEach((rhs) => expect(lhs.lessThan(rhs)).toBe(BrsBoolean.False));
         });
     });
 
@@ -333,7 +333,7 @@ describe("Int32", () => {
 
         it("returns false for all other types", () => {
             let nonNumbers = [new BrsString("hello"), BrsBoolean.True, BrsInvalid.Instance];
-            nonNumbers.forEach(rhs => expect(lhs.greaterThan(rhs)).toBe(BrsBoolean.False));
+            nonNumbers.forEach((rhs) => expect(lhs.greaterThan(rhs)).toBe(BrsBoolean.False));
         });
     });
 
@@ -375,7 +375,7 @@ describe("Int32", () => {
 
         it("returns false for all other types", () => {
             let nonNumbers = [new BrsString("hello"), BrsBoolean.True, BrsInvalid.Instance];
-            nonNumbers.forEach(rhs => expect(lhs.equalTo(rhs)).toBe(BrsBoolean.False));
+            nonNumbers.forEach((rhs) => expect(lhs.equalTo(rhs)).toBe(BrsBoolean.False));
         });
     });
 

--- a/test/brsTypes/Int64.test.js
+++ b/test/brsTypes/Int64.test.js
@@ -288,7 +288,7 @@ describe("Int64", () => {
 
         it("returns false for all other types", () => {
             let nonNumbers = [new BrsString("hello"), BrsBoolean.True, BrsInvalid.Instance];
-            nonNumbers.forEach(rhs => expect(lhs.lessThan(rhs)).toBe(BrsBoolean.False));
+            nonNumbers.forEach((rhs) => expect(lhs.lessThan(rhs)).toBe(BrsBoolean.False));
         });
     });
 
@@ -330,7 +330,7 @@ describe("Int64", () => {
 
         it("returns false for all other types", () => {
             let nonNumbers = [new BrsString("hello"), BrsBoolean.True, BrsInvalid.Instance];
-            nonNumbers.forEach(rhs => expect(lhs.greaterThan(rhs)).toBe(BrsBoolean.False));
+            nonNumbers.forEach((rhs) => expect(lhs.greaterThan(rhs)).toBe(BrsBoolean.False));
         });
     });
 
@@ -372,7 +372,7 @@ describe("Int64", () => {
 
         it("returns false for all other types", () => {
             let nonNumbers = [new BrsString("hello"), BrsBoolean.True, BrsInvalid.Instance];
-            nonNumbers.forEach(rhs => expect(lhs.equalTo(rhs)).toBe(BrsBoolean.False));
+            nonNumbers.forEach((rhs) => expect(lhs.equalTo(rhs)).toBe(BrsBoolean.False));
         });
     });
 

--- a/test/brsTypes/Invalid.test.js
+++ b/test/brsTypes/Invalid.test.js
@@ -11,7 +11,7 @@ describe("Invalid", () => {
             BrsTypes.BrsBoolean.False,
         ];
 
-        notInvalid.forEach(other =>
+        notInvalid.forEach((other) =>
             expect(BrsTypes.BrsInvalid.Instance.equalTo(other)).toBe(BrsTypes.BrsBoolean.False)
         );
 
@@ -31,7 +31,7 @@ describe("Invalid", () => {
             BrsTypes.BrsInvalid.Instance,
         ];
 
-        notInvalid.forEach(other =>
+        notInvalid.forEach((other) =>
             expect(BrsTypes.BrsInvalid.Instance.lessThan(other)).toBe(BrsTypes.BrsBoolean.False)
         );
     });
@@ -47,7 +47,7 @@ describe("Invalid", () => {
             BrsTypes.BrsInvalid.Instance,
         ];
 
-        notInvalid.forEach(other =>
+        notInvalid.forEach((other) =>
             expect(BrsTypes.BrsInvalid.Instance.greaterThan(other)).toBe(BrsTypes.BrsBoolean.False)
         );
     });

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -283,10 +283,7 @@ describe("RoSGNode", () => {
                     { name: new BrsString("letter1"), value: letter1 },
                     { name: new BrsString("letter2"), value: letter2 },
                 ]);
-                let change = node
-                    .getFields()
-                    .get("change")
-                    .getValue();
+                let change = node.getFields().get("change").getValue();
 
                 let items = node.getMethod("items");
                 expect(items).toBeTruthy();
@@ -316,10 +313,7 @@ describe("RoSGNode", () => {
                 let id = new BrsString("");
 
                 let node = new RoSGNode([]);
-                let change = node
-                    .getFields()
-                    .get("change")
-                    .getValue();
+                let change = node.getFields().get("change").getValue();
 
                 let items = node.getMethod("items");
                 expect(items).toBeTruthy();

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -425,7 +425,9 @@ describe("RoString", () => {
                 let result = split.call(interpreter, new BrsString(""));
                 expect(result).toBeInstanceOf(RoArray);
                 expect(result.elements).toEqual(
-                    ["🐶", "g", "o", "o", "d", " ", "d", "o", "g", "🐶"].map(c => new BrsString(c))
+                    ["🐶", "g", "o", "o", "d", " ", "d", "o", "g", "🐶"].map(
+                        (c) => new BrsString(c)
+                    )
                 );
             });
 

--- a/test/componentprocessor/componentprocessor.test.js
+++ b/test/componentprocessor/componentprocessor.test.js
@@ -83,7 +83,7 @@ describe.only("component parsing support", () => {
                 expect(parsedExtendedComp.children.length).toBeGreaterThan(0);
 
                 let expectedChildOrder = ["label_b"];
-                let childOrder = parsedExtendedComp.children.map(child => {
+                let childOrder = parsedExtendedComp.children.map((child) => {
                     return child.fields && child.fields.name;
                 });
                 expect(childOrder).toEqual(expectedChildOrder);
@@ -97,10 +97,10 @@ describe.only("component parsing support", () => {
                 expect(parsedExtendedComp.scripts.length).toBeGreaterThan(0);
 
                 const expectedPrefix = "pkg:/test/componentprocessor/resources/scripts/";
-                let expectedScripts = ["extendedComponent.brs", "utility.brs"].map(scriptName =>
+                let expectedScripts = ["extendedComponent.brs", "utility.brs"].map((scriptName) =>
                     path.posix.join(expectedPrefix, scriptName)
                 );
-                let actualScripts = parsedExtendedComp.scripts.map(script => script.uri);
+                let actualScripts = parsedExtendedComp.scripts.map((script) => script.uri);
                 expect(actualScripts).toEqual(expectedScripts);
             });
 

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -24,7 +24,7 @@ describe("end to end brightscript functions", () => {
     test("components/roArray.brs", async () => {
         await execute([resourceFile("components", "roArray.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "array length: ",
             "4",
             "last element: ",
@@ -41,7 +41,7 @@ describe("end to end brightscript functions", () => {
     test("components/roAssociativeArray.brs", async () => {
         await execute([resourceFile("components", "roAssociativeArray.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "AA size: ",
             "3",
             "AA keys size: ",
@@ -68,7 +68,7 @@ describe("end to end brightscript functions", () => {
     test("components/roDateTime.brs", async () => {
         await execute([resourceFile("components", "roDateTime.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "Full Date: ",
             "Friday November 12, 2010",
             "No Week Day: ",
@@ -103,7 +103,7 @@ describe("end to end brightscript functions", () => {
     test("components/roTimespan.brs", async () => {
         await execute([resourceFile("components", "roTimespan.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "can return seconds from date until now: ",
             "373447701",
             "can return 2077252342 for date that can't be parsed: ",
@@ -114,7 +114,7 @@ describe("end to end brightscript functions", () => {
     test("components/roSGNode.brs", async () => {
         await execute([resourceFile("components", "roSGNode.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "node size: ",
             "7",
             "node keys size: ",
@@ -240,7 +240,7 @@ describe("end to end brightscript functions", () => {
     test("components/roRegex.brs", async () => {
         await execute([resourceFile("components", "roRegex.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "HeLlO_123_WoRlD is match of hello_[0-9]*_world: ",
             "true",
             "goodbye_123_WoRlD isn't match of hello_[0-9]*_world: ",
@@ -277,7 +277,7 @@ describe("end to end brightscript functions", () => {
         await execute([resourceFile("components", "roString.brs")], outputStreams);
 
         expect(allArgs(outputStreams.stderr.write)).toEqual([]);
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "bar",
             "bar",
             "true", // comparison
@@ -291,7 +291,7 @@ describe("end to end brightscript functions", () => {
     test("components/customComponent.brs", async () => {
         await execute([resourceFile("components", "customComponent.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "node.baseBoolField: ",
             "false",
             "node.baseIntField: ",
@@ -320,7 +320,7 @@ describe("end to end brightscript functions", () => {
     test("components/componentExtension.brs", async () => {
         await execute([resourceFile("components", "componentExtension.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "BaseChild init",
             "BaseComponent init",
             "ExtendedComponent start",
@@ -334,7 +334,7 @@ describe("end to end brightscript functions", () => {
         await execute([resourceFile("components", "roIntrinsics.brs")], outputStreams);
 
         expect(allArgs(outputStreams.stderr.write)).toEqual([]);
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "Boolean object A ",
             "true",
             "Boolean object B ",
@@ -366,7 +366,7 @@ describe("end to end brightscript functions", () => {
         await execute([resourceFile("components", "roInvalid.brs")], outputStreams);
 
         expect(allArgs(outputStreams.stderr.write)).toEqual([]);
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "roInvalid",
             "<Component: roInvalid>",
             "invalid",
@@ -377,7 +377,7 @@ describe("end to end brightscript functions", () => {
     test("components/Group.brs", async () => {
         await execute([resourceFile("components", "Group.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "group node type:",
             "Node",
             "group node subtype:",
@@ -402,7 +402,7 @@ describe("end to end brightscript functions", () => {
     test("components/LayoutGroup.brs", async () => {
         await execute([resourceFile("components", "LayoutGroup.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "layoutGroup node type:",
             "Node",
             "layoutGroup node subtype:",
@@ -421,7 +421,7 @@ describe("end to end brightscript functions", () => {
     test("components/Rectangle.brs", async () => {
         await execute([resourceFile("components", "Rectangle.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "rectangle node type:",
             "Node",
             "rectangle node subtype:",
@@ -440,7 +440,7 @@ describe("end to end brightscript functions", () => {
     test("components/Label.brs", async () => {
         await execute([resourceFile("components", "Label.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "label node type:",
             "Node",
             "label node subtype:",
@@ -461,7 +461,7 @@ describe("end to end brightscript functions", () => {
     test("components/Timer.brs", async () => {
         await execute([resourceFile("components", "Timer.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "timer node type:",
             "Node",
             "timer node subtype:",
@@ -480,7 +480,7 @@ describe("end to end brightscript functions", () => {
     test("components/Font.brs", async () => {
         await execute([resourceFile("components", "Font.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "font node type:",
             "Node",
             "font node subtype:",
@@ -501,7 +501,7 @@ describe("end to end brightscript functions", () => {
     test("components/Poster.brs", async () => {
         await execute([resourceFile("components", "Poster.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "poster node type:",
             "Node",
             "poster node subtype:",
@@ -522,7 +522,7 @@ describe("end to end brightscript functions", () => {
     test("components/ArrayGrid.brs", async () => {
         await execute([resourceFile("components", "ArrayGrid.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "arraygrid node type:",
             "Node",
             "arraygrid node subtype:",
@@ -541,7 +541,7 @@ describe("end to end brightscript functions", () => {
     test("components/MarkupGrid.brs", async () => {
         await execute([resourceFile("components", "MarkupGrid.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "markupgrid node type:",
             "Node",
             "markupgrid node subtype:",
@@ -563,7 +563,7 @@ describe("end to end brightscript functions", () => {
             outputStreams
         );
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             // inheritance/overrides
             "runner: node childHandled text field value before modifying:",
             "childHandled initial",
@@ -604,7 +604,7 @@ describe("end to end brightscript functions", () => {
     test("components/scripts/CallFuncMain.brs", async () => {
         await execute([resourceFile("components", "scripts", "CallFuncMain.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "component: inside componentFunction, args.test: ",
             "123",
             "component: componentField:",
@@ -620,7 +620,7 @@ describe("end to end brightscript functions", () => {
             "invalid",
         ]);
 
-        expect(allArgs(outputStreams.stderr.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stderr.write).filter((arg) => arg !== "\n")).toEqual([
             "Warning calling function in CallFuncComponent: no function interface specified for componentPrivateFunction",
         ]);
     });
@@ -628,7 +628,7 @@ describe("end to end brightscript functions", () => {
     test("components/ContentNode.brs", async () => {
         await execute([resourceFile("components", "scripts", "ContentNode.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "contentnode node type:",
             "Node",
             "contentnode node subtype:",
@@ -650,7 +650,7 @@ describe("end to end brightscript functions", () => {
             outputStreams
         );
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "bar",
             "invalid",
             "invalid",

--- a/test/e2e/BrsMock.test.js
+++ b/test/e2e/BrsMock.test.js
@@ -23,7 +23,7 @@ describe("end to end brightscript functions", () => {
     test("mockComponents.brs", async () => {
         await execute([resourceFile("mockComponents.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "marking mock timespan",
             "mocked timespan should return 8: ",
             "8",
@@ -51,7 +51,7 @@ describe("end to end brightscript functions", () => {
         let consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
         await execute([resourceFile("mockFunctions.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "{fake:'json'}",
             "your wish is my command",
             "Named foo",
@@ -62,7 +62,7 @@ describe("end to end brightscript functions", () => {
 
         // split the warning because the line number output is user-specific.
         let warning = allArgs(consoleErrorSpy)
-            .filter(arg => arg !== "\n")[0]
+            .filter((arg) => arg !== "\n")[0]
             .split("WARNING: ")[1];
         expect(warning).toEqual(
             "using mocked function 'thisfuncdoesnotexist', but no function with that name is found in-scope in source."

--- a/test/e2e/BrsNamespace.test.js
+++ b/test/e2e/BrsNamespace.test.js
@@ -20,7 +20,7 @@ describe("end to end brightscript functions", () => {
     test("_brs_-namespace.brs", async () => {
         await execute([resourceFile("stdlib", "_brs_-namespace.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "_brs_.process.argv is non-empty: ",
             "true",
         ]);

--- a/test/e2e/ComponentGlobal.test.js
+++ b/test/e2e/ComponentGlobal.test.js
@@ -20,7 +20,7 @@ describe("m.global usage in scenegraph components", () => {
     test("components/componentGlobalUsage.brs", async () => {
         await execute([resourceFile("components", "componentGlobalUsage.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "inside component init, m.global.brsIntField: ",
             "123",
             "MGlobalWidget.text: ",

--- a/test/e2e/ComponentTop.test.js
+++ b/test/e2e/ComponentTop.test.js
@@ -24,7 +24,7 @@ describe("m.top usage in scenegraph components", () => {
         outputStreams.root = __dirname + "/resources";
         await execute([resourceFile("components", "componentTopUsage.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "this is a default value defined in xml",
             "true",
             "false",

--- a/test/e2e/ConditionalCompilation.test.js
+++ b/test/e2e/ConditionalCompilation.test.js
@@ -24,13 +24,13 @@ describe("end to end conditional compilation", () => {
             })
         );
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "I'm ipsum!",
         ]);
     });
 
     describe("(with sterr captured)", () => {
-        test("conditional-compilation/compile-error.brs", async done => {
+        test("conditional-compilation/compile-error.brs", async (done) => {
             let stderr = outputStreams.stderrSpy;
 
             try {
@@ -42,7 +42,7 @@ describe("end to end conditional compilation", () => {
                 stderr.mockRestore();
                 done.fail("execute() should have rejected");
             } catch (err) {
-                expect(allArgs(stderr).filter(arg => arg !== "\n")).toEqual([
+                expect(allArgs(stderr).filter((arg) => arg !== "\n")).toEqual([
                     expect.stringContaining("I'm a compile-time error!"),
                 ]);
 

--- a/test/e2e/E2ETests.js
+++ b/test/e2e/E2ETests.js
@@ -2,7 +2,7 @@ const path = require("path");
 const stream = require("stream");
 
 /** Returns the path to a file in `resources/`. */
-exports.resourceFile = function(...filenameParts) {
+exports.resourceFile = function (...filenameParts) {
     return path.join(__dirname, "resources", ...filenameParts);
 };
 
@@ -11,7 +11,7 @@ exports.resourceFile = function(...filenameParts) {
  * @param jestMock the mock to extract arguments from
  * @returns an array containing every argument from every call to a Jest mock.
  */
-exports.allArgs = function(jestMock) {
+exports.allArgs = function (jestMock) {
     return (
         jestMock.mock.calls
             // flatten arguments to `stdout.write` into a single array
@@ -20,7 +20,7 @@ exports.allArgs = function(jestMock) {
 };
 
 /** Creates a set of mocked streams, suitable for use in place of `process.stdout` and `process.stderr`. */
-exports.createMockStreams = function() {
+exports.createMockStreams = function () {
     const stdout = Object.assign(new stream.PassThrough(), process.stdout);
     const stderr = Object.assign(new stream.PassThrough(), process.stderr);
 

--- a/test/e2e/Functions.test.js
+++ b/test/e2e/Functions.test.js
@@ -20,7 +20,7 @@ describe("end to end functions", () => {
     test("function/arguments.brs", async () => {
         await execute([resourceFile("function", "arguments.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "noArgsFunc",
             "requiredArgsFunc:",
             "1",
@@ -39,7 +39,7 @@ describe("end to end functions", () => {
     test("function/return.brs", async () => {
         await execute([resourceFile("function", "return.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "staticReturn",
             "conditionalReturn:",
             "5",
@@ -61,7 +61,7 @@ describe("end to end functions", () => {
     test("function/expressions.brs", async () => {
         await execute([resourceFile("function", "expressions.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "anonymous function",
             "immediately-invoked function expression (IIFE)",
             "pre-callback",
@@ -74,7 +74,7 @@ describe("end to end functions", () => {
     test("function/m-pointer.brs", async () => {
         await execute([resourceFile("function", "m-pointer.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "carpenter.safetyGlassesOn = ",
             "true",
             "m.houseAge = ",
@@ -85,7 +85,7 @@ describe("end to end functions", () => {
     test("function/m-pointer-global.brs", async () => {
         await execute([resourceFile("function", "m-pointer-global.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "old: ",
             "value 1",
             "new: ",
@@ -104,7 +104,7 @@ describe("end to end functions", () => {
     test("function/m-pointer-func.brs", async () => {
         await execute([resourceFile("function", "m-pointer-func.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "not root",
             "root",
         ]);
@@ -113,7 +113,7 @@ describe("end to end functions", () => {
     test("function/scoping.brs", async () => {
         await execute([resourceFile("function", "scoping.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "Global: ",
             "true",
             "Module: ",

--- a/test/e2e/Iterables.test.js
+++ b/test/e2e/Iterables.test.js
@@ -20,7 +20,7 @@ describe("end to end iterables", () => {
     test("arrays.brs", async () => {
         await execute([resourceFile("arrays.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "1",
             "4",
             "9", // squared values, via for-each
@@ -33,7 +33,7 @@ describe("end to end iterables", () => {
     test("associative-arrays.brs", async () => {
         await execute([resourceFile("associative-arrays.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             // iterate through keys
             "has-second-layer",
             "level",

--- a/test/e2e/MultiFile.test.js
+++ b/test/e2e/MultiFile.test.js
@@ -25,7 +25,7 @@ describe("end to end brightscript functions", () => {
 
         await execute(resourceFiles, outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "function in same file: from sameFileFunc()",
             "function in different file: from differentFileFunc()",
             "function with dependency: from dependentFunc() with help from: from dependencyFunc()",

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -20,7 +20,7 @@ describe("end to end standard libary", () => {
     test("stdlib/files.brs", async () => {
         await execute([resourceFile("stdlib", "files.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "false",
             "true",
             "true",
@@ -38,7 +38,7 @@ describe("end to end standard libary", () => {
     test("stdlib/strings.brs", async () => {
         await execute([resourceFile("stdlib", "strings.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "MIXED CASE",
             "mixed case",
             "12359",
@@ -62,7 +62,7 @@ describe("end to end standard libary", () => {
     test("stdlib/math.brs", async () => {
         await execute([resourceFile("stdlib", "math.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "22.19795",
             "2.85647",
             "3.342155",
@@ -84,13 +84,13 @@ describe("end to end standard libary", () => {
     test("stdlib/runtime.brs", async () => {
         await execute([resourceFile("stdlib", "runtime.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual(["true"]);
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual(["true"]);
     });
 
     test("stdlib/json.brs", async () => {
         await execute([resourceFile("stdlib", "json.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "",
             `{"boolean":false,"float":3.14,"integer":2147483647,"longinteger":2147483650,"null":null,"string":"ok"}`,
             [
@@ -110,7 +110,7 @@ describe("end to end standard libary", () => {
     test("stdlib/run.brs", async () => {
         await execute([resourceFile("stdlib", "run.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "in run.brs",
             "    in runme.brs",
             "returned to run.brs",
@@ -122,7 +122,7 @@ describe("end to end standard libary", () => {
     test("stdlib/global-utilities.brs", async () => {
         await execute([resourceFile("stdlib", "global-utilities.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "<Interface: ifFloat>",
             "<Interface: ifAssociativeArray>",
             "<Interface: ifSGNodeDict>",

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -25,7 +25,7 @@ describe("end to end syntax", () => {
     test("printLiterals.brs", async () => {
         await execute([resourceFile("printLiterals.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "invalid",
             "true",
             "false",
@@ -41,7 +41,7 @@ describe("end to end syntax", () => {
     test("arithmetic.brs", async () => {
         await execute([resourceFile("arithmetic.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "3",
             "3",
             "3",
@@ -74,7 +74,7 @@ describe("end to end syntax", () => {
     test("assignment.brs", async () => {
         await execute([resourceFile("assignment.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "new value",
         ]);
     });
@@ -82,7 +82,7 @@ describe("end to end syntax", () => {
     test("assignment-operators.brs", async () => {
         await execute([resourceFile("assignment-operators.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "5",
             "2",
             "6",
@@ -94,7 +94,7 @@ describe("end to end syntax", () => {
     test("conditionals.brs", async () => {
         await execute([resourceFile("conditionals.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "1",
             "2",
             "3",
@@ -122,7 +122,7 @@ describe("end to end syntax", () => {
     test("while-loops.brs", async () => {
         await execute([resourceFile("while-loops.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "0",
             "1",
             "2",
@@ -136,7 +136,7 @@ describe("end to end syntax", () => {
     test("for-loops.brs", async () => {
         await execute([resourceFile("for-loops.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "0",
             "2",
             "4",
@@ -175,7 +175,7 @@ describe("end to end syntax", () => {
     test("reserved-words.brs", async () => {
         await execute([resourceFile("reserved-words.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             // note: associative array keys are sorted before iteration
             "createobject",
             "in",
@@ -191,7 +191,7 @@ describe("end to end syntax", () => {
     test("increment.brs", async () => {
         await execute([resourceFile("increment.brs")], outputStreams);
 
-        expect(allArgs(outputStreams.stdout.write).filter(arg => arg !== "\n")).toEqual([
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             "6", // var = 5: var++
             "2", // aa = { foo: 3 }: aa.foo--
             "14", // arr = [13]: arr[0]++

--- a/test/extensions/Process.test.js
+++ b/test/extensions/Process.test.js
@@ -6,6 +6,6 @@ describe("_brs_.process", () => {
     it("mirrors node's process.argv", () => {
         let brsArgv = brsProcess.get(new BrsString("argv"));
         expect(brsArgv).toBeDefined();
-        expect(brsArgv.getValue().map(arg => arg.value)).toEqual(process.argv);
+        expect(brsArgv.getValue().map((arg) => arg.value)).toEqual(process.argv);
     });
 });

--- a/test/extensions/RunInScope.test.js
+++ b/test/extensions/RunInScope.test.js
@@ -81,7 +81,7 @@ describe("global Run function", () => {
                     args: [],
                     returns: ValueKind.Void,
                 },
-                impl: interpreter => {
+                impl: (interpreter) => {
                     // just an empty main function - it just needs to exist for this test
                     return BrsInvalid.Instance;
                 },
@@ -106,7 +106,7 @@ describe("global Run function", () => {
                     args: [],
                     returns: ValueKind.String,
                 },
-                impl: interpreter => {
+                impl: (interpreter) => {
                     return new BrsString("hello!");
                 },
             })

--- a/test/interpreter/Comparison.test.js
+++ b/test/interpreter/Comparison.test.js
@@ -140,7 +140,7 @@ describe("interpreter comparisons", () => {
                 ).toEqual([BrsBoolean.False, BrsBoolean.False, BrsBoolean.True, BrsBoolean.True]);
 
                 [Lexeme.Less, Lexeme.LessEqual, Lexeme.Greater, Lexeme.GreaterEqual].forEach(
-                    operator => {
+                    (operator) => {
                         expect(() => interpreter.exec([binary(value, operator, invalid)])).toThrow(
                             /Attempting to compare non-primitive values/
                         );

--- a/test/interpreter/Environment.test.js
+++ b/test/interpreter/Environment.test.js
@@ -10,7 +10,7 @@ describe("Environment", () => {
     let lineNumber;
 
     /** Creates an identifier with the given text. */
-    let identifier = text => ({ kind: Lexeme.Identifier, text: text, line: lineNumber++ });
+    let identifier = (text) => ({ kind: Lexeme.Identifier, text: text, line: lineNumber++ });
 
     beforeEach(() => {
         env = new Environment();

--- a/test/interpreter/ForEach.test.js
+++ b/test/interpreter/ForEach.test.js
@@ -26,7 +26,7 @@ describe("interpreter for-each loops", () => {
         const receivedElements = [];
         const emptyBlockSpy = jest
             .spyOn(emptyBlock, "accept")
-            .mockImplementation(_interpreter =>
+            .mockImplementation((_interpreter) =>
                 receivedElements.push(_interpreter.environment.get(identifier("element")))
             );
 
@@ -34,7 +34,7 @@ describe("interpreter for-each loops", () => {
             new Stmt.Assignment(
                 { equals: token(Lexeme.Equals, "=") },
                 identifier("array"),
-                new Expr.ArrayLiteral(arrayMembers.map(member => new Expr.Literal(member)))
+                new Expr.ArrayLiteral(arrayMembers.map((member) => new Expr.Literal(member)))
             ),
             new Stmt.ForEach(
                 {
@@ -88,7 +88,7 @@ describe("interpreter for-each loops", () => {
             new Stmt.Assignment(
                 { equals: token(Lexeme.Equals, "=") },
                 identifier("array"),
-                new Expr.ArrayLiteral(arrayMembers.map(member => new Expr.Literal(member)))
+                new Expr.ArrayLiteral(arrayMembers.map((member) => new Expr.Literal(member)))
             ),
             new Stmt.ForEach(
                 {
@@ -119,7 +119,7 @@ describe("interpreter for-each loops", () => {
             new Stmt.Assignment(
                 { equals: token(Lexeme.Equals, "=") },
                 identifier("array"),
-                new Expr.ArrayLiteral(arrayMembers.map(member => new Expr.Literal(member)))
+                new Expr.ArrayLiteral(arrayMembers.map((member) => new Expr.Literal(member)))
             ),
             new Stmt.ForEach(
                 {

--- a/test/interpreter/If.test.js
+++ b/test/interpreter/If.test.js
@@ -95,9 +95,11 @@ describe("interpreter if statements", () => {
         let shouldNotExecute = jest.fn();
 
         [assignTo.foo, assignTo.bar, assignTo.dolor, assignTo.sit, assignTo.amet].forEach(
-            assignment => (assignment.accept = shouldNotExecute)
+            (assignment) => (assignment.accept = shouldNotExecute)
         );
-        [assignTo.lorem, assignTo.ipsum].forEach(assignment => (assignment.accept = shouldExecute));
+        [assignTo.lorem, assignTo.ipsum].forEach(
+            (assignment) => (assignment.accept = shouldExecute)
+        );
 
         let statements = [
             new Stmt.If(
@@ -144,7 +146,7 @@ describe("interpreter if statements", () => {
             assignTo.ipsum,
             assignTo.dolor,
             assignTo.sit,
-        ].forEach(assignment => (assignment.accept = shouldNotExecute));
+        ].forEach((assignment) => (assignment.accept = shouldNotExecute));
         assignTo.amet.accept = shouldExecute;
 
         let statements = [

--- a/test/interpreter/Interpreter.test.js
+++ b/test/interpreter/Interpreter.test.js
@@ -36,8 +36,8 @@ describe("integration tests", () => {
 
     test("interpreter environments have the right functions per component", async () => {
         let componentMap = await getComponentDefinitionMap("/doesnt/matter");
-        componentMap.forEach(comp => {
-            comp.scripts = comp.scripts.map(script => {
+        componentMap.forEach((comp) => {
+            comp.scripts = comp.scripts.map((script) => {
                 script.uri = path.join("scripts/", path.parse(script.uri).base);
                 return script;
             });
@@ -53,7 +53,7 @@ describe("integration tests", () => {
 
         let extendedComp = interpreter.environment.nodeDefMap.get("ExtendedComponent");
         expect(extendedComp).not.toBeUndefined();
-        let actualFns = Array.from(extendedComp.environment.module).map(methodKV => {
+        let actualFns = Array.from(extendedComp.environment.module).map((methodKV) => {
             let [fnName] = methodKV;
             return fnName;
         });

--- a/test/interpreter/InterpreterTests.js
+++ b/test/interpreter/InterpreterTests.js
@@ -10,7 +10,7 @@ const Stmt = require("../../lib/parser/Statement");
  *
  * @returns An AST representing the expression `${left} ${operator} ${right}`.
  */
-exports.binary = function(left, operator, right) {
+exports.binary = function (left, operator, right) {
     return new Stmt.Expression(
         new Expr.Binary(
             new Expr.Literal(left),

--- a/test/interpreter/Variables.test.js
+++ b/test/interpreter/Variables.test.js
@@ -65,7 +65,7 @@ describe("interpreter variables", () => {
         expect(() => interpreter.exec(assign)).not.toThrow();
 
         let retrieve = ["str$", "int32%", "float!", "double#", "int64&"].map(
-            name => new Stmt.Expression(new Expr.Variable(identifier(name)))
+            (name) => new Stmt.Expression(new Expr.Variable(identifier(name)))
         );
 
         let stored = interpreter.exec(retrieve);
@@ -108,7 +108,7 @@ describe("interpreter variables", () => {
             },
         ].forEach(({ lhs, values }) => {
             test(lhs, () => {
-                values.forEach(value => {
+                values.forEach((value) => {
                     let assign = new Stmt.Assignment(
                         tokens,
                         identifier(lhs),

--- a/test/lexer/Lexer.test.js
+++ b/test/lexer/Lexer.test.js
@@ -5,17 +5,17 @@ const { BrsString, Int32, Int64, Float, Double } = types;
 describe("lexer", () => {
     it("includes an end-of-file marker", () => {
         let { tokens } = Lexer.scan("");
-        expect(tokens.map(t => t.kind)).toEqual([Lexeme.Eof]);
+        expect(tokens.map((t) => t.kind)).toEqual([Lexeme.Eof]);
     });
 
     it("ignores tabs and spaces", () => {
         let { tokens } = Lexer.scan("\t\t  \t     \t");
-        expect(tokens.map(t => t.kind)).toEqual([Lexeme.Eof]);
+        expect(tokens.map((t) => t.kind)).toEqual([Lexeme.Eof]);
     });
 
     it("retains one newline from consecutive newlines", () => {
         let { tokens } = Lexer.scan("\n\n'foo\n\n\nprint 2\n\n");
-        expect(tokens.map(t => t.kind)).toEqual([
+        expect(tokens.map((t) => t.kind)).toEqual([
             Lexeme.Print,
             Lexeme.Integer,
             Lexeme.Newline,
@@ -25,48 +25,48 @@ describe("lexer", () => {
 
     it("gives the `stop` keyword its own Lexeme", () => {
         let { tokens } = Lexer.scan("stop");
-        expect(tokens.map(t => t.kind)).toEqual([Lexeme.Stop, Lexeme.Eof]);
+        expect(tokens.map((t) => t.kind)).toEqual([Lexeme.Stop, Lexeme.Eof]);
     });
 
     it("aliases '?' to 'print'", () => {
         let { tokens } = Lexer.scan("?2");
-        expect(tokens.map(t => t.kind)).toEqual([Lexeme.Print, Lexeme.Integer, Lexeme.Eof]);
+        expect(tokens.map((t) => t.kind)).toEqual([Lexeme.Print, Lexeme.Integer, Lexeme.Eof]);
     });
 
     describe("comments", () => {
         it("ignores everything after `'`", () => {
             let { tokens } = Lexer.scan("= ' (");
-            expect(tokens.map(t => t.kind)).toEqual([Lexeme.Equal, Lexeme.Eof]);
+            expect(tokens.map((t) => t.kind)).toEqual([Lexeme.Equal, Lexeme.Eof]);
         });
 
         it("ignores everything after `REM`", () => {
             let { tokens } = Lexer.scan("= REM (");
-            expect(tokens.map(t => t.kind)).toEqual([Lexeme.Equal, Lexeme.Eof]);
+            expect(tokens.map((t) => t.kind)).toEqual([Lexeme.Equal, Lexeme.Eof]);
         });
 
         it("ignores everything after `rem`", () => {
             let { tokens } = Lexer.scan("= rem (");
-            expect(tokens.map(t => t.kind)).toEqual([Lexeme.Equal, Lexeme.Eof]);
+            expect(tokens.map((t) => t.kind)).toEqual([Lexeme.Equal, Lexeme.Eof]);
         });
     }); // comments
 
     describe("non-literals", () => {
         it("reads parens & braces", () => {
             let { tokens } = Lexer.scan("(){}");
-            expect(tokens.map(t => t.kind)).toEqual([
+            expect(tokens.map((t) => t.kind)).toEqual([
                 Lexeme.LeftParen,
                 Lexeme.RightParen,
                 Lexeme.LeftBrace,
                 Lexeme.RightBrace,
                 Lexeme.Eof,
             ]);
-            expect(tokens.filter(t => !!t.literal).length).toBe(0);
+            expect(tokens.filter((t) => !!t.literal).length).toBe(0);
         });
 
         it("reads operators", () => {
             let { tokens } = Lexer.scan("^ - + * MOD / \\ -- ++");
 
-            expect(tokens.map(t => t.kind)).toEqual([
+            expect(tokens.map((t) => t.kind)).toEqual([
                 Lexeme.Caret,
                 Lexeme.Minus,
                 Lexeme.Plus,
@@ -78,33 +78,33 @@ describe("lexer", () => {
                 Lexeme.PlusPlus,
                 Lexeme.Eof,
             ]);
-            expect(tokens.filter(t => !!t.literal).length).toBe(0);
+            expect(tokens.filter((t) => !!t.literal).length).toBe(0);
         });
 
         it("reads bitshift operators", () => {
             let { tokens } = Lexer.scan("<< >> <<");
-            expect(tokens.map(t => t.kind)).toEqual([
+            expect(tokens.map((t) => t.kind)).toEqual([
                 Lexeme.LeftShift,
                 Lexeme.RightShift,
                 Lexeme.LeftShift,
                 Lexeme.Eof,
             ]);
-            expect(tokens.filter(t => !!t.literal).length).toBe(0);
+            expect(tokens.filter((t) => !!t.literal).length).toBe(0);
         });
 
         it("reads bitshift assignment operators", () => {
             let { tokens } = Lexer.scan("<<= >>=");
-            expect(tokens.map(t => t.kind)).toEqual([
+            expect(tokens.map((t) => t.kind)).toEqual([
                 Lexeme.LeftShiftEqual,
                 Lexeme.RightShiftEqual,
                 Lexeme.Eof,
             ]);
-            expect(tokens.filter(t => !!t.literal).length).toBe(0);
+            expect(tokens.filter((t) => !!t.literal).length).toBe(0);
         });
 
         it("reads comparators", () => {
             let { tokens } = Lexer.scan("< <= > >= = <>");
-            expect(tokens.map(t => t.kind)).toEqual([
+            expect(tokens.map((t) => t.kind)).toEqual([
                 Lexeme.Less,
                 Lexeme.LessEqual,
                 Lexeme.Greater,
@@ -113,14 +113,14 @@ describe("lexer", () => {
                 Lexeme.LessGreater,
                 Lexeme.Eof,
             ]);
-            expect(tokens.filter(t => !!t.literal).length).toBe(0);
+            expect(tokens.filter((t) => !!t.literal).length).toBe(0);
         });
     }); // non-literals
 
     describe("string literals", () => {
         it("produces string literal tokens", () => {
             let { tokens } = Lexer.scan(`"hello world"`);
-            expect(tokens.map(t => t.kind)).toEqual([Lexeme.String, Lexeme.Eof]);
+            expect(tokens.map((t) => t.kind)).toEqual([Lexeme.String, Lexeme.Eof]);
             expect(tokens[0].literal).toEqual(new BrsString("hello world"));
         });
 
@@ -132,14 +132,14 @@ describe("lexer", () => {
 
         it("produces an error for unterminated strings", () => {
             let { errors } = Lexer.scan(`"unterminated!`);
-            expect(errors.map(err => err.message)).toEqual([
+            expect(errors.map((err) => err.message)).toEqual([
                 expect.stringMatching("Unterminated string"),
             ]);
         });
 
         it("disallows multiline strings", () => {
             let { errors } = Lexer.scan(`"multi-line\n\n`);
-            expect(errors.map(err => err.message)).toEqual([
+            expect(errors.map((err) => err.message)).toEqual([
                 expect.stringMatching("Unterminated string"),
             ]);
         });
@@ -250,7 +250,7 @@ describe("lexer", () => {
             // test just a sample of single-word reserved words for now.
             // if we find any that we've missed
             let { tokens } = Lexer.scan("and or if else endif return true false line_num");
-            expect(tokens.map(w => w.kind)).toEqual([
+            expect(tokens.map((w) => w.kind)).toEqual([
                 Lexeme.And,
                 Lexeme.Or,
                 Lexeme.If,
@@ -262,12 +262,12 @@ describe("lexer", () => {
                 Lexeme.Identifier,
                 Lexeme.Eof,
             ]);
-            expect(tokens.filter(w => !!w.literal).length).toBe(0);
+            expect(tokens.filter((w) => !!w.literal).length).toBe(0);
         });
 
         it("matches multi-word keywords", () => {
             let { tokens } = Lexer.scan("else if end if end while End Sub end Function Exit wHILe");
-            expect(tokens.map(w => w.kind)).toEqual([
+            expect(tokens.map((w) => w.kind)).toEqual([
                 Lexeme.ElseIf,
                 Lexeme.EndIf,
                 Lexeme.EndWhile,
@@ -276,12 +276,12 @@ describe("lexer", () => {
                 Lexeme.ExitWhile,
                 Lexeme.Eof,
             ]);
-            expect(tokens.filter(w => !!w.literal).length).toBe(0);
+            expect(tokens.filter((w) => !!w.literal).length).toBe(0);
         });
 
         it("accepts 'exit for' but not 'exitfor'", () => {
             let { tokens } = Lexer.scan("exit for exitfor");
-            expect(tokens.map(w => w.kind)).toEqual([
+            expect(tokens.map((w) => w.kind)).toEqual([
                 Lexeme.ExitFor,
                 Lexeme.Identifier,
                 Lexeme.Eof,
@@ -290,7 +290,7 @@ describe("lexer", () => {
 
         it("matches keywords with silly capitalization", () => {
             let { tokens } = Lexer.scan("iF ELSE eNDIf FUncTioN");
-            expect(tokens.map(w => w.kind)).toEqual([
+            expect(tokens.map((w) => w.kind)).toEqual([
                 Lexeme.If,
                 Lexeme.Else,
                 Lexeme.EndIf,
@@ -307,9 +307,9 @@ describe("lexer", () => {
 
         it("allows identifiers with trailing type designators", () => {
             let { tokens } = Lexer.scan("lorem$ ipsum% dolor! sit# amet&");
-            let identifiers = tokens.filter(t => t.kind !== Lexeme.Eof);
-            expect(identifiers.every(t => t.kind === Lexeme.Identifier));
-            expect(identifiers.map(t => t.text)).toEqual([
+            let identifiers = tokens.filter((t) => t.kind !== Lexeme.Eof);
+            expect(identifiers.every((t) => t.kind === Lexeme.Identifier));
+            expect(identifiers.map((t) => t.text)).toEqual([
                 "lorem$",
                 "ipsum%",
                 "dolor!",
@@ -322,7 +322,7 @@ describe("lexer", () => {
     describe("conditional compilation", () => {
         it("reads constant declarations", () => {
             let { tokens } = Lexer.scan("#const foo true");
-            expect(tokens.map(t => t.kind)).toEqual([
+            expect(tokens.map((t) => t.kind)).toEqual([
                 Lexeme.HashConst,
                 Lexeme.Identifier,
                 Lexeme.True,
@@ -332,7 +332,7 @@ describe("lexer", () => {
 
         it("reads constant aliases", () => {
             let { tokens } = Lexer.scan("#const bar foo");
-            expect(tokens.map(t => t.kind)).toEqual([
+            expect(tokens.map((t) => t.kind)).toEqual([
                 Lexeme.HashConst,
                 Lexeme.Identifier,
                 Lexeme.Identifier,
@@ -344,7 +344,7 @@ describe("lexer", () => {
             let { tokens } = Lexer.scan(
                 "#if #else if #elseif #else #end if #endif #IF #ELSE IF #ELSEIF #ELSE #END IF #ENDIF"
             );
-            expect(tokens.map(t => t.kind)).toEqual([
+            expect(tokens.map((t) => t.kind)).toEqual([
                 Lexeme.HashIf,
                 Lexeme.HashElseIf,
                 Lexeme.HashElseIf,
@@ -363,7 +363,7 @@ describe("lexer", () => {
 
         it("reads forced compilation errors with messages", () => {
             let { tokens } = Lexer.scan("#error a message goes here\n");
-            expect(tokens.map(t => t.kind)).toEqual([
+            expect(tokens.map((t) => t.kind)).toEqual([
                 Lexeme.HashError,
                 Lexeme.HashErrorMessage,
                 Lexeme.Eof,
@@ -376,14 +376,25 @@ describe("lexer", () => {
     describe("location tracking", () => {
         it("tracks starting and ending lines", () => {
             let { tokens } = Lexer.scan(`sub foo()\n\n    print "bar"\nend sub`);
-            expect(tokens.map(t => t.location.start.line)).toEqual([1, 1, 1, 1, 1, 3, 3, 3, 4, 4]);
+            expect(tokens.map((t) => t.location.start.line)).toEqual([
+                1,
+                1,
+                1,
+                1,
+                1,
+                3,
+                3,
+                3,
+                4,
+                4,
+            ]);
 
-            expect(tokens.map(t => t.location.end.line)).toEqual([1, 1, 1, 1, 1, 3, 3, 3, 4, 4]);
+            expect(tokens.map((t) => t.location.end.line)).toEqual([1, 1, 1, 1, 1, 3, 3, 3, 4, 4]);
         });
 
         it("tracks starting and ending columns", () => {
             let { tokens } = Lexer.scan(`sub foo()\n    print "bar"\nend sub`);
-            expect(tokens.map(t => [t.location.start.column, t.location.end.column])).toEqual([
+            expect(tokens.map((t) => [t.location.start.column, t.location.end.column])).toEqual([
                 [0, 3], // sub
                 [4, 7], // foo
                 [7, 8], // (
@@ -403,7 +414,7 @@ describe("lexer", () => {
             let { tokens } = Lexer.scan(
                 "for each for  each for    each for\teach for\t each for \teach for \t each"
             );
-            expect(tokens.map(t => t.kind)).toEqual([
+            expect(tokens.map((t) => t.kind)).toEqual([
                 Lexeme.ForEach,
                 Lexeme.ForEach,
                 Lexeme.ForEach,
@@ -418,7 +429,7 @@ describe("lexer", () => {
             let { tokens } = Lexer.scan(
                 "else if else  if else    if else\tif else\t if else \tif else \t if"
             );
-            expect(tokens.map(t => t.kind)).toEqual([
+            expect(tokens.map((t) => t.kind)).toEqual([
                 Lexeme.ElseIf,
                 Lexeme.ElseIf,
                 Lexeme.ElseIf,
@@ -433,7 +444,7 @@ describe("lexer", () => {
 
     it("detects rem when used as keyword", () => {
         let { tokens } = Lexer.scan("person.rem=true");
-        expect(tokens.map(t => t.kind)).toEqual([
+        expect(tokens.map((t) => t.kind)).toEqual([
             Lexeme.Identifier,
             Lexeme.Dot,
             Lexeme.Identifier,
@@ -443,7 +454,7 @@ describe("lexer", () => {
         ]);
 
         //verify the location of `rem`
-        expect(tokens.map(t => [t.location.start.column, t.location.end.column])).toEqual([
+        expect(tokens.map((t) => [t.location.start.column, t.location.end.column])).toEqual([
             [0, 6], // person
             [6, 7], // .
             [7, 10], // rem

--- a/test/parser/ComponentScopeResolver.test.js
+++ b/test/parser/ComponentScopeResolver.test.js
@@ -37,8 +37,8 @@ describe("ComponentScopeResolver", () => {
         parseFn = LexerParser.getLexerParserFn(new Map(), defaultExecutionOptions);
 
         componentMap = await getComponentDefinitionMap("/doesnt/matter");
-        componentMap.forEach(comp => {
-            comp.scripts = comp.scripts.map(script => {
+        componentMap.forEach((comp) => {
+            comp.scripts = comp.scripts.map((script) => {
                 script.uri = path.join("scripts/", path.parse(script.uri).base);
                 return script;
             });
@@ -57,10 +57,10 @@ describe("ComponentScopeResolver", () => {
         expect(statements).toBeDefined();
         expect(statements.length).toBe(2);
 
-        let statementNames = statements.map(s => s.name.text);
+        let statementNames = statements.map((s) => s.name.text);
         expect(statementNames).toEqual(["test", "test2"]);
 
-        let testStatement = statements.find(s => s.name.text === "test");
+        let testStatement = statements.find((s) => s.name.text === "test");
         let testStatementCount = testStatement.func.body.statements.length;
         expect(testStatementCount).toEqual(2);
     });
@@ -72,11 +72,11 @@ describe("ComponentScopeResolver", () => {
         expect(statements).toBeDefined();
         expect(statements.length).toBe(5);
 
-        let statementNames = statements.map(s => s.name.text);
+        let statementNames = statements.map((s) => s.name.text);
         // Statements are in a specific order
         expect(statementNames).toEqual(["test", "util1", "util_y", "test2", "util_x"]);
 
-        let testStatement = statements.find(s => s.name.text === "util1");
+        let testStatement = statements.find((s) => s.name.text === "util1");
         let testStatementCount = testStatement.func.body.statements.length;
         expect(testStatementCount).toEqual(2);
     });
@@ -87,7 +87,7 @@ describe("ComponentScopeResolver", () => {
         let statements = await componentScopeResolver.resolve(componentToResolve);
         expect(statements).toBeDefined();
 
-        let statementNames = statements.map(s => s.name.text);
+        let statementNames = statements.map((s) => s.name.text);
         expect(statementNames).not.toContain("init");
     });
 });

--- a/test/parser/ParserTests.js
+++ b/test/parser/ParserTests.js
@@ -10,7 +10,7 @@ const { Lexeme } = brs.lexer;
  * @param {*} [literal] the literal value that the produced token should contain, if any
  * @returns {object} a token of `kind` representing `text` with value `literal`.
  */
-exports.token = function(kind, text, literal) {
+exports.token = function (kind, text, literal) {
     return {
         kind: kind,
         text: text,
@@ -28,7 +28,7 @@ exports.token = function(kind, text, literal) {
  * @param {string} text
  * @returns {object} a token with the provided `text`.
  */
-exports.identifier = function(text) {
+exports.identifier = function (text) {
     return exports.token(Lexeme.Identifier, text);
 };
 

--- a/test/parser/expression/ArrayLiterals.test.js
+++ b/test/parser/expression/ArrayLiterals.test.js
@@ -324,7 +324,7 @@ describe("parser array literals", () => {
 
         expect(errors).toEqual([]);
         expect(statements.length).toEqual(2);
-        expect(statements.map(s => s.value.location)).toEqual([
+        expect(statements.map((s) => s.value.location)).toEqual([
             {
                 start: { line: 1, column: 4 },
                 end: { line: 1, column: 9 },

--- a/test/parser/expression/AssociativeArrayLiterals.test.js
+++ b/test/parser/expression/AssociativeArrayLiterals.test.js
@@ -329,7 +329,7 @@ describe("parser associative array literals", () => {
 
         expect(errors).toEqual([]);
         expect(statements.length).toEqual(2);
-        expect(statements.map(s => s.value.location)).toEqual([
+        expect(statements.map((s) => s.value.location)).toEqual([
             {
                 start: { line: 1, column: 4 },
                 end: { line: 1, column: 9 },

--- a/test/parser/expression/Call.test.js
+++ b/test/parser/expression/Call.test.js
@@ -37,7 +37,7 @@ describe("parser call expressions", () => {
         expect(errors.length).toBeGreaterThan(0);
 
         //ALL of the errors should be on the `DoThin` line
-        let lineNumbers = errors.map(x => x.location.start.line);
+        let lineNumbers = errors.map((x) => x.location.start.line);
         for (let lineNumber of lineNumbers) {
             expect(lineNumber).toEqual(3);
         }

--- a/test/parser/expression/Indexing.test.js
+++ b/test/parser/expression/Indexing.test.js
@@ -214,7 +214,7 @@ describe("parser indexing", () => {
 
             expect(errors).toEqual([]);
             expect(statements.length).toBe(2);
-            expect(statements.map(s => s.value.location)).toEqual([
+            expect(statements.map((s) => s.value.location)).toEqual([
                 {
                     start: { line: 1, column: 4 },
                     end: { line: 1, column: 11 },

--- a/test/parser/expression/Primary.test.js
+++ b/test/parser/expression/Primary.test.js
@@ -201,7 +201,7 @@ describe("parser primary expressions", () => {
 
         expect(errors).toEqual([]);
         expect(statements.length).toBe(3);
-        expect(statements.map(s => s.value.location)).toEqual([
+        expect(statements.map((s) => s.value.location)).toEqual([
             {
                 start: { line: 1, column: 4 },
                 end: { line: 1, column: 5 },

--- a/test/parser/statement/Set.test.js
+++ b/test/parser/statement/Set.test.js
@@ -261,7 +261,7 @@ describe("parser indexed assignment", () => {
 
         expect(errors).toEqual([]);
         expect(statements.length).toBe(2);
-        expect(statements.map(s => s.location)).toEqual([
+        expect(statements.map((s) => s.location)).toEqual([
             {
                 start: { line: 1, column: 0 },
                 end: { line: 1, column: 10 },

--- a/test/stdlib/Json.test.js
+++ b/test/stdlib/Json.test.js
@@ -230,7 +230,7 @@ describe("global JSON functions", () => {
             expect(actual).toBeInstanceOf(RoAssociativeArray);
             actualKeys = actual.getElements();
             expect(actualKeys).toEqual(expected.getElements());
-            actualKeys.forEach(key => {
+            actualKeys.forEach((key) => {
                 expect(actual.get(key)).toEqual(expected.get(key));
             });
         });

--- a/test/stdlib/Runtime.test.js
+++ b/test/stdlib/Runtime.test.js
@@ -45,7 +45,7 @@ describe("global runtime functions", () => {
                 { value: new RoArray([]), type: "roArray" },
                 { value: new RoAssociativeArray([]), type: "roAssociativeArray" },
                 { value: Uninitialized.Instance, type: "<UNINITIALIZED>" },
-            ].forEach(testCase =>
+            ].forEach((testCase) =>
                 test(testCase.type, () => {
                     expect(Type.call(interpreter, testCase.value, new Int32(3))).toEqual(
                         new BrsString(testCase.type)
@@ -68,7 +68,7 @@ describe("global runtime functions", () => {
                 { value: new RoArray([]), type: "roArray" },
                 { value: new RoAssociativeArray([]), type: "roAssociativeArray" },
                 { value: Uninitialized.Instance, type: "<UNINITIALIZED>" },
-            ].forEach(testCase =>
+            ].forEach((testCase) =>
                 test(testCase.type, () => {
                     expect(Type.call(interpreter, testCase.value)).toEqual(
                         new BrsString(testCase.type)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3405,10 +3405,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.17.0:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@2:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
The defaults changed for prettier -- mostly `arrowParens: true` -- andI've been meaning to enable that anyway.  Let's use that major-version bump as an excuse to reformat everything.  It pains me a little to have such a large diff but at least it's mostly `()` insertion.

Realistically, the main motivation for the upgrade is support for TypeScript 3.8 language features like `import type …`.