### PR TITLE
fix(parse): Allow multiple statements in single-line `if` branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "watch": "tsc -w",
     "clean": "rimraf ./lib ./types",
     "test": "jest",
+    "test:debug": "node --inspect-brk ./node_modules/.bin/jest --runInBand -- ",
     "lint": "tslint --project .",
     "prettier:write": "prettier --write \"{bin,src,test}/**/*.{js,ts}\"",
     "prettier": "prettier --check \"{bin,src,test}/**/*.{js,ts}\"",

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -116,6 +116,7 @@ describe("end to end syntax", () => {
             "foo is not > 1",
             "foo is not < 2",
             "foo is not < 2 and not > 2",
+            "#481 fixed",
         ]);
     });
 

--- a/test/e2e/resources/conditionals.brs
+++ b/test/e2e/resources/conditionals.brs
@@ -1,123 +1,135 @@
-foo = 5
+sub main()
+    foo = 5
 
-' just a simple if statement; no else
-if foo < 10 then print 1
+    ' just a simple if statement; no else
+    if foo < 10 then print 1
 
-' this one should get skipped
-if foo < 0 then print "foo < 0"
+    ' this one should get skipped
+    if foo < 0 then print "foo < 0"
 
-' add an else
-if foo < 1 then print "foo < 1" else print 2
+    ' add an else
+    if foo < 1 then print "foo < 1" else print 2
 
-' add an else if
-if foo < 1 then print "foo < 1" else if foo = 5 then print 3 else print "foo > 1 and not 5"
+    ' add an else if
+    if foo < 1 then print "foo < 1" else if foo = 5 then print 3 else print "foo > 1 and not 5"
 
-' just a simple if statement; no else
-if foo < 10 then
-    print 4
-end if
+    ' just a simple if statement; no else
+    if foo < 10 then
+        print 4
+    end if
 
-' this one should get skipped
-if foo < 0 then
-    print "foo < 0"
-end if
+    ' this one should get skipped
+    if foo < 0 then
+        print "foo < 0"
+    end if
 
-' add an else
-if foo < 1 then
-    print "foo < 1"
-else
-    print 5
-end if
+    ' add an else
+    if foo < 1 then
+        print "foo < 1"
+    else
+        print 5
+    end if
 
-' add an elseif
-if foo < 1 then
-    print "foo < 1"
-else if foo < 3 then
-    print "foo < 3"
-else if foo = 5 then
-    print 6
-else if foo < 10 then
-    print "foo < 10"
-else
-    print "from else"
-endif
+    ' add an elseif
+    if foo < 1 then
+        print "foo < 1"
+    else if foo < 3 then
+        print "foo < 3"
+    else if foo = 5 then
+        print 6
+    else if foo < 10 then
+        print "foo < 10"
+    else
+        print "from else"
+    endif
 
-' inline if inside if
-if foo < 5
-    if foo < 3 then print "foo < 3"
-else if foo = 5
-    print 7
-end if
+    ' inline if inside if
+    if foo < 5
+        if foo < 3 then print "foo < 3"
+    else if foo = 5
+        print 7
+    end if
 
-' inline if with dotted expression
-aa = {}
-if foo > 5 then aa.value = ">5" else aa.value = 8
-print aa.value
+    ' inline if with dotted expression
+    aa = {}
+    if foo > 5 then aa.value = ">5" else aa.value = 8
+    print aa.value
 
-' if not with boolean
-if not true then
-    print "this will never print"
-end if
+    ' if not with boolean
+    if not true then
+        print "this will never print"
+    end if
 
-if not false then
-    print "not false"
-end if
+    if not false then
+        print "not false"
+    end if
 
-' if not with an expression
-bar = "abc"
-if not bar = "def" then
-    print "bar does not equal 'def'"
-end if
+    ' if not with an expression
+    bar = "abc"
+    if not bar = "def" then
+        print "bar does not equal 'def'"
+    end if
 
-' if not with or
-if not bar = "def" or false then
-    print "if not with or variation 1"
-end if
+    ' if not with or
+    if not bar = "def" or false then
+        print "if not with or variation 1"
+    end if
 
-if not bar = "abc" or true then
-    print "if not with or variation 2"
-end if
+    if not bar = "abc" or true then
+        print "if not with or variation 2"
+    end if
 
-' if not with and
-if not bar = "def" and true then
-    print "if not with and"
-end if
+    ' if not with and
+    if not bar = "def" and true then
+        print "if not with and"
+    end if
 
