### PR TITLE
implement dim statement (#283)

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1158,23 +1158,23 @@ export class Parser {
          * @returns an AST representation of an `goto` statement.
          */
         function dimStatement() {
-            let tokens = {
-                dim: advance(),
-            };
+            let dimToken = advance();
 
-            let name = advance();
+            let name = consume("Expected variable name after 'dim'", Lexeme.Identifier);
 
             match(Lexeme.LeftSquare);
 
-            let dimensions: Expression[] = [];
+            let dimensions: Expression[] = [expression()];
             while (!match(Lexeme.RightSquare)) {
+                consume("Expected ',' after expression in 'dim' statement", Lexeme.Comma);
                 dimensions.push(expression());
-                if (check(Lexeme.Comma)) advance();
             }
+            let rightSquare = previous();
 
-            if (dimensions.length === 0) {
-                throw addError(tokens.dim, `Dim must have at least one dimension`);
-            }
+            let tokens = {
+                dim: dimToken,
+                closingBrace: rightSquare,
+            };
 
             return new Stmt.Dim(tokens, name as Identifier, dimensions);
         }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -612,6 +612,10 @@ export class Parser {
                 return returnStatement();
             }
 
+            if (check(Lexeme.Dim)) {
+                return dimStatement();
+            }
+
             if (check(Lexeme.Goto)) {
                 return gotoStatement();
             }
@@ -1147,6 +1151,32 @@ export class Parser {
             consume("Labels must be declared on their own line", Lexeme.Newline, Lexeme.Eof);
 
             return new Stmt.Label(tokens);
+        }
+
+        /**
+         * Parses a `dim` statement
+         * @returns an AST representation of an `goto` statement.
+         */
+        function dimStatement() {
+            let tokens = {
+                dim: advance(),
+            };
+
+            let name = advance();
+
+            match(Lexeme.LeftSquare);
+
+            let dimensions: Expression[] = [];
+            while (!match(Lexeme.RightSquare)) {
+                dimensions.push(expression());
+                if (check(Lexeme.Comma)) advance();
+            }
+
+            if (dimensions.length === 0) {
+                throw addError(tokens.dim, `Dim must have at least one dimension`);
+            }
+
+            return new Stmt.Dim(tokens, name as Identifier, dimensions);
         }
 
         /**

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -85,7 +85,7 @@ export class Dim extends AstNode implements Statement {
         return {
             file: this.tokens.dim.location.file,
             start: this.tokens.dim.location.start,
-            end: this.tokens.dim.location.end,
+            end: this.tokens.closingBrace.location.end,
         };
     }
 }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -9,6 +9,7 @@ export * from "./BlockEndReason";
 
 export interface Visitor<T> {
     visitAssignment(statement: Assignment): BrsType;
+    visitDim(statement: Dim): BrsType;
     visitExpression(statement: Expression): BrsType;
     visitExitFor(statement: ExitFor): never;
     visitExitWhile(statement: ExitWhile): never;
@@ -60,6 +61,30 @@ export class Assignment extends AstNode implements Statement {
             file: this.name.location.file,
             start: this.name.location.start,
             end: this.value.location.end,
+        };
+    }
+}
+
+export class Dim extends AstNode implements Statement {
+    constructor(
+        readonly tokens: {
+            dim: Token;
+        },
+        readonly name: Identifier,
+        readonly dimensions: Expr.Expression[]
+    ) {
+        super("Dim");
+    }
+
+    accept<R>(_visitor: Visitor<R>): BrsType {
+        return _visitor.visitDim(this);
+    }
+
+    get location() {
+        return {
+            file: this.tokens.dim.location.file,
+            start: this.tokens.dim.location.start,
+            end: this.tokens.dim.location.end,
         };
     }
 }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -69,6 +69,7 @@ export class Dim extends AstNode implements Statement {
     constructor(
         readonly tokens: {
             dim: Token;
+            closingBrace: Token;
         },
         readonly name: Identifier,
         readonly dimensions: Expr.Expression[]
@@ -76,8 +77,8 @@ export class Dim extends AstNode implements Statement {
         super("Dim");
     }
 
-    accept<R>(_visitor: Visitor<R>): BrsType {
-        return _visitor.visitDim(this);
+    accept<R>(visitor: Visitor<R>): BrsType {
+        return visitor.visitDim(this);
     }
 
     get location() {

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -120,6 +120,19 @@ describe("end to end syntax", () => {
         ]);
     });
 
+    test("dim.brs", async () => {
+        await execute([resourceFile("dim.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
+            "4",
+            "5",
+            "5",
+            "hello",
+            "invalid",
+            "invalid",
+        ]);
+    });
+
     test("while-loops.brs", async () => {
         await execute([resourceFile("while-loops.brs")], outputStreams);
 

--- a/test/e2e/resources/dim.brs
+++ b/test/e2e/resources/dim.brs
@@ -1,0 +1,17 @@
+' initialize foo to some base value
+dim array[3,4]
+
+' NOTE: Roku's dim implementation creates a resizeable, empty array for the
+'   bottom children. Resizeable arrays aren't implemented yet (issue #530), 
+'   so when that's added this code should be updated so the final array size
+'   matches the index of what it expanded to after assignment
+print array.count()
+print array[0].count()
+print array[3].count()
+
+array[3][4] = "hello"
+print array[3][4]
+
+print array[4]
+print array[3][5]
+

--- a/test/interpreter/Dim.test.js
+++ b/test/interpreter/Dim.test.js
@@ -1,0 +1,113 @@
+const Expr = require("../../lib/parser/Expression");
+const Stmt = require("../../lib/parser/Statement");
+const { Interpreter } = require("../../lib/interpreter");
+const brs = require("brs");
+const { Lexeme } = brs.lexer;
+const { Int32, BrsString } = brs.types;
+
+const { token, identifier, fakeLocation } = require("../parser/ParserTests");
+
+let interpreter;
+
+const LEFT_SQUARE = token(Lexeme.LeftSquare, "[");
+const RIGHT_SQUARE = token(Lexeme.RightSquare, "]");
+const LEFT_BRACE = token(Lexeme.LeftBrace, "{");
+const RIGHT_BRACE = token(Lexeme.RightBrace, "}");
+
+describe("creating arrays using dim", () => {
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    test("one-dimensional creation", () => {
+        let maxIndex = 5;
+        let statements = [
+            new Stmt.Dim(
+                {
+                    dim: token(Lexeme.Dim, "dim"),
+                },
+                identifier("array"),
+                [new Expr.Literal(new Int32(maxIndex))]
+            ),
+            new Stmt.IndexedSet(
+                new Expr.Variable(identifier("array")),
+                new Expr.Literal(new Int32(4), fakeLocation),
+                new Expr.Literal(new BrsString("new index4"), fakeLocation),
+                RIGHT_SQUARE
+            ),
+            new Stmt.Assignment(
+                { equals: token(Lexeme.Equals, "=") },
+                identifier("result"),
+                new Expr.IndexedGet(
+                    new Expr.Variable(identifier("array")),
+                    new Expr.Literal(new Int32(4), fakeLocation),
+                    RIGHT_SQUARE
+                )
+            ),
+        ];
+
+        interpreter.exec(statements);
+        expect(interpreter.environment.get(identifier("result"))).toEqual(
+            new BrsString("new index4")
+        );
+
+        // NOTE: Roku's dim implementation creates a resizeable, empty array for the
+        //   bottom children. Resizeable arrays aren't implemented yet (issue #530),
+        //   so when that's added this code should be updated so the final array size
+        //   matches the index of what it expanded to after assignment
+        let arr = interpreter.environment.get(identifier("array"));
+        let count = arr.getMethod("count");
+        expect(count.call(interpreter)).toEqual(new Int32(maxIndex + 1));
+    });
+
+    test("multi-dimensional creation", () => {
+        let maxIndex1 = 6;
+        let maxIndex2 = 3;
+        let statements = [
+            new Stmt.Dim(
+                {
+                    dim: token(Lexeme.Dim, "dim"),
+                },
+                identifier("baseArray"),
+                [new Expr.Literal(new Int32(maxIndex1)), new Expr.Literal(new Int32(maxIndex2))]
+            ),
+            new Stmt.IndexedSet(
+                new Expr.IndexedGet(
+                    new Expr.Variable(identifier("baseArray")),
+                    new Expr.Literal(new Int32(2), fakeLocation),
+                    RIGHT_SQUARE
+                ),
+                new Expr.Literal(new Int32(1), fakeLocation),
+                new Expr.Literal(new BrsString("new (2,1)"), fakeLocation),
+                RIGHT_SQUARE
+            ),
+            new Stmt.Assignment(
+                { equals: token(Lexeme.Equals, "=") },
+                identifier("result"),
+                new Expr.IndexedGet(
+                    new Expr.IndexedGet(
+                        new Expr.Variable(identifier("baseArray")),
+                        new Expr.Literal(new Int32(2), fakeLocation),
+                        RIGHT_SQUARE
+                    ),
+                    new Expr.Literal(new Int32(1), fakeLocation),
+                    RIGHT_SQUARE
+                )
+            ),
+        ];
+
+        interpreter.exec(statements);
+        expect(interpreter.environment.has(identifier("baseArray"))).toBe(true);
+        expect(interpreter.environment.get(identifier("result"))).toEqual(
+            new BrsString("new (2,1)")
+        );
+
+        // NOTE: Roku's dim implementation creates a resizeable, empty array for the
+        //   bottom children. Resizeable arrays aren't implemented yet (issue #530),
+        //   so when that's added this code should be updated so the final array size
+        //   matches the index of what it expanded to after assignment
+        let arr = interpreter.environment.get(identifier("baseArray"));
+        let count = arr.getMethod("count");
+        expect(count.call(interpreter)).toEqual(new Int32(maxIndex1 + 1));
+    });
+});

--- a/test/interpreter/Dim.test.js
+++ b/test/interpreter/Dim.test.js
@@ -25,6 +25,7 @@ describe("creating arrays using dim", () => {
             new Stmt.Dim(
                 {
                     dim: token(Lexeme.Dim, "dim"),
+                    closingBrace: token(Lexeme.RightSquare, "closingSquare"),
                 },
                 identifier("array"),
                 [new Expr.Literal(new Int32(maxIndex))]
@@ -67,6 +68,7 @@ describe("creating arrays using dim", () => {
             new Stmt.Dim(
                 {
                     dim: token(Lexeme.Dim, "dim"),
+                    closingBrace: token(Lexeme.RightSquare, "closingSquare"),
                 },
                 identifier("baseArray"),
                 [new Expr.Literal(new Int32(maxIndex1)), new Expr.Literal(new Int32(maxIndex2))]

--- a/test/parser/statement/Dim.test.js
+++ b/test/parser/statement/Dim.test.js
@@ -1,0 +1,30 @@
+const brs = require("brs");
+const { token, identifier, EOF } = require("../ParserTests");
+const { Lexeme } = brs.lexer;
+const { Expr, Stmt } = brs.parser;
+
+describe("parser dim statements", () => {
+    it("parses one-dimension", () => {
+        let { statements, errors } = brs.parser.Parser.parse([
+            token(Lexeme.Dim, "dim"),
+            identifier("foo"),
+            token(Lexeme.LeftSquare, "["),
+            identifier("bar"), // any valid expression
+            token(Lexeme.RightSquare, "]"),
+            EOF,
+        ]);
+        expect(errors.length).toEqual(0);
+    });
+
+    it("errors when no dimensions provided", () => {
+        let { statements, errors } = brs.parser.Parser.parse([
+            token(Lexeme.Dim, "dim"),
+            identifier("foo"),
+            token(Lexeme.LeftSquare, "["),
+            // missing dimension, throw error
+            token(Lexeme.RightSquare, "]"),
+            EOF,
+        ]);
+        expect(errors.length).toEqual(1);
+    });
+});


### PR DESCRIPTION
This implements the dim statement for as requested for #283. It doesn't match Roku's spec exactly as Roku's dim will leave the bottom-level arrays unexpanded but resizeable. When brs supports resizeable arrays (#530) we can come back and update this code to match the spec. 