### PR TITLE
fix(exts,mocks): differentiate between scoped and unscoped function mocks

### DIFF
--- a/src/extensions/mockComponentPartial.ts
+++ b/src/extensions/mockComponentPartial.ts
@@ -31,7 +31,11 @@ export const mockComponentPartial = new Callable("mockComponentPartial", {
                 .filter(([_, value]) => value.kind === ValueKind.Callable)
                 .forEach(([key, value]) => {
                     if (value instanceof Callable) {
-                        maybeComponent?.environment?.setMockFunction(key.toString(), value, /* isScoped */ true);
+                        maybeComponent?.environment?.setMockFunction(
+                            key.toString(),
+                            value,
+                            /* isScoped */ true
+                        );
                     }
                 });
         } else {

--- a/src/extensions/mockComponentPartial.ts
+++ b/src/extensions/mockComponentPartial.ts
@@ -31,7 +31,7 @@ export const mockComponentPartial = new Callable("mockComponentPartial", {
                 .filter(([_, value]) => value.kind === ValueKind.Callable)
                 .forEach(([key, value]) => {
                     if (value instanceof Callable) {
-                        maybeComponent?.environment?.setMockFunction(key.toString(), value);
+                        maybeComponent?.environment?.setMockFunction(key.toString(), value, /* isScoped */ true);
                     }
                 });
         } else {

--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -253,9 +253,6 @@ export class Environment {
     public createSubEnvironment(includeModuleScope: boolean = true): Environment {
         let newEnvironment = new Environment(this.rootM);
         newEnvironment.global = new Map(this.global);
-        newEnvironment.module = includeModuleScope
-            ? new Map(this.module)
-            : new Map<string, BrsType>();
         newEnvironment.mPointer = this.mPointer;
         newEnvironment.mockObjects = this.mockObjects;
         newEnvironment.unscopedMockFunctions = this.unscopedMockFunctions;

--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -328,9 +328,9 @@ export class Environment {
      */
     private isMockedFunction(possibleMockFunction: BrsType, possibleMockName: string): boolean {
         return (
-            (possibleMockFunction instanceof Callable &&
-                this.scopedMockFunctions.has(possibleMockName)) ||
-            this.unscopedMockFunctions.has(possibleMockName)
+            possibleMockFunction instanceof Callable &&
+            (this.scopedMockFunctions.has(possibleMockName) ||
+                this.unscopedMockFunctions.has(possibleMockName))
         );
     }
 

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -666,21 +666,4 @@ describe("end to end brightscript functions", () => {
             "Node",
         ]);
     });
-
-    test("components/scripts/MockFunctionsMain.brs", async () => {
-        await execute(
-            [resourceFile("components", "scripts", "MockFunctionsMain.brs")],
-            outputStreams
-        );
-        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
-            "{fake:'json'}",
-            "GET status: 400",
-            "POST status: 500",
-            "true",
-            "{real: 'json'}",
-            "GET status: 200",
-            "POST status: 200",
-            "false",
-        ]);
-    });
 });

--- a/test/e2e/BrsMock.test.js
+++ b/test/e2e/BrsMock.test.js
@@ -86,10 +86,12 @@ describe("end to end brightscript functions", () => {
             "GET status: 400",
             "POST status: 500",
             "true",
+            "mocked correctly!",
             "{real: 'json'}",
             "GET status: 200",
             "POST status: 200",
             "false",
+            "mocked correctly!"
         ]);
     });
 

--- a/test/e2e/BrsMock.test.js
+++ b/test/e2e/BrsMock.test.js
@@ -91,7 +91,7 @@ describe("end to end brightscript functions", () => {
             "GET status: 200",
             "POST status: 200",
             "false",
-            "mocked correctly!"
+            "mocked correctly!",
         ]);
     });
 

--- a/test/e2e/resources/components/ComponentMockFunctions.xml
+++ b/test/e2e/resources/components/ComponentMockFunctions.xml
@@ -3,6 +3,7 @@
     <script type="text/brightscript" uri="pkg:/components/scripts/ComponentMockFunctions.brs" />
     <script type="text/brightscript" uri="pkg:/components/scripts/MockFunctionsUtils-A.brs" />
     <script type="text/brightscript" uri="pkg:/components/scripts/MockFunctionsUtils-B.brs" />