-' if not with two expressions
-foo = 1
-if not bar = "def" and foo = 1 then
-    print "if not with two expressions variation 1"
-end if
+    ' if not with two expressions
+    foo = 1
+    if not bar = "def" and foo = 1 then
+        print "if not with two expressions variation 1"
+    end if
 
-if bar = "abc" and not foo = 2 then
-    print "if not with two expressions variation 2"
-end if
+    if bar = "abc" and not foo = 2 then
+        print "if not with two expressions variation 2"
+    end if
 
-' if not multiple times
-foo = 1
-if not bar = "def" and not foo = 2 then
-    print "if not multiple times"
-end if
+    ' if not multiple times
+    foo = 1
+    if not bar = "def" and not foo = 2 then
+        print "if not multiple times"
+    end if
 
-' if not with <> operator
-if not bar <> "abc" then
-    print "if not with <> operator"
-end if
+    ' if not with <> operator
+    if not bar <> "abc" then
+        print "if not with <> operator"
+    end if
 
-' if not with > operator
-foo = 1
-if not foo > 1 then
-    print "foo is not > 1"
-end if
+    ' if not with > operator
+    foo = 1
+    if not foo > 1 then
+        print "foo is not > 1"
+    end if
 
-' if not with < operator
-foo = 2
-if not foo < 2 then
-    print "foo is not < 2"
-end if
+    ' if not with < operator
+    foo = 2
+    if not foo < 2 then
+        print "foo is not < 2"
+    end if
 
-' if not with < operator
-foo = 2
-if not foo < 2 and not foo > 2 then
-    print "foo is not < 2 and not > 2"
-end if
+    ' if not with < operator
+    foo = 2
+    if not foo < 2 and not foo > 2 then
+        print "foo is not < 2 and not > 2"
+    end if
+
+    test_481()
+end sub
+
+' MWE from https://github.com/sjbarag/brs/issues/481
+sub test_481()
+    nop = sub() : end sub
+
+    if false then nop(): print "#481 still repro's": return
+    print "#481 fixed"
+end sub

--- a/test/parser/controlFlow/If.test.js
+++ b/test/parser/controlFlow/If.test.js
@@ -165,6 +165,20 @@ describe("parser if statements", () => {
             expect(statements).not.toBeNull();
             expect(statements).toMatchSnapshot();
         });
+
+        it("allows multiple statements in 'then' block (#481)", () => {
+            let { tokens } = brs.lexer.Lexer.scan(`
+                if false then nop(): print "#481 still repro's": return
+                print "#481 fixed"
+            `);
+
+            let { statements, errors } = parser.parse(tokens);
+            expect(errors).toEqual([]);
+            expect(statements).toBeDefined();
+            expect(statements).not.toBeNull();
+            let ifStatement = statements[0];
+            expect(ifStatement.thenBranch.statements.length).toBe(3);
+        });
     });
 
     describe("block if", () => {
@@ -379,8 +393,4 @@ describe("parser if statements", () => {
         expect(errors.length).toEqual(0);
         expect(statements).toMatchSnapshot();
     });
-
-    // TODO: Improve `if` statement structure to allow a linter to require a `then` keyword for
-    // all `if` statements, then test location tracking
-    test.todo("location tracking");
 });

--- a/test/parser/controlFlow/__snapshots__/If.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/If.test.js.snap
@@ -64,7 +64,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 21,
+          "column": 20,
           "line": 7,
         },
       },
@@ -189,7 +189,7 @@ Array [
             },
             "file": "",
             "start": Object {
-              "column": 30,
+              "column": 29,
               "line": 4,
             },
           },
@@ -316,7 +316,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 25,
+          "column": 24,
           "line": 2,
         },
       },
@@ -504,7 +504,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 30,
+          "column": 29,
           "line": 2,
         },
       },
@@ -743,7 +743,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 21,
+          "column": 20,
           "line": 4,
         },
       },
@@ -869,7 +869,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 30,
+          "column": 29,
           "line": 2,
         },
       },
@@ -1053,7 +1053,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 21,
+          "column": 20,
           "line": 7,
         },
       },
@@ -1178,7 +1178,7 @@ Array [
             },
             "file": "",
             "start": Object {
-              "column": 35,
+              "column": 34,
               "line": 4,
             },
           },
@@ -1305,7 +1305,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 30,
+          "column": 29,
           "line": 2,
         },
       },
@@ -1455,7 +1455,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 24,
+            "column": 23,
             "line": 2,
           },
         },
@@ -1486,7 +1486,7 @@ Array [
                 },
                 "file": "",
                 "start": Object {
-                  "column": 25,
+                  "column": 24,
                   "line": 7,
                 },
               },
