### PR TITLE
fix(ci): Use actions/setup-node to seed auth token in .npmrc

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -2,7 +2,7 @@
   name: "Nightly build",
   on: {
     schedule: [
-      { cron: "05 16 * * *" }
+      { cron: "20 17 * * *" }
     ]
   },
   jobs: {
@@ -20,10 +20,18 @@
         },
         { run: "yarn" },
         {
-          run: "yarn publish --no-git-tag-version --new-version `node scripts/getNightlyVersion.js` --tag nightly",
+          name: "Re-initialize node w/ auth token",
+          uses: "actions/setup-node@v1",
+          with: {
+            registry-url: "https://registry.npmjs.org",
+            node-version: "12"
+          },
           env: {
             NODE_AUTH_TOKEN: "${{ secrets.NPM_PUBLISH_TOKEN }}"
           }
+        },
+        {
+          run: "yarn publish --no-git-tag-version --new-version `node scripts/getNightlyVersion.js` --tag nightly"
         },
       ],
       env: {


### PR DESCRIPTION
While `yarn` doesn't seem to look at an environment variable for authentication, it does look at ~/.npmrc and the setup-node action reads an auth token from the `NODE_AUTH_TOKEN` environment variable:

https://github.com/actions/setup-node/blob/59e61b89511ed136a0b17773f07c349fa5c01e8b/src/authutil.ts#L46-L48

All of which is to say this _should_ work now.
I think.
:fingers_crossed: