### PR TITLE
fix(stdlib): remove duplicate extends warning

### DIFF
--- a/src/componentprocessor/index.ts
+++ b/src/componentprocessor/index.ts
@@ -156,24 +156,6 @@ async function processXmlTree(
         if (xmlNode) {
             nodeDef.children = getChildren(xmlNode);
             nodeDef.scripts = getScripts(xmlNode);
-            let baseNode = xmlNode.attr.extends;
-            while (baseNode) {
-                let baseNodeDef = nodeDefMap.get(baseNode);
-                if (baseNodeDef) {
-                    nodeDef.children = [...nodeDef.children];
-                    baseNode = baseNodeDef.xmlNode!.attr.extends;
-                } else {
-                    if (!(baseNode in BrsComponentName)) {
-                        // The reference implementation doesn't allow extensions of unknown node subtypes, but
-                        // BRS hasn't implemented every node type in the reference implementation!  For now,
-                        // let's warn when we detect unknown subtypes.
-                        console.error(
-                            `XML component '${nodeDef.name}' extends unknown component '${baseNode}'. Ignoring extension.`
-                        );
-                    }
-                    break;
-                }
-            }
         }
     });
 

--- a/src/parser/ComponentScopeResolver.ts
+++ b/src/parser/ComponentScopeResolver.ts
@@ -74,8 +74,11 @@ export class ComponentScopeResolver {
             let previousComponent = currentComponent;
             currentComponent = this.componentMap.get(currentComponent.extends);
             if (!currentComponent) {
+                // The reference implementation doesn't allow extensions of unknown node subtypes, but
+                // BRS hasn't implemented every node type in the reference implementation!  For now,
+                // let's warn when we detect unknown subtypes.
                 console.error(
-                    `XML component '${previousComponent.extends}' extends unknown component '${previousComponent.name}'. Ignoring extension.`
+                    `Warning: XML component '${previousComponent.extends}' extends unknown component '${previousComponent.name}'. Ignoring extension.`
                 );
                 return Promise.resolve();
             }

--- a/src/parser/ComponentScopeResolver.ts
+++ b/src/parser/ComponentScopeResolver.ts
@@ -75,7 +75,7 @@ export class ComponentScopeResolver {
             currentComponent = this.componentMap.get(currentComponent.extends);
             if (!currentComponent) {
                 console.error(
-                    `Cannot find extended component ${previousComponent.extends} defined on ${previousComponent.name}`
+                    `XML component '${previousComponent.extends}' extends unknown component '${previousComponent.name}'. Ignoring extension.`
                 );
                 return Promise.resolve();
             }


### PR DESCRIPTION
# Change Summary

This removes a duplicate warning we logged to `stdout` when we encountered an unknown component extension. It's exactly the same scenario, so there's no need to log it twice.