@@ -1560,7 +1560,7 @@ Array [
                     },
                     "file": "",
                     "start": Object {
-                      "column": 38,
+                      "column": 37,
                       "line": 5,
                     },
                   },
@@ -1617,7 +1617,7 @@ Array [
                 },
                 "file": "",
                 "start": Object {
-                  "column": 33,
+                  "column": 32,
                   "line": 3,
                 },
               },
@@ -1858,12 +1858,12 @@ Array [
     "thenBranch": Block {
       "location": Object {
         "end": Object {
-          "column": 41,
-          "line": 2,
+          "column": 8,
+          "line": 3,
         },
         "file": "",
         "start": Object {
-          "column": 35,
+          "column": 21,
           "line": 2,
         },
       },
@@ -2000,7 +2000,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 22,
+          "column": 21,
           "line": 2,
         },
       },
@@ -2101,7 +2101,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 36,
+            "column": 35,
             "line": 2,
           },
         },
@@ -2268,7 +2268,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 40,
+          "column": 41,
           "line": 2,
         },
       },
@@ -2322,7 +2322,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 22,
+          "column": 21,
           "line": 2,
         },
       },
@@ -2432,13 +2432,13 @@ Array [
     "elseBranch": Block {
       "location": Object {
         "end": Object {
-          "column": 9,
+          "column": 8,
           "line": 3,
         },
         "file": "",
         "start": Object {
-          "column": 8,
-          "line": 3,
+          "column": 51,
+          "line": 2,
         },
       },
       "statements": Array [
@@ -2522,12 +2522,12 @@ Array [
     "thenBranch": Block {
       "location": Object {
         "end": Object {
-          "column": 52,
+          "column": 51,
           "line": 2,
         },
         "file": "",
         "start": Object {
-          "column": 51,
+          "column": 25,
           "line": 2,
         },
       },
@@ -2709,6 +2709,7 @@ Array [
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,
@@ -2827,6 +2828,7 @@ Array [
               "column": -9,
               "line": -9,
             },
+            "file": undefined,
             "start": Object {
               "column": -9,
               "line": -9,
@@ -2895,6 +2897,7 @@ Array [
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,
@@ -3008,7 +3011,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 17,
+          "column": 16,
           "line": 4,
         },
       },
@@ -3023,7 +3026,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 20,
+          "column": 19,
           "line": 2,
         },
       },
@@ -3051,13 +3054,13 @@ Array [
           "thenBranch": Block {
             "location": Object {
               "end": Object {
-                "column": 16,
-                "line": 4,
+                "column": 34,
+                "line": 3,
               },
               "file": "",
               "start": Object {
-                "column": 12,
-                "line": 4,
+                "column": 29,
+                "line": 3,
               },
             },
             "statements": Array [
@@ -3345,7 +3348,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 17,
+          "column": 16,
           "line": 7,
         },
       },
@@ -3629,7 +3632,7 @@ Array [
             },
             "file": "",
             "start": Object {
-              "column": 62,
+              "column": 61,
               "line": 5,
             },
           },
@@ -3741,7 +3744,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 59,
+          "column": 58,
           "line": 2,
         },
       },
@@ -3979,13 +3982,13 @@ Array [
           "thenBranch": Block {
             "location": Object {
               "end": Object {
-                "column": 19,
-                "line": 5,
+                "column": 60,
+                "line": 4,
               },
               "file": "",
               "start": Object {
-                "column": 12,
-                "line": 5,
+                "column": 39,
+                "line": 4,
               },
             },
             "statements": Array [
@@ -4248,6 +4251,7 @@ Array [
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,
@@ -4407,6 +4411,7 @@ Array [
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,
@@ -4474,6 +4479,7 @@ Array [
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,
@@ -4633,6 +4639,7 @@ Array [
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,
@@ -4751,6 +4758,7 @@ Array [
               "column": -9,
               "line": -9,
             },
+            "file": undefined,
             "start": Object {
               "column": -9,
               "line": -9,
@@ -4819,6 +4827,7 @@ Array [
           "column": -9,
           "line": -9,
         },
+        "file": undefined,
         "start": Object {
           "column": -9,
           "line": -9,
@@ -4949,7 +4958,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 22,
+          "column": 21,
           "line": 2,
         },
       },
@@ -5066,7 +5075,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 75,
+          "column": 74,
           "line": 2,
         },
       },
@@ -5140,7 +5149,7 @@ Array [
             },
             "file": "",
             "start": Object {
-              "column": 52,
+              "column": 51,
               "line": 2,
             },
           },
@@ -5197,7 +5206,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 20,
+          "column": 19,
           "line": 2,
         },
       },
@@ -5370,7 +5379,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 21,
+          "column": 20,
           "line": 2,
         },
       },
@@ -5487,7 +5496,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 26,
+          "column": 25,
           "line": 2,
         },
       },
