### PR TITLE
fix(rsg): Return invalid when findNode passed empty string

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -1276,6 +1276,9 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             returns: ValueKind.Dynamic,
         },
         impl: (interpreter: Interpreter, name: BrsString) => {
+            // Roku's implementation returns invalid on empty string
+            if (name.value.length === 0) return BrsInvalid.Instance;
+
             // climb parent hierarchy to find node to start search at
             let root: RoSGNode = this;
             while (root.parent && root.parent instanceof RoSGNode) {

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -2073,6 +2073,7 @@ describe("RoSGNode", () => {
             child2 = new RoSGNode([{ name: idString, value: new BrsString("child2") }]);
             child3 = new RoSGNode([{ name: idString, value: new BrsString("child3") }]);
             child4 = new RoSGNode([{ name: idString, value: new BrsString("child4") }]);
+            child5 = new RoSGNode([{ name: idString, value: new BrsString("") }]);
         });
 
         describe("findnode", () => {
@@ -2081,6 +2082,13 @@ describe("RoSGNode", () => {
                 expect(findNode).toBeTruthy();
 
                 let invalidNode = findNode.call(interpreter, new BrsString("someRandomId"));
+                expect(invalidNode).toEqual(BrsInvalid.Instance);
+            });
+
+            it("returns invalid on empty id string", () => {
+                let findNode = parent.getMethod("findnode");
+
+                let invalidNode = findNode.call(interpreter, new BrsString(""));
                 expect(invalidNode).toEqual(BrsInvalid.Instance);
             });
 

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -234,6 +234,8 @@ describe("end to end brightscript functions", () => {
             "Cousin-2",
             "node finds its grandparent: ",
             "root-node",
+            "returns invalid on empty:",
+            "invalid",
             "is same node returns true:",
             "true",
             "is same node returns false:",

--- a/test/e2e/resources/components/roSGNode.brs
+++ b/test/e2e/resources/components/roSGNode.brs
@@ -154,6 +154,7 @@ sub main()
         child.name = "sibling-" + id
         children[id] = child
     end for
+    root.createChild("Node") ' create node with empty id
 
     result = children["c4"].findNode("c7")
     print "node finds its sibling: " result.name                    ' => name-c7
@@ -173,6 +174,10 @@ sub main()
     ' finds its grandparent
     result = cousin2.findNode("root")
     print "node finds its grandparent: " result.name                ' => root-node
+
+    ' returns invalid on empty string
+    result = root.findNode("")
+    print "returns invalid on empty:" result
 
     ' returns true if both nodes are the same
     n = createObject("roSGNode", "Node")


### PR DESCRIPTION
Fixes #523 where it seems _findNode()_ always returns invalid if passed an empty string for an id even if nodes exist with an empty id. 