### PR TITLE
feat(rsg): Implement unobserveField

### DIFF
--- a/test/e2e/Observers.test.js
+++ b/test/e2e/Observers.test.js
@@ -1,0 +1,41 @@
+const { execute } = require("../../lib/");
+const { createMockStreams, resourceFile, allArgs } = require("./E2ETests");
+const path = require("path");
+
+describe("end to end brightscript functions", () => {
+    let outputStreams;
+
+    beforeAll(() => {
+        outputStreams = createMockStreams();
+        outputStreams.root = path.join(__dirname, "resources", "observers");
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("observers/unscoped-main.brs", async () => {
+        await execute([resourceFile("observers", "unscoped-main.brs")], outputStreams);
+        expect(allArgs(outputStreams.stdout.write).join("")).toBe(
+            `[Observer::init]
+[Observer::init]
+[Observer2::init]
+[Observer#a :: onTargetChanged] observing
+[Observer#b :: onTargetChanged] observing
+[Observer2#c :: onTargetChanged] observing
+[Observer#a :: onTriggerChanged] trigger = 1
+[Observer#b :: onTriggerChanged] trigger = 1
+[Observer2#c :: onTriggerChanged] trigger = 1
+[Observer#a :: onTriggerChanged] trigger = 2
+[Observer#b :: onTriggerChanged] trigger = 2
+[Observer2#c :: onTriggerChanged] trigger = 2
+[Observer#a :: onTriggerChanged] trigger = unobserve-a
+[Observer#a :: onTriggerChanged] unobserveField result = true
+`
+        );
+    });
+});

--- a/test/e2e/resources/observers/components/Observer.brs
+++ b/test/e2e/resources/observers/components/Observer.brs
@@ -1,0 +1,25 @@
+sub init()
+    m.subtype = m.top.subtype()
+    print "[" m.subtype "::init]"
+    m.target = invalid
+end sub
+
+sub onTargetChanged(event as object)
+    target = event.getData()
+    if m.target <> invalid and target <> invalid and m.target.isSameNode(target) then return
+    if target <> invalid then
+        m.target = target
+        print "[" + m.subtype + "#" + m.top.id + " :: onTargetChanged] observing"
+        target.observeField("trigger", "onTriggerChanged")
+    end if
+end sub
+
+sub onTriggerChanged(event as object)
+    trigger = event.getData()
+    print "[" + m.subtype + "#" + m.top.id + " :: onTriggerChanged] trigger = " + trigger
+
+    if trigger = "unobserve-" + m.top.id then
+        result = m.top.target.unobserveField("trigger")
+        print "[" + m.subtype + "#" + m.top.id + " :: onTriggerChanged] unobserveField result = " + result.toStr()
+    end if
+end sub

--- a/test/e2e/resources/observers/components/Observer.xml
+++ b/test/e2e/resources/observers/components/Observer.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="Observer">
+    <interface>
+        <field id="target" type="node" onChange="onTargetChanged" />
+    </interface>
+
+    <script type="text/brightscript" uri="./Observer.brs"/>
+</component>

--- a/test/e2e/resources/observers/components/Observer2.xml
+++ b/test/e2e/resources/observers/components/Observer2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="Observer2">
+    <interface>
+        <field id="target" type="node" onChange="onTargetChanged" />
+    </interface>
+
+    <script type="text/brightscript" uri="./Observer.brs"/>
+</component>

--- a/test/e2e/resources/observers/components/UnscopedObserversTestBed.brs
+++ b/test/e2e/resources/observers/components/UnscopedObserversTestBed.brs
@@ -1,0 +1,22 @@
+sub init()
+    target = createObject("roSGNode", "Node")
+    target.update({ trigger: "none" }, true)
+
+    a = createObject("roSGNode", "Observer")
+    b = createObject("roSGNode", "Observer")
+    c = createObject("roSGNode", "Observer2")
+
+    a.id = "a"
+    a.target = target
+
+    b.id = "b"
+    b.target = target
+
+    c.id = "c"
+    c.target = target
+
+    target.trigger = "1"
+    target.trigger = "2"
+    target.trigger = "unobserve-a"
+    target.trigger = "3"
+end sub

--- a/test/e2e/resources/observers/components/UnscopedObserversTestBed.xml
+++ b/test/e2e/resources/observers/components/UnscopedObserversTestBed.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="UnscopedObserversTestBed">
+    <script type="text/brightscript" uri="./UnscopedObserversTestBed.brs"/>
+</component>

--- a/test/e2e/resources/observers/unscoped-main.brs
+++ b/test/e2e/resources/observers/unscoped-main.brs
@@ -1,0 +1,5 @@
+sub main()
+    ' observeField can only be called from the context of a node,
+    ' so these tests happen in `UnscopedObserversTestBed::init()`
+    createObject("roSGNode", "UnscopedObserversTestBed")
+end sub


### PR DESCRIPTION
`roSGNode#unobserveField` unsubscribes _all_ nodes subscribed to that field, regardless of subtype, when they subscribed, etc.  It's pretty dangerous, but available in the standard library.