### PR TITLE
fix(rsg): Support relative paths in <script/> tags

### DIFF
--- a/src/Error.ts
+++ b/src/Error.ts
@@ -11,11 +11,22 @@ export class BrsError extends Error {
      * and column, and the message associated with the error, e.g.:
      *
      * `lorem.brs(1,1-3): Expected '(' after sub name`
-     * ```
+     * @see BrsError#format
      */
     format() {
-        let location = this.location;
+        return BrsError.format(this.message, this.location);
+    }
 
+    /**
+     * Formats a location and message into a human-readable string including filename, starting
+     * and ending line and column, and the message associated with the error, e.g.:
+     *
+     * `lorem.brs(1,1-3): Expected '(' after sub name`
+     *
+     * @param message a string describing the error
+     * @param location where the error occurred
+     */
+    static format(message: string, location: Location): string {
         let formattedLocation: string;
 
         if (location.start.line === location.end.line) {
@@ -28,9 +39,11 @@ export class BrsError extends Error {
             formattedLocation = `${location.file}(${location.start.line},${location.start.column},${location.end.line},${location.end.line})`;
         }
 
-        return `${formattedLocation}: ${this.message}\n`;
+        return `${formattedLocation}: ${message}\n`;
     }
 }
+
+export function formatError(location: Location, message: string) {}
 
 /** Wraps up the metadata associated with a type mismatch error. */
 export interface TypeMismatchMetadata {

--- a/src/Error.ts
+++ b/src/Error.ts
@@ -43,8 +43,6 @@ export class BrsError extends Error {
     }
 }
 
-export function formatError(location: Location, message: string) {}
-
 /** Wraps up the metadata associated with a type mismatch error. */
 export interface TypeMismatchMetadata {
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,12 +38,7 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
     const executionOptions = Object.assign(defaultExecutionOptions, options);
 
     let manifest = await PP.getManifest(executionOptions.root);
-    let componentDefinitions: Map<string, ComponentDefinition>;
-    try {
-        componentDefinitions = await getComponentDefinitionMap(executionOptions.root);
-    } catch (err) {
-        throw err;
-    }
+    let componentDefinitions = await getComponentDefinitionMap(executionOptions.root);
 
     componentDefinitions.forEach((component: ComponentDefinition) => {
         if (component.scripts.length < 1) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,12 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
     const executionOptions = Object.assign(defaultExecutionOptions, options);
 
     let manifest = await PP.getManifest(executionOptions.root);
-    let componentDefinitions = await getComponentDefinitionMap(executionOptions.root);
+    let componentDefinitions: Map<string, ComponentDefinition>;
+    try {
+        componentDefinitions = await getComponentDefinitionMap(executionOptions.root);
+    } catch (err) {
+        throw err;
+    }
 
     componentDefinitions.forEach((component: ComponentDefinition) => {
         if (component.scripts.length < 1) return;

--- a/test/componentprocessor/componentprocessor.test.js
+++ b/test/componentprocessor/componentprocessor.test.js
@@ -8,7 +8,7 @@ const fs = require("fs");
 
 const realFs = jest.requireActual("fs");
 
-describe.only("component parsing support", () => {
+describe("component parsing support", () => {
     afterEach(() => {
         fg.sync.mockRestore();
         fs.readFile.mockRestore();
@@ -65,11 +65,10 @@ describe.only("component parsing support", () => {
                         "scripts/baseComp.brs",
                         "scripts/extendedComp.brs",
                         "scripts/utility.brs",
-                    ];
+                    ].map((f) => path.join(__dirname, "resources", f));
                 });
                 fs.readFile.mockImplementation((filename, _, cb) => {
-                    resourcePath = path.join(__dirname, "resources", filename);
-                    realFs.readFile(resourcePath, (err, contents) => {
+                    realFs.readFile(filename, (err, contents) => {
                         cb(/* no error */ null, contents);
                     });
                 });
@@ -90,7 +89,7 @@ describe.only("component parsing support", () => {
             });
 
             it("adds all scripts into node in correct order", async () => {
-                let map = await getComponentDefinitionMap("/doesnt/matter");
+                let map = await getComponentDefinitionMap(process.cwd());
                 let parsedExtendedComp = map.get("ExtendedComponent");
                 expect(parsedExtendedComp).not.toBeUndefined();
                 expect(parsedExtendedComp.scripts).not.toBeUndefined();
@@ -106,7 +105,7 @@ describe.only("component parsing support", () => {
 
             it("ignores extensions of unknown node subtypes", async () => {
                 fg.sync.mockImplementation(() => {
-                    return ["unknownExtensionComponent.xml"];
+                    return [path.join(__dirname, "resources", "unknownExtensionComponent.xml")];
                 });
 
                 jest.spyOn(global.console, "error").mockImplementation();

--- a/test/componentprocessor/resources/extendedComponent.xml
+++ b/test/componentprocessor/resources/extendedComponent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="ExtendedComponent" extends="BaseComponent">
-<script type="text/brightscript" uri="pkg:/test/componentprocessor/resources/scripts/extendedComponent.brs" />
+<script type="text/brightscript" uri="scripts/extendedComponent.brs" />
 <script type="text/brightscript" uri="pkg:/test/componentprocessor/resources/scripts/utility.brs" />
 <children>
         <Label name="label_b" />


### PR DESCRIPTION
RBI allows relative paths in <script/> tags, resolved relative to the XML file that contains the element.  We should support that too, because SGDEX makes heavy use of relative paths (also it's really handy :D)

fixes #471