### PR TITLE
fix(rsg): Cast numbers to proper field types

### DIFF
--- a/src/brsTypes/Double.ts
+++ b/src/brsTypes/Double.ts
@@ -20,8 +20,8 @@ export class Double implements Numeric, Comparable, Boxable {
      * @param value the value to store in the BrightScript double, rounded to 64-bit (double)
      *              precision.
      */
-    constructor(value: number) {
-        this.value = value;
+    constructor(value: number | Long) {
+        this.value = Number(value);
     }
 
     /**

--- a/src/brsTypes/Double.ts
+++ b/src/brsTypes/Double.ts
@@ -6,6 +6,7 @@ import { Int64 } from "./Int64";
 import { Float } from "./Float";
 import { roDouble } from "./components/RoDouble";
 import { Boxable } from "./Boxing";
+import Long from "long";
 
 export class Double implements Numeric, Comparable, Boxable {
     readonly kind = ValueKind.Double;
@@ -21,7 +22,7 @@ export class Double implements Numeric, Comparable, Boxable {
      *              precision.
      */
     constructor(value: number | Long) {
-        this.value = Number(value);
+        this.value = value instanceof Long ? value.toNumber() : value;
     }
 
     /**

--- a/src/brsTypes/Float.ts
+++ b/src/brsTypes/Float.ts
@@ -26,8 +26,8 @@ export class Float implements Numeric, Comparable, Boxable {
      * @param value the value to store in the BrightScript float, rounded to 32-bit floating point
      *              precision and maintaining only seven significant digits of accuracy.
      */
-    constructor(value: number) {
-        this.value = parseFloat(Math.fround(value).toPrecision(IEEE_FLOAT_SIGFIGS));
+    constructor(value: number | Long) {
+        this.value = parseFloat(Math.fround(Number(value)).toPrecision(IEEE_FLOAT_SIGFIGS));
     }
 
     /**

--- a/src/brsTypes/Float.ts
+++ b/src/brsTypes/Float.ts
@@ -6,6 +6,7 @@ import { Int32 } from "./Int32";
 import { Double } from "./Double";
 import { Int64 } from "./Int64";
 import { roFloat } from "./components/RoFloat";
+import Long from "long";
 
 /**
  * Number of significant digits represented in an IEEE 32-bit floating point number.
@@ -27,7 +28,8 @@ export class Float implements Numeric, Comparable, Boxable {
      *              precision and maintaining only seven significant digits of accuracy.
      */
     constructor(value: number | Long) {
-        this.value = parseFloat(Math.fround(Number(value)).toPrecision(IEEE_FLOAT_SIGFIGS));
+        if (value instanceof Long) value = value.toNumber();
+        this.value = parseFloat(Math.fround(value).toPrecision(IEEE_FLOAT_SIGFIGS));
     }
 
     /**

--- a/src/brsTypes/Int32.ts
+++ b/src/brsTypes/Int32.ts
@@ -20,8 +20,8 @@ export class Int32 implements Numeric, Comparable, Boxable {
      * @param value the value to store in the BrightScript number, truncated to a 32-bit
      *              integer.
      */
-    constructor(initialValue: number) {
-        this.value = Math.trunc(initialValue);
+    constructor(initialValue: number | Long) {
+        this.value = Math.trunc(Number(initialValue));
     }
 
     /**

--- a/src/brsTypes/Int32.ts
+++ b/src/brsTypes/Int32.ts
@@ -6,6 +6,7 @@ import { Float } from "./Float";
 import { Double } from "./Double";
 import { Int64 } from "./Int64";
 import { roInt } from "./components/RoInt";
+import Long from "long";
 
 export class Int32 implements Numeric, Comparable, Boxable {
     readonly kind = ValueKind.Int32;
@@ -20,8 +21,9 @@ export class Int32 implements Numeric, Comparable, Boxable {
      * @param value the value to store in the BrightScript number, truncated to a 32-bit
      *              integer.
      */
-    constructor(initialValue: number | Long) {
-        this.value = Math.trunc(Number(initialValue));
+    constructor(value: number | Long) {
+        if (value instanceof Long) value = value.toNumber();
+        this.value = Math.trunc(value);
     }
 
     /**

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -154,14 +154,14 @@ export class Field {
         // Once a field is set, it is no longer hidden.
         this.hidden = false;
 
-        if (isBrsNumber(value)) {
-            if (this.type === FieldKind.Float && value.kind !== ValueKind.Float) {
+        if (isBrsNumber(value) && value.kind !== getValueKindFromFieldType(this.type)) {
+            if (this.type === FieldKind.Float) {
                 value = new Float(value.getValue());
-            } else if (this.type === FieldKind.Int32 && value.kind !== ValueKind.Int32) {
+            } else if (this.type === FieldKind.Int32) {
                 value = new Int32(value.getValue());
-            } else if (this.type === FieldKind.Int64 && value.kind !== ValueKind.Int64) {
+            } else if (this.type === FieldKind.Int64) {
                 value = new Int64(value.getValue());
-            } else if (this.type === FieldKind.Double && value.kind !== ValueKind.Double) {
+            } else if (this.type === FieldKind.Double) {
                 value = new Double(value.getValue());
             }
         }

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -10,10 +10,13 @@ import {
 } from "../BrsType";
 import { RoSGNodeEvent } from "./RoSGNodeEvent";
 import { BrsComponent, BrsIterable } from "./BrsComponent";
-import { BrsType } from "..";
+import { BrsType, isBrsNumber } from "..";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { Int32 } from "../Int32";
+import { Int64 } from "../Int64";
+import { Float } from "../Float";
+import { Double } from "../Double";
 import { RoAssociativeArray } from "./RoAssociativeArray";
 import { RoArray } from "./RoArray";
 import { AAMember } from "./RoAssociativeArray";
@@ -151,6 +154,18 @@ export class Field {
         // Once a field is set, it is no longer hidden.
         this.hidden = false;
 
+        if (isBrsNumber(value)) {
+            if (this.type === FieldKind.Float && value.kind !== ValueKind.Float) {
+                value = new Float(value.getValue());
+            } else if (this.type === FieldKind.Int32 && value.kind !== ValueKind.Int32) {
+                value = new Int32(value.getValue());
+            } else if (this.type === FieldKind.Int64 && value.kind !== ValueKind.Int64) {
+                value = new Int64(value.getValue());
+            } else if (this.type === FieldKind.Double && value.kind !== ValueKind.Double) {
+                value = new Double(value.getValue());
+            }
+        }
+
         let oldValue = this.value;
         this.value = value;
         if (this.alwaysNotify || oldValue !== value) {
@@ -162,6 +177,9 @@ export class Field {
         // Objects are allowed to be set to invalid.
         let fieldIsObject = getValueKindFromFieldType(this.type) === ValueKind.Object;
         if (fieldIsObject && (value === BrsInvalid.Instance || value instanceof roInvalid)) {
+            return true;
+        } else if (isBrsNumber(this.value) && isBrsNumber(value)) {
+            // can convert between number types
             return true;
         }
 

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -6,6 +6,9 @@ const {
     BrsBoolean,
     BrsString,
     Int32,
+    Int64,
+    Float,
+    Double,
     BrsInvalid,
     ValueKind,
     Uninitialized,
@@ -76,6 +79,51 @@ describe("RoSGNode", () => {
             node.set(new BrsString("foo"), new Int32(66));
 
             expect(node.get(new BrsString("foo"))).toEqual(new Int32(66));
+        });
+
+        it("converts types on number fields", () => {
+            let node = new RoSGNode([
+                {
+                    name: new BrsString("intFoo"),
+                    value: new Int32(99),
+                },
+                {
+                    name: new BrsString("longBar"),
+                    value: new Int64(4321),
+                },
+                {
+                    name: new BrsString("floatBat"),
+                    value: new Float(33.7),
+                },
+                {
+                    name: new BrsString("doubleTrouble"),
+                    value: new Double(33.7),
+                },
+            ]);
+
+            node.set(new BrsString("intFoo"), new Float(34.3));
+            expect(node.get(new BrsString("intFoo"))).toEqual(new Int32(34));
+
+            node.set(new BrsString("intFoo"), new Double(38.7));
+            expect(node.get(new BrsString("intFoo"))).toEqual(new Int32(38));
+
+            node.set(new BrsString("longBar"), new Float(34.3));
+            expect(node.get(new BrsString("longBar"))).toEqual(new Int64(34));
+
+            node.set(new BrsString("longBar"), new Double(38.7));
+            expect(node.get(new BrsString("longBar"))).toEqual(new Int64(38));
+
+            node.set(new BrsString("floatBat"), new Int32(38));
+            expect(node.get(new BrsString("floatBat"))).toEqual(new Float(38));
+
+            node.set(new BrsString("floatBat"), new Double(31.7));
+            expect(node.get(new BrsString("floatBat"))).toEqual(new Float(31.7));
+
+            node.set(new BrsString("doubleTrouble"), new Int32(49));
+            expect(node.get(new BrsString("doubleTrouble"))).toEqual(new Double(49));
+
+            node.set(new BrsString("doubleTrouble"), new Float(11.2));
+            expect(node.get(new BrsString("doubleTrouble"))).toEqual(new Double(11.2));
         });
     });
 

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -234,6 +234,8 @@ describe("end to end brightscript functions", () => {
             "newValue",
             "updatedId",
             "invalid",
+            "33",
+            "37",
         ]);
     });
 

--- a/test/e2e/resources/components/roSGNode.brs
+++ b/test/e2e/resources/components/roSGNode.brs
@@ -214,6 +214,13 @@ sub main()
     }, false)
     print node.id
     print node.newField
+
+    ' setting numbers of different types on fields
+    node = createObject("roSGNode", "ContentNode")
+    node.FrameRate = 33.3
+    ?node.FrameRate
+    node.ClipStart = 37
+    ?node.ClipStart
 end sub
 
 sub onCB1Called()


### PR DESCRIPTION
In issue #508 setting numbers on fields that didn't match the field type were ignored because the check to compare types didn't take numbers into account. 

This updates that check to allow assigning numbers to any number-based field by converting it to the proper type. 

Note, I've updated all number constructors to accept long to make the conversion simpler (so _getValue()_ from a number can be applied to any other number). 

fixes #508 