@@ -5538,7 +5547,7 @@ Array [
                 },
                 "file": "",
                 "start": Object {
-                  "column": 41,
+                  "column": 40,
                   "line": 2,
                 },
               },
@@ -5695,7 +5704,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 23,
+            "column": 22,
             "line": 2,
           },
         },
@@ -5762,7 +5771,7 @@ Array [
                 },
                 "file": "",
                 "start": Object {
-                  "column": 22,
+                  "column": 20,
                   "line": 7,
                 },
               },
@@ -5872,7 +5881,7 @@ Array [
                     },
                     "file": "",
                     "start": Object {
-                      "column": 31,
+                      "column": 29,
                       "line": 5,
                     },
                   },
@@ -5929,7 +5938,7 @@ Array [
                 },
                 "file": "",
                 "start": Object {
-                  "column": 26,
+                  "column": 24,
                   "line": 3,
                 },
               },
@@ -6159,7 +6168,7 @@ Array [
         },
         "file": "",
         "start": Object {
-          "column": 21,
+          "column": 20,
           "line": 2,
         },
       },

--- a/test/parser/expression/__snapshots__/Call.test.js.snap
+++ b/test/parser/expression/__snapshots__/Call.test.js.snap
@@ -133,7 +133,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 29,
+            "column": 28,
             "line": 2,
           },
         },
@@ -260,7 +260,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 29,
+            "column": 28,
             "line": 6,
           },
         },
@@ -336,7 +336,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 29,
+            "column": 28,
             "line": 2,
           },
         },
@@ -407,7 +407,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 29,
+            "column": 28,
             "line": 5,
           },
         },

--- a/test/parser/statement/Block.test.js
+++ b/test/parser/statement/Block.test.js
@@ -18,7 +18,7 @@ describe("block statements", () => {
         //the block location should begin immediately following `sub Main()`, and end immediately preceeding the first character of `end sub`
         expect(blockLocation).toEqual({
             file: "",
-            start: { line: 2, column: 23 },
+            start: { line: 2, column: 22 },
             end: { line: 4, column: 12 },
         });
 
@@ -45,21 +45,21 @@ describe("block statements", () => {
         const thenBlock = ifStatement.thenBranch;
         expect(thenBlock.location).toEqual({
             file: "",
-            start: { line: 3, column: 29 },
+            start: { line: 3, column: 28 },
             end: { line: 5, column: 16 },
         });
 
         const elseIfBlock = ifStatement.elseIfs[0].thenBranch;
         expect(elseIfBlock.location).toEqual({
             file: "",
-            start: { line: 5, column: 34 },
+            start: { line: 5, column: 33 },
             end: { line: 7, column: 16 },
         });
 
         const elseBlock = ifStatement.elseBranch;
         expect(elseBlock.location).toEqual({
             file: "",
-            start: { line: 7, column: 21 },
+            start: { line: 7, column: 20 },
             end: { line: 9, column: 16 },
         });
 
@@ -81,7 +81,7 @@ describe("block statements", () => {
         //the block location should begin immediately following `step 1`, and end immediately preceeding the first character of `end for`
         expect(loopBlock.location).toEqual({
             file: "",
-            start: { line: 3, column: 39 },
+            start: { line: 3, column: 38 },
             end: { line: 5, column: 16 },
         });
 

--- a/test/parser/statement/__snapshots__/Block.test.js.snap
+++ b/test/parser/statement/__snapshots__/Block.test.js.snap
@@ -12,7 +12,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 23,
+            "column": 22,
             "line": 2,
           },
         },
@@ -26,7 +26,7 @@ Array [
                 },
                 "file": "",
                 "start": Object {
-                  "column": 39,
+                  "column": 38,
                   "line": 3,
                 },
               },
@@ -307,7 +307,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 23,
+            "column": 22,
             "line": 2,
           },
         },
@@ -439,7 +439,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 23,
+            "column": 22,
             "line": 2,
           },
         },
@@ -470,7 +470,7 @@ Array [
                 },
                 "file": "",
                 "start": Object {
-                  "column": 21,
+                  "column": 20,
                   "line": 7,
                 },
               },
