### PR TITLE
feat(perf): further memoize lexing and parsing

### DIFF
--- a/src/LexerParser.ts
+++ b/src/LexerParser.ts
@@ -19,47 +19,66 @@ export function getLexerParserFn(
     options: Partial<ExecutionOptions>
 ) {
     const executionOptions = Object.assign(defaultExecutionOptions, options);
+    /**
+     * Map file URIs to promises. The promises resolve to an array of that file's statements.
+     * This allows us to only parse each file once.
+     */
+    let memoizedStatements = new Map<string, Promise<Stmt.Statement[]>>();
     return async function parse(filenames: string[]): Promise<Stmt.Statement[]> {
+        async function lexAndParseFile(filename: string) {
+            let contents;
+            try {
+                contents = await readFile(filename, "utf-8");
+            } catch (err) {
+                return Promise.reject({
+                    message: `brs: can't open file '${filename}': [Errno ${err.errno}]`,
+                });
+            }
+
+            let lexer = new Lexer();
+            let preprocessor = new PP.Preprocessor();
+            let parser = new Parser();
+            [lexer, preprocessor, parser].forEach((emitter) =>
+                emitter.onError(BrsError.getLoggerUsing(executionOptions.stderr))
+            );
+
+            let scanResults = lexer.scan(contents, filename);
+            if (scanResults.errors.length > 0) {
+                return Promise.reject({
+                    message: "Error occurred during lexing",
+                });
+            }
+
+            let preprocessResults = preprocessor.preprocess(scanResults.tokens, manifest);
+            if (preprocessResults.errors.length > 0) {
+                return Promise.reject({
+                    message: "Error occurred during pre-processing",
+                });
+            }
+
+            let parseResults = parser.parse(preprocessResults.processedTokens);
+            if (parseResults.errors.length > 0) {
+                return Promise.reject({
+                    message: "Error occurred parsing",
+                });
+            }
+
+            return Promise.resolve(parseResults.statements);
+        }
+
         let parsedFiles = await pSettle(
-            filenames.map(async (filename) => {
-                let contents;
-                try {
-                    contents = await readFile(filename, "utf-8");
-                } catch (err) {
-                    return Promise.reject({
-                        message: `brs: can't open file '${filename}': [Errno ${err.errno}]`,
-                    });
+            filenames.map(async filename => {
+                let maybeStatements = memoizedStatements.get(filename);
+                if (maybeStatements) {
+                    return maybeStatements;
+                } else {
+                    let statementsPromise = lexAndParseFile(filename);
+                    if (!memoizedStatements.has(filename)) {
+                        memoizedStatements.set(filename, statementsPromise);
+                    }
+    
+                    return statementsPromise;
                 }
-
-                let lexer = new Lexer();
-                let preprocessor = new PP.Preprocessor();
-                let parser = new Parser();
-                [lexer, preprocessor, parser].forEach((emitter) =>
-                    emitter.onError(BrsError.getLoggerUsing(executionOptions.stderr))
-                );
-
-                let scanResults = lexer.scan(contents, filename);
-                if (scanResults.errors.length > 0) {
-                    return Promise.reject({
-                        message: "Error occurred during lexing",
-                    });
-                }
-
-                let preprocessResults = preprocessor.preprocess(scanResults.tokens, manifest);
-                if (preprocessResults.errors.length > 0) {
-                    return Promise.reject({
-                        message: "Error occurred during pre-processing",
-                    });
-                }
-
-                let parseResults = parser.parse(preprocessResults.processedTokens);
-                if (parseResults.errors.length > 0) {
-                    return Promise.reject({
-                        message: "Error occurred parsing",
-                    });
-                }
-
-                return Promise.resolve(parseResults.statements);
             })
         );
 

--- a/src/LexerParser.ts
+++ b/src/LexerParser.ts
@@ -67,7 +67,7 @@ export function getLexerParserFn(
         }
 
         let parsedFiles = await pSettle(
-            filenames.map(async filename => {
+            filenames.map(async (filename) => {
                 let maybeStatements = memoizedStatements.get(filename);
                 if (maybeStatements) {
                     return maybeStatements;
@@ -76,7 +76,7 @@ export function getLexerParserFn(
                     if (!memoizedStatements.has(filename)) {
                         memoizedStatements.set(filename, statementsPromise);
                     }
-    
+
                     return statementsPromise;
                 }
             })


### PR DESCRIPTION
# Change Summary

This pulls the statement memoization into the lexer-parser function instead of the component scope resolver class. After we resolve component scopes, [we then lex and parse](https://github.com/sjbarag/brs/blob/master/src/index.ts#L66) what ends up being a lot of the same files, but without the memoization benefits. Also, this sets us up for the incoming code coverage work, part of which will be lexing and parsing all the same files.