### PR TITLE
feat(perf): Memoize component scope resolution lexing and parsing

### DIFF
--- a/test/parser/ComponentScopeResolver.test.js
+++ b/test/parser/ComponentScopeResolver.test.js
@@ -55,7 +55,6 @@ describe("ComponentScopeResolver", () => {
         let componentScopeResolver = new brs.parser.ComponentScopeResolver(componentMap, parseFn);
         let statements = await componentScopeResolver.resolve(componentToResolve);
         expect(statements).toBeDefined();
-        expect(statements.length).toBe(2);
 
         let statementNames = statements.map((s) => s.name.text);
         expect(statementNames).toEqual(["test", "test2"]);
@@ -70,7 +69,6 @@ describe("ComponentScopeResolver", () => {
         let componentScopeResolver = new brs.parser.ComponentScopeResolver(componentMap, parseFn);
         let statements = await componentScopeResolver.resolve(componentToResolve);
         expect(statements).toBeDefined();
-        expect(statements.length).toBe(5);
 
         let statementNames = statements.map((s) => s.name.text);
         // Statements are in a specific order


### PR DESCRIPTION
Many components can include the same files via `<script/>` tag, and we previously lexed, preprocessed, and parsed those files every time they were encountered in any component.  Even if a component and its extension both import `uri="pkg:/components/foo.brs"`, we'd parse it twice.  Bummer!

We can save a significant amount of time by memoizing that lexing, preprocessing, and parsing process across components.