### PR TITLE
fix(parse): Restore nested block parsing

### DIFF
--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -131,6 +131,7 @@ describe("end to end syntax", () => {
             "4", // count up
             "5",
             "4", // count down with exit
+            "15", // compute 3 * 5 with nested loops
         ]);
     });
 

--- a/test/e2e/resources/while-loops.brs
+++ b/test/e2e/resources/while-loops.brs
@@ -13,3 +13,17 @@ while foo > 0
     ' but stop at three
     if foo = 3 then exit while
 end while
+
+' nested while loops to compute 4 * 2
+total = 0
+i = 0
+while i < 5
+    j = 0
+
+    while j < 3
+        total++
+        j++
+    end while
+    i++
+end while
+print total

--- a/test/parser/controlFlow/While.test.js
+++ b/test/parser/controlFlow/While.test.js
@@ -48,6 +48,27 @@ describe("parser while statements", () => {
         expect(statements).toMatchSnapshot();
     });
 
+    test("nested", () => {
+        const { tokens } = brs.lexer.Lexer.scan(
+            `
+            while i < 1000
+                while j < 1000
+                    while k < 1000 : k++ : end while
+                    j++
+                end while
+                i++
+            end while
+            `
+        );
+
+        const { statements, errors } = parser.parse(tokens);
+
+        expect(errors).toEqual([]);
+        expect(statements).toBeDefined();
+        expect(statements).not.toBeNull();
+        expect(statements).toMatchSnapshot();
+    });
+
     test("location tracking", () => {
         /**
          *    0   0   0   1   1

--- a/test/parser/controlFlow/__snapshots__/If.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/If.test.js.snap
@@ -1936,8 +1936,8 @@ Array [
     "thenBranch": Block {
       "location": Object {
         "end": Object {
-          "column": 8,
-          "line": 3,
+          "column": 41,
+          "line": 2,
         },
         "file": "",
         "start": Object {
@@ -2537,8 +2537,8 @@ Array [
     "elseBranch": Block {
       "location": Object {
         "end": Object {
-          "column": 8,
-          "line": 3,
+          "column": 72,
+          "line": 2,
         },
         "file": "",
         "start": Object {
@@ -2632,7 +2632,7 @@ Array [
     "thenBranch": Block {
       "location": Object {
         "end": Object {
-          "column": 51,
+          "column": 46,
           "line": 2,
         },
         "file": "",
@@ -3091,7 +3091,24 @@ Array [
       "type": "Block",
     },
     "tokens": Object {
-      "elseIfs": Array [],
+      "elseIfs": Array [
+        Object {
+          "isReserved": false,
+          "kind": "ElseIf",
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": -9,
+              "line": -9,
+            },
+            "start": Object {
+              "column": -9,
+              "line": -9,
+            },
+          },
+          "text": "else if",
+        },
+      ],
       "endIf": undefined,
       "if": Object {
         "isReserved": true,
@@ -5110,7 +5127,24 @@ Array [
       "type": "Block",
     },
     "tokens": Object {
-      "elseIfs": Array [],
+      "elseIfs": Array [
+        Object {
+          "isReserved": false,
+          "kind": "ElseIf",
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": -9,
+              "line": -9,
+            },
+            "start": Object {
+              "column": -9,
+              "line": -9,
+            },
+          },
+          "text": "else if",
+        },
+      ],
       "endIf": undefined,
       "if": Object {
         "isReserved": true,

--- a/test/parser/controlFlow/__snapshots__/While.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/While.test.js.snap
@@ -1,5 +1,469 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parser while statements nested 1`] = `
+Array [
+  While {
+    "body": Block {
+      "location": Object {
+        "end": Object {
+          "column": 12,
+          "line": 8,
+        },
+        "file": "",
+        "start": Object {
+          "column": 26,
+          "line": 2,
+        },
+      },
+      "statements": Array [
+        While {
+          "body": Block {
+            "location": Object {
+              "end": Object {
+                "column": 16,
+                "line": 6,
+              },
+              "file": "",
+              "start": Object {
+                "column": 30,
+                "line": 3,
+              },
+            },
+            "statements": Array [
+              While {
+                "body": Block {
+                  "location": Object {
+                    "end": Object {
+                      "column": 43,
+                      "line": 4,
+                    },
+                    "file": "",
+                    "start": Object {
+                      "column": 35,
+                      "line": 4,
+                    },
+                  },
+                  "statements": Array [
+                    Increment {
+                      "token": Object {
+                        "isReserved": false,
+                        "kind": "PlusPlus",
+                        "literal": undefined,
+                        "location": Object {
+                          "end": Object {
+                            "column": 40,
+                            "line": 4,
+                          },
+                          "file": "",
+                          "start": Object {
+                            "column": 38,
+                            "line": 4,
+                          },
+                        },
+                        "text": "++",
+                      },
+                      "type": "Increment",
+                      "value": Variable {
+                        "name": Object {
+                          "isReserved": false,
+                          "kind": "Identifier",
+                          "literal": undefined,
+                          "location": Object {
+                            "end": Object {
+                              "column": 38,
+                              "line": 4,
+                            },
+                            "file": "",
+                            "start": Object {
+                              "column": 37,
+                              "line": 4,
+                            },
+                          },
+                          "text": "k",
+                        },
+                        "type": "Variable",
+                      },
+                    },
+                  ],
+                  "type": "Block",
+                },
+                "condition": Binary {
+                  "left": Variable {
+                    "name": Object {
+                      "isReserved": false,
+                      "kind": "Identifier",
+                      "literal": undefined,
+                      "location": Object {
+                        "end": Object {
+                          "column": 27,
+                          "line": 4,
+                        },
+                        "file": "",
+                        "start": Object {
+                          "column": 26,
+                          "line": 4,
+                        },
+                      },
+                      "text": "k",
+                    },
+                    "type": "Variable",
+                  },
+                  "right": Literal {
+                    "_location": Object {
+                      "end": Object {
+                        "column": 34,
+                        "line": 4,
+                      },
+                      "file": "",
+                      "start": Object {
+                        "column": 30,
+                        "line": 4,
+                      },
+                    },
+                    "type": "Literal",
+                    "value": Int32 {
+                      "kind": 4,
+                      "value": 1000,
+                    },
+                  },
+                  "token": Object {
+                    "isReserved": false,
+                    "kind": "Less",
+                    "literal": undefined,
+                    "location": Object {
+                      "end": Object {
+                        "column": 29,
+                        "line": 4,
+                      },
+                      "file": "",
+                      "start": Object {
+                        "column": 28,
+                        "line": 4,
+                      },
+                    },
+                    "text": "<",
+                  },
+                  "type": "Binary",
+                },
+                "tokens": Object {
+                  "endWhile": Object {
+                    "isReserved": false,
+                    "kind": "EndWhile",
+                    "literal": undefined,
+                    "location": Object {
+                      "end": Object {
+                        "column": 52,
+                        "line": 4,
+                      },
+                      "file": "",
+                      "start": Object {
+                        "column": 43,
+                        "line": 4,
+                      },
+                    },
+                    "text": "end while",
+                  },
+                  "while": Object {
+                    "isReserved": true,
+                    "kind": "While",
+                    "literal": undefined,
+                    "location": Object {
+                      "end": Object {
+                        "column": 25,
+                        "line": 4,
+                      },
+                      "file": "",
+                      "start": Object {
+                        "column": 20,
+                        "line": 4,
+                      },
+                    },
+                    "text": "while",
+                  },
+                },
+                "type": "While",
+              },
+              Increment {
+                "token": Object {
+                  "isReserved": false,
+                  "kind": "PlusPlus",
+                  "literal": undefined,
+                  "location": Object {
+                    "end": Object {
+                      "column": 23,
+                      "line": 5,
+                    },
+                    "file": "",
+                    "start": Object {
+                      "column": 21,
+                      "line": 5,
+                    },
+                  },
+                  "text": "++",
+                },
+                "type": "Increment",
+                "value": Variable {
+                  "name": Object {
+                    "isReserved": false,
+                    "kind": "Identifier",
+                    "literal": undefined,
+                    "location": Object {
+                      "end": Object {
+                        "column": 21,
+                        "line": 5,
+                      },
+                      "file": "",
+                      "start": Object {
+                        "column": 20,
+                        "line": 5,
+                      },
+                    },
+                    "text": "j",
+                  },
+                  "type": "Variable",
+                },
+              },
+            ],
+            "type": "Block",
+          },
+          "condition": Binary {
+            "left": Variable {
+              "name": Object {
+                "isReserved": false,
+                "kind": "Identifier",
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": 23,
+                    "line": 3,
+                  },
+                  "file": "",
+                  "start": Object {
+                    "column": 22,
+                    "line": 3,
+                  },
+                },
+                "text": "j",
+              },
+              "type": "Variable",
+            },
+            "right": Literal {
+              "_location": Object {
+                "end": Object {
+                  "column": 30,
+                  "line": 3,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 26,
+                  "line": 3,
+                },
+              },
+              "type": "Literal",
+              "value": Int32 {
+                "kind": 4,
+                "value": 1000,
+              },
+            },
+            "token": Object {
+              "isReserved": false,
+              "kind": "Less",
+              "literal": undefined,
+              "location": Object {
+                "end": Object {
+                  "column": 25,
+                  "line": 3,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 24,
+                  "line": 3,
+                },
+              },
+              "text": "<",
+            },
+            "type": "Binary",
+          },
+          "tokens": Object {
+            "endWhile": Object {
+              "isReserved": false,
+              "kind": "EndWhile",
+              "literal": undefined,
+              "location": Object {
+                "end": Object {
+                  "column": 25,
+                  "line": 6,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 16,
+                  "line": 6,
+                },
+              },
+              "text": "end while",
+            },
+            "while": Object {
+              "isReserved": true,
+              "kind": "While",
+              "literal": undefined,
+              "location": Object {
+                "end": Object {
+                  "column": 21,
+                  "line": 3,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 16,
+                  "line": 3,
+                },
+              },
+              "text": "while",
+            },
+          },
+          "type": "While",
+        },
+        Increment {
+          "token": Object {
+            "isReserved": false,
+            "kind": "PlusPlus",
+            "literal": undefined,
+            "location": Object {
+              "end": Object {
+                "column": 19,
+                "line": 7,
+              },
+              "file": "",
+              "start": Object {
+                "column": 17,
+                "line": 7,
+              },
+            },
+            "text": "++",
+          },
+          "type": "Increment",
+          "value": Variable {
+            "name": Object {
+              "isReserved": false,
+              "kind": "Identifier",
+              "literal": undefined,
+              "location": Object {
+                "end": Object {
+                  "column": 17,
+                  "line": 7,
+                },
+                "file": "",
+                "start": Object {
+                  "column": 16,
+                  "line": 7,
+                },
+              },
+              "text": "i",
+            },
+            "type": "Variable",
+          },
+        },
+      ],
+      "type": "Block",
+    },
+    "condition": Binary {
+      "left": Variable {
+        "name": Object {
+          "isReserved": false,
+          "kind": "Identifier",
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": 19,
+              "line": 2,
+            },
+            "file": "",
+            "start": Object {
+              "column": 18,
+              "line": 2,
+            },
+          },
+          "text": "i",
+        },
+        "type": "Variable",
+      },
+      "right": Literal {
+        "_location": Object {
+          "end": Object {
+            "column": 26,
+            "line": 2,
+          },
+          "file": "",
+          "start": Object {
+            "column": 22,
+            "line": 2,
+          },
+        },
+        "type": "Literal",
+        "value": Int32 {
+          "kind": 4,
+          "value": 1000,
+        },
+      },
+      "token": Object {
+        "isReserved": false,
+        "kind": "Less",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 21,
+            "line": 2,
+          },
+          "file": "",
+          "start": Object {
+            "column": 20,
+            "line": 2,
+          },
+        },
+        "text": "<",
+      },
+      "type": "Binary",
+    },
+    "tokens": Object {
+      "endWhile": Object {
+        "isReserved": false,
+        "kind": "EndWhile",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 21,
+            "line": 8,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 8,
+          },
+        },
+        "text": "end while",
+      },
+      "while": Object {
+        "isReserved": true,
+        "kind": "While",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": 17,
+            "line": 2,
+          },
+          "file": "",
+          "start": Object {
+            "column": 12,
+            "line": 2,
+          },
+        },
+        "text": "while",
+      },
+    },
+    "type": "While",
+  },
+]
+`;
+
 exports[`parser while statements while with exit 1`] = `
 Array [
   While {


### PR DESCRIPTION
I'd accidentally broken nested-block parsing in #510!  This fixes that and ensures that `block()` always consumes the block-closing token.