### PR TITLE
fix(stdlib): make tests run again

### DIFF
--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -249,14 +249,11 @@ export class Environment {
     public createSubEnvironment(includeModuleScope: boolean = true): Environment {
         let newEnvironment = new Environment(this.rootM);
         newEnvironment.global = new Map(this.global);
-        newEnvironment.module = includeModuleScope
-            ? new Map(this.module)
-            : new Map<string, BrsType>();
         newEnvironment.mPointer = this.mPointer;
         newEnvironment.mockObjects = this.mockObjects;
 
         if (includeModuleScope) {
-            newEnvironment.module = this.module;
+            newEnvironment.module = new Map(this.module);
             newEnvironment.mockFunctions = this.mockFunctions;
         } else {
             newEnvironment.module = new Map<string, BrsType>();


### PR DESCRIPTION
# Change Summary

I noticed on the most recent version of `roca` (0.10.1) and the nightly build version of `brs`, running tests didn't work (no tests ran at all). It appears that we were doing a copy-by-reference operation instead of copy-by-value, which was causing the tests to not run. That change was added in [this commit](https://github.com/sjbarag/brs/commit/c3d417521a1109ab9d24966aec75704c64c86e98#diff-ab5e0cb216fac83164743862c64250b3R259), which hasn't been released outside of nightly builds yet.