+    <script type="text/brightscript" uri="pkg:/components/scripts/MockFunctionsUtils-C.brs" />
     <children>
     </children>
 </component>

--- a/test/e2e/resources/components/ComponentWithoutMockFunctions.xml
+++ b/test/e2e/resources/components/ComponentWithoutMockFunctions.xml
@@ -3,6 +3,7 @@
     <script type="text/brightscript" uri="pkg:/components/scripts/ComponentWithoutMockFunctions.brs" />
     <script type="text/brightscript" uri="pkg:/components/scripts/MockFunctionsUtils-A.brs" />
     <script type="text/brightscript" uri="pkg:/components/scripts/MockFunctionsUtils-B.brs" />
+    <script type="text/brightscript" uri="pkg:/components/scripts/MockFunctionsUtils-C.brs" />
     <children>
     </children>
 </component>

--- a/test/e2e/resources/components/scripts/ComponentMockFunctions.brs
+++ b/test/e2e/resources/components/scripts/ComponentMockFunctions.brs
@@ -4,5 +4,5 @@ sub init()
     print http_get() ' => GET status: 400
     print http_post() ' => POST status: 500
     print isValid() ' => true
-    print indirectCall() ' => {fake:'json'}
+    print shouldBeMocked() ' => "mocked correctly!"
 end sub

--- a/test/e2e/resources/components/scripts/ComponentMockFunctions.brs
+++ b/test/e2e/resources/components/scripts/ComponentMockFunctions.brs
@@ -4,4 +4,5 @@ sub init()
     print http_get() ' => GET status: 400
     print http_post() ' => POST status: 500
     print isValid() ' => true
+    print indirectCall() ' => {fake:'json'}
 end sub

--- a/test/e2e/resources/components/scripts/ComponentWithoutMockFunctions.brs
+++ b/test/e2e/resources/components/scripts/ComponentWithoutMockFunctions.brs
@@ -3,5 +3,5 @@ sub init()
     print http_get() ' => GET status: 200
     print http_post() ' => POST status: 200
     print isValid() ' => false
-    print indirectCall() ' => {real:'json'}
+    print shouldBeMocked() ' => "mocked correctly!"
 end sub

--- a/test/e2e/resources/components/scripts/ComponentWithoutMockFunctions.brs
+++ b/test/e2e/resources/components/scripts/ComponentWithoutMockFunctions.brs
@@ -3,4 +3,5 @@ sub init()
     print http_get() ' => GET status: 200
     print http_post() ' => POST status: 200
     print isValid() ' => false
+    print indirectCall() ' => {real:'json'}
 end sub

--- a/test/e2e/resources/components/scripts/MockFunctionsMain.brs
+++ b/test/e2e/resources/components/scripts/MockFunctionsMain.brs
@@ -14,6 +14,10 @@ sub main()
         end function
     })
 
+    _brs_.mockFunction("shouldBeMocked", function() as dynamic
+        return "mocked correctly!"
+    end function)
+
     m1 = createObject("roSGNode", "ComponentMockFunctions")
     real = createObject("roSGNode", "ComponentWithoutMockFunctions")
 end sub

--- a/test/e2e/resources/components/scripts/MockFunctionsUtils-C.brs
+++ b/test/e2e/resources/components/scripts/MockFunctionsUtils-C.brs
@@ -1,0 +1,3 @@
+function indirectCall()
+    return formatJson({})
+end function

--- a/test/e2e/resources/components/scripts/MockFunctionsUtils-C.brs
+++ b/test/e2e/resources/components/scripts/MockFunctionsUtils-C.brs
@@ -1,3 +1,3 @@
-function indirectCall()
-    return formatJson({})
+function shouldBeMocked()
+    return "noooo should be mocked"
 end function


### PR DESCRIPTION
# Change Summary

We currently conflate module-scoped mock functions (`mockComponentPartial`) with universally scoped mock functions (mocks that override any function of the same name, at every scope level above function-scope). This causes issues when the universal mocks aren't copied from environment to environment.

This PR separates scoped vs. unscoped function mocks.