@@ -544,7 +544,7 @@ Array [
                     },
                     "file": "",
                     "start": Object {
-                      "column": 34,
+                      "column": 33,
                       "line": 5,
                     },
                   },
@@ -601,7 +601,7 @@ Array [
                 },
                 "file": "",
                 "start": Object {
-                  "column": 29,
+                  "column": 28,
                   "line": 3,
                 },
               },

--- a/test/parser/statement/__snapshots__/Function.test.js.snap
+++ b/test/parser/statement/__snapshots__/Function.test.js.snap
@@ -19,7 +19,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 39,
+              "column": 38,
               "line": 2,
             },
           },
@@ -129,7 +129,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 40,
+              "column": 39,
               "line": 6,
             },
           },
@@ -239,7 +239,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 38,
+              "column": 37,
               "line": 10,
             },
           },
@@ -349,7 +349,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 39,
+              "column": 38,
               "line": 14,
             },
           },
@@ -1562,7 +1562,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 32,
+              "column": 31,
               "line": 2,
             },
           },
@@ -1674,7 +1674,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 34,
+              "column": 33,
               "line": 6,
             },
           },
@@ -1758,7 +1758,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 33,
+              "column": 32,
               "line": 2,
             },
           },
@@ -1829,7 +1829,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 34,
+              "column": 33,
               "line": 5,
             },
           },
@@ -1900,7 +1900,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 32,
+              "column": 31,
               "line": 8,
             },
           },
@@ -1971,7 +1971,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 33,
+              "column": 32,
               "line": 11,
             },
           },
@@ -3072,7 +3072,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 27,
+              "column": 26,
               "line": 2,
             },
           },
@@ -3184,7 +3184,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 34,
+              "column": 33,
               "line": 6,
             },
           },

--- a/test/parser/statement/__snapshots__/Goto.test.js.snap
+++ b/test/parser/statement/__snapshots__/Goto.test.js.snap
@@ -12,7 +12,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 23,
+            "column": 22,
             "line": 2,
           },
         },

--- a/test/parser/statement/__snapshots__/LibraryStatement.test.js.snap
+++ b/test/parser/statement/__snapshots__/LibraryStatement.test.js.snap
@@ -16,7 +16,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 23,
+              "column": 22,
               "line": 2,
             },
           },
@@ -138,7 +138,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 23,
+              "column": 22,
               "line": 2,
             },
           },
@@ -259,7 +259,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 23,
+              "column": 22,
               "line": 2,
             },
           },
@@ -438,7 +438,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 23,
+              "column": 22,
               "line": 2,
             },
           },
@@ -597,7 +597,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 23,
+              "column": 22,
               "line": 3,
             },
           },
@@ -758,7 +758,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 23,
+              "column": 22,
               "line": 3,
             },
           },
@@ -878,7 +878,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 23,
+              "column": 22,
               "line": 3,
             },
           },
@@ -1039,7 +1039,7 @@ Object {
             },
             "file": "",
             "start": Object {
-              "column": 23,
+              "column": 22,
               "line": 3,
             },
           },

--- a/test/parser/statement/__snapshots__/Misc.test.js.snap
+++ b/test/parser/statement/__snapshots__/Misc.test.js.snap
@@ -12,7 +12,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 27,
+            "column": 26,
             "line": 2,
           },
         },
@@ -188,7 +188,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 27,
+            "column": 26,
             "line": 2,
           },
         },
@@ -286,7 +286,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 27,
+            "column": 26,
             "line": 2,
           },
         },
@@ -418,7 +418,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 23,
+            "column": 22,
             "line": 2,
           },
         },
@@ -3430,7 +3430,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 23,
+            "column": 22,
             "line": 2,
           },
         },

--- a/test/parser/statement/__snapshots__/Stop.test.js.snap
+++ b/test/parser/statement/__snapshots__/Stop.test.js.snap
@@ -12,7 +12,7 @@ Array [
           },
           "file": "",
           "start": Object {
-            "column": 23,
+            "column": 22,
             "line": 2,
           },
         },


### PR DESCRIPTION
`:` appears to be a valid statement separator for nearly all cases -- including the branches of a single-line `if` statement!  This also solves an off-by-one error in some location tracking logic, likely caused by the fact that editors perfer one-indexing and our AST (in compliance with ESTree) uses zero-indexing.

As a side benefit, this includes a `test:debug` npm script.  I've been using it for a while and keep forgetting to publish it.  It starts `jest` and immediately pauses for a debugger to attach, allowing for interactive debugging without having to remember a bunch of `jest` arguments.  Pretty handy!

fixes #481 
