### PR TITLE
v0.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "description": "An interpreter for the BrightScript language that runs on non-Roku platforms.",
   "author": "Sean Barag <sean@barag.org>",
   "license": "MIT",


### PR DESCRIPTION
# Change summary

Upgrades to `v0.26.0`. Have to do it via PR because `master` is protected.