### PR TITLE
feat(extensions): enable mock resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,84 @@ Thanks to the [npm-run-all](https://www.npmjs.com/package/npm-run-all) package, 
 ```shell
 $ yarn run-s clean build test
 ```
+
+## Extensions
+
+For the most part, `brs` attempts to emulate BrightScript as closely as possible. However, in the spirit of unit testing, it also has a few extensions that will help with testing.
+
+### `_brs_.process`
+
+Allows you to access the command line arguments. Usage:
+
+```brightscript
+print _brs_.process
+' {
+'   argv: [ "some", "arg" ]
+' }
+```
+
+### `_brs_.global`
+
+Allows you to access `m.global` from inside your unit tests. Usage:
+
+```brightscript
+print _brs_.global
+' {
+'   someGlobalField: "someGlobalValue"
+' }
+```
+
+### `_brs_.runInScope`
+
+Runs a file (or set of files) **in the current global + module scope** with the provided arguments, returning either the value returned by those files' `main` function or `invalid` if an error occurs.
+
+```brightscript
+_brs_.runInScope("/path/to/myFile.brs", { foo: "bar" })
+```
+
+### `_brs_.mockComponent`
+
+Allows you to mock a component. Usage:
+
+```brightscript
+_brs_.mockComponent("ComponentName", {
+    someField: "foobar",
+    someFunc: sub()
+      return 123
+    end sub
+})
+```
+
+### `_brs_.mockFunction`
+
+Allows you to mock a function. Usage:
+
+```brightscript
+_brs_.mockFunction("FunctionName", sub()
+    print "foobar"
+end sub)
+```
+
+### `_brs_.resetMocks`
+
+Resets all component and function mocks. Usage:
+
+```brightscript
+_brs_.resetMocks()
+```
+
+### `_brs_.resetMockComponents`
+
+Resets all component mocks. Usage:
+
+```brightscript
+_brs_.resetMockComponents()
+```
+
+### `_brs_.resetMockFunctions`
+
+Resets all function mocks. Usage:
+
+```brightscript
+_brs_.resetMockFunctions()
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "An interpreter for the BrightScript language that runs on non-Roku platforms.",
   "author": "Sean Barag <sean@barag.org>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs",
-  "version": "0.24.2",
+  "version": "0.24.1",
   "description": "An interpreter for the BrightScript language that runs on non-Roku platforms.",
   "author": "Sean Barag <sean@barag.org>",
   "license": "MIT",

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -3,10 +3,14 @@ import { mockComponent } from "./mockComponent";
 import { mockFunction } from "./mockFunction";
 import { RunInScope } from "./RunInScope";
 import { Process } from "./Process";
+import { resetMocks, resetMockComponents, resetMockFunctions } from "./resetMocks";
 
 export const _brs_ = new RoAssociativeArray([
     { name: new BrsString("mockComponent"), value: mockComponent },
     { name: new BrsString("mockFunction"), value: mockFunction },
+    { name: new BrsString("resetMocks"), value: resetMocks },
+    { name: new BrsString("resetMockComponents"), value: resetMockComponents },
+    { name: new BrsString("resetMockFunctions"), value: resetMockFunctions },
     { name: new BrsString("runInScope"), value: RunInScope },
     { name: new BrsString("process"), value: Process },
     { name: new BrsString("global"), value: mGlobal },

--- a/src/extensions/resetMocks.ts
+++ b/src/extensions/resetMocks.ts
@@ -1,8 +1,4 @@
-import {
-    ValueKind,
-    Callable,
-    BrsInvalid,
-} from "../brsTypes";
+import { ValueKind, Callable, BrsInvalid } from "../brsTypes";
 import { Interpreter } from "../interpreter";
 
 export const resetMocks = new Callable("resetMocks", {

--- a/src/extensions/resetMocks.ts
+++ b/src/extensions/resetMocks.ts
@@ -1,0 +1,39 @@
+import {
+    ValueKind,
+    Callable,
+    BrsInvalid,
+} from "../brsTypes";
+import { Interpreter } from "../interpreter";
+
+export const resetMocks = new Callable("resetMocks", {
+    signature: {
+        args: [],
+        returns: ValueKind.Void,
+    },
+    impl: (interpreter: Interpreter) => {
+        interpreter.environment.resetMocks();
+        return BrsInvalid.Instance;
+    },
+});
+
+export const resetMockFunctions = new Callable("resetMockFunctions", {
+    signature: {
+        args: [],
+        returns: ValueKind.Void,
+    },
+    impl: (interpreter: Interpreter) => {
+        interpreter.environment.resetMockFunctions();
+        return BrsInvalid.Instance;
+    },
+});
+
+export const resetMockComponents = new Callable("resetMockComponents", {
+    signature: {
+        args: [],
+        returns: ValueKind.Void,
+    },
+    impl: (interpreter: Interpreter) => {
+        interpreter.environment.resetMockObjects();
+        return BrsInvalid.Instance;
+    },
+});

--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -305,6 +305,28 @@ export class Environment {
     }
 
     /**
+     * resets all of the mocked functions and objects in this environment
+     */
+    public resetMocks() {
+        this.resetMockObjects();
+        this.resetMockFunctions();
+    }
+
+    /**
+     * resets all of the mocked objects in this environment
+     */
+    public resetMockObjects() {
+        this.mockObjects.clear();
+    }
+
+    /**
+     * resets all of the mocked functions in this environment
+     */
+    public resetMockFunctions() {
+        this.mockFunctions.clear();
+    }
+
+    /**
      * Sets the currently focused node, which reacts to onKey button presses
      * @param node either node object or invalid
      */

--- a/test/e2e/BrsMock.test.js
+++ b/test/e2e/BrsMock.test.js
@@ -74,4 +74,19 @@ describe("end to end brightscript functions", () => {
 
         consoleErrorSpy.mockRestore();
     });
+
+    test("resetMocks.brs", async () => {
+        await execute([resourceFile("resetMocks.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
+            "fake",
+            "foo bar",
+            "fake",
+            "bar",
+            "foo bar",
+            "fake",
+            "fake",
+            "bar",
+        ]);
+    });
 });

--- a/test/e2e/resources/components/ResetMocksComponent.xml
+++ b/test/e2e/resources/components/ResetMocksComponent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="ResetMocksComponent">
+    <interface>
+        <field id="foo" type="string" value="bar" />
+    </interface>
+</component>

--- a/test/e2e/resources/resetMocks.brs
+++ b/test/e2e/resources/resetMocks.brs
@@ -1,0 +1,54 @@
+sub Main()
+    ' mock to start
+    mockFunctionsHelper()
+    print fooBar() ' => "fake"
+
+    _brs_.resetMocks()
+    print fooBar() ' => "foo bar"
+
+    ' create mocks
+    mockComponentsHelper()
+
+    node = createObject("RoSGNode", "ResetMocksComponent")
+    print node.foo ' => "fake"
+
+    _brs_.resetMocks()
+
+    node = createObject("RoSGNode", "ResetMocksComponent")
+    print node.foo ' => "bar"
+
+    mockFunctionsHelper()
+    mockComponentsHelper()
+    node = createObject("RoSGNode", "ResetMocksComponent")
+
+    _brs_.resetMockFunctions()
+
+    print fooBar() ' => "foo bar"
+    print node.foo ' => "fake"
+
+    mockFunctionsHelper()
+    mockComponentsHelper()
+
+    _brs_.resetMockComponents()
+    node = createObject("RoSGNode", "ResetMocksComponent")
+
+    print fooBar() ' => "fake"
+    print node.foo ' => "bar"
+end sub
+
+function fooBar()
+    return "foo bar"
+end function
+
+
+function mockFunctionsHelper()
+    _brs_.mockFunction("fooBar", function() as string
+        return "fake"
+    end function)
+end function
+
+function mockComponentsHelper()
+    _brs_.mockComponent("ResetMocksComponent", {
+        foo: "fake"
+    })
+end function


### PR DESCRIPTION
# Change Summary

This allows you to reset mocks for components, functions, or both. Closes #466.