### PR TITLE
fix(interp): Allow return statements in observeField callbacks

### DIFF
--- a/src/Error.ts
+++ b/src/Error.ts
@@ -1,5 +1,4 @@
-import { BrsType, ValueKind } from "./brsTypes";
-import { Location } from "./lexer";
+import type { Location } from "./lexer";
 
 export class BrsError extends Error {
     constructor(message: string, readonly location: Location) {
@@ -43,50 +42,6 @@ export class BrsError extends Error {
     }
 }
 
-/** Wraps up the metadata associated with a type mismatch error. */
-export interface TypeMismatchMetadata {
-    /**
-     * The base message to use for this error. Should be as helpful as possible, e.g.
-     * "Attempting to subtract non-numeric values".
-     */
-    message: string;
-    /** The value on the left-hand side of a binary operator, or the *only* value for a unary operator. */
-    left: TypeAndLocation;
-    /** The value on the right-hand side of a binary operator. */
-    right?: TypeAndLocation;
-}
-
-export type TypeAndLocation = {
-    /** The type of a value involved in a type mismatch. */
-    type: BrsType | ValueKind;
-    /** The location at which the offending value was resolved. */
-    location: Location;
-};
-
-/**
- * Creates a "type mismatch"-like error message, but with the appropriate types specified.
- * @return a type mismatch error that will be tracked by this module.
- */
-export class TypeMismatch extends BrsError {
-    constructor(mismatchMetadata: TypeMismatchMetadata) {
-        let messageLines = [
-            mismatchMetadata.message,
-            `    left: ${ValueKind.toString(getKind(mismatchMetadata.left.type))}`,
-        ];
-        let location = mismatchMetadata.left.location;
-
-        if (mismatchMetadata.right) {
-            messageLines.push(
-                `    right: ${ValueKind.toString(getKind(mismatchMetadata.right.type))}`
-            );
-
-            location.end = mismatchMetadata.right.location.end;
-        }
-
-        super(messageLines.join("\n"), location);
-    }
-}
-
 /**
  * Logs a detected BRS error to console.
  * @param err the error to log to console
@@ -102,17 +57,4 @@ export function logConsoleError(err: BrsError) {
  */
 export function getLoggerUsing(errorStream: NodeJS.WriteStream): (err: BrsError) => boolean {
     return (err) => errorStream.write(err.format());
-}
-
-/**
- * Returns the `.kind` property of a `BrsType`, otherwise returns the provided `ValueKind`.
- * @param maybeType the `BrsType` to extract a `.kind` field from, or the `ValueKind` to return directly
- * @returns the `ValueKind` for `maybeType`
- */
-function getKind(maybeType: BrsType | ValueKind): ValueKind {
-    if (typeof maybeType === "number") {
-        return maybeType;
-    } else {
-        return maybeType.kind;
-    }
 }

--- a/src/interpreter/TypeMismatch.ts
+++ b/src/interpreter/TypeMismatch.ts
@@ -1,0 +1,60 @@
+import { BrsType, ValueKind } from "../brsTypes";
+import { BrsError } from "../Error";
+import type { Location } from "../lexer";
+
+/** Wraps up the metadata associated with a type mismatch error. */
+export interface TypeMismatchMetadata {
+    /**
+     * The base message to use for this error. Should be as helpful as possible, e.g.
+     * "Attempting to subtract non-numeric values".
+     */
+    message: string;
+    /** The value on the left-hand side of a binary operator, or the *only* value for a unary operator. */
+    left: TypeAndLocation;
+    /** The value on the right-hand side of a binary operator. */
+    right?: TypeAndLocation;
+}
+
+export type TypeAndLocation = {
+    /** The type of a value involved in a type mismatch. */
+    type: BrsType | ValueKind;
+    /** The location at which the offending value was resolved. */
+    location: Location;
+};
+
+/**
+ * Creates a "type mismatch"-like error message, but with the appropriate types specified.
+ * @return a type mismatch error that will be tracked by this module.
+ */
+export class TypeMismatch extends BrsError {
+    constructor(mismatchMetadata: TypeMismatchMetadata) {
+        let messageLines = [
+            mismatchMetadata.message,
+            `    left: ${ValueKind.toString(getKind(mismatchMetadata.left.type))}`,
+        ];
+        let location = mismatchMetadata.left.location;
+
+        if (mismatchMetadata.right) {
+            messageLines.push(
+                `    right: ${ValueKind.toString(getKind(mismatchMetadata.right.type))}`
+            );
+
+            location.end = mismatchMetadata.right.location.end;
+        }
+
+        super(messageLines.join("\n"), location);
+    }
+}
+
+/**
+ * Returns the `.kind` property of a `BrsType`, otherwise returns the provided `ValueKind`.
+ * @param maybeType the `BrsType` to extract a `.kind` field from, or the `ValueKind` to return directly
+ * @returns the `ValueKind` for `maybeType`
+ */
+function getKind(maybeType: BrsType | ValueKind): ValueKind {
+    if (typeof maybeType === "number") {
+        return maybeType;
+    } else {
+        return maybeType.kind;
+    }
+}

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -24,12 +24,13 @@ import {
 import { Lexeme } from "../lexer";
 import { isToken } from "../lexer/Token";
 import { Expr, Stmt, ComponentScopeResolver } from "../parser";
-import { BrsError, TypeMismatch, getLoggerUsing } from "../Error";
+import { BrsError, getLoggerUsing } from "../Error";
 
 import * as StdLib from "../stdlib";
 import { _brs_ } from "../extensions";
 
 import { Scope, Environment, NotFound } from "./Environment";
+import { TypeMismatch } from "./TypeMismatch";
 import { OutputProxy } from "./OutputProxy";
 import { toCallable } from "./BrsFunction";
 import { Runtime } from "../parser/Statement";

--- a/src/parser/BlockEndReason.ts
+++ b/src/parser/BlockEndReason.ts
@@ -1,6 +1,6 @@
-import { BrsType } from "../brsTypes";
+import type { BrsType } from "../brsTypes";
+import type { Location } from "../lexer";
 import { BrsError } from "../Error";
-import { Location } from "../lexer";
 
 /** Marker class for errors thrown to exit block execution early. */
 export class BlockEnd extends BrsError {}

--- a/test/e2e/resources/components/roSGNode.brs
+++ b/test/e2e/resources/components/roSGNode.brs
@@ -225,6 +225,7 @@ end sub
 
 sub onCB1Called()
     print "callback 1 called"
+    return
 end sub
 
 sub onCB2Called()


### PR DESCRIPTION
This exposed a circular dependency between `brsTypes/` `interpreter/index.ts`, and `Error.ts`, resolved by extracting `TypeMismatch.ts` to the `interpreter/` tree since it's currently only used at BrightScript runtime.

fixes #508
