### PR TITLE
fix(rsg): Adds optional arg to RoString constructor

### DIFF
--- a/src/brsTypes/components/BrsObjects.ts
+++ b/src/brsTypes/components/BrsObjects.ts
@@ -32,7 +32,7 @@ export const BrsObjects = new Map<string, Function>([
         "roregex",
         (_: Interpreter, expression: BrsString, flags: BrsString) => new RoRegex(expression, flags),
     ],
-    ["rostring", (_: Interpreter, literal: BrsString) => new RoString(literal)],
+    ["rostring", (_: Interpreter) => new RoString()],
     ["roboolean", (_: Interpreter, literal: BrsBoolean) => new roBoolean(literal)],
     ["rodouble", (_: Interpreter, literal: Double) => new roDouble(literal)],
     ["rofloat", (_: Interpreter, literal: Float) => new roFloat(literal)],

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -10,16 +10,19 @@ import { Float } from "../Float";
 
 export class RoString extends BrsComponent implements BrsValue, Comparable, Unboxable {
     readonly kind = ValueKind.Object;
-    private intrinsic: BrsString;
+    private intrinsic: BrsString = new BrsString("");
 
     public getValue(): string {
         return this.intrinsic.value;
     }
 
-    constructor(initialValue: BrsString) {
+    constructor(initialValue?: BrsString) {
         super("roString");
 
-        this.intrinsic = initialValue;
+        if (initialValue instanceof BrsString) {
+            this.intrinsic = initialValue;
+        }
+
         this.registerMethods({
             ifString: [this.setString, this.getString],
             ifStringOps: [

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -20,8 +20,6 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
         super("roString");
 
         if (initialValue) {
-        // or if you want to be explicit:
-        // if (initialValue != null) {
             this.intrinsic = initialValue;
         }
 

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -19,7 +19,9 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
     constructor(initialValue?: BrsString) {
         super("roString");
 
-        if (initialValue instanceof BrsString) {
+        if (initialValue) {
+        // or if you want to be explicit:
+        // if (initialValue != null) {
             this.intrinsic = initialValue;
         }
 

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -3,6 +3,13 @@ const { Int32, Float, BrsString, RoString, RoArray, BrsBoolean, Callable } = brs
 const { Interpreter } = require("../../../lib/interpreter");
 
 describe("RoString", () => {
+    describe("constructor", () => {
+        it("starts with empty string when no arg is passed to constructor", () => {
+            let a = new RoString();
+            expect(a.equalTo(new BrsString(""))).toBe(BrsBoolean.True);
+        });
+    });
+
     describe("equality", () => {
         it("compares to intrinsic strings", () => {
             let a = new RoString(new BrsString("foo"));

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -296,6 +296,7 @@ describe("end to end brightscript functions", () => {
 
         expect(allArgs(outputStreams.stderr.write)).toEqual([]);
         expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
+            "hello",
             "bar",
             "bar",
             "true", // comparison

--- a/test/e2e/resources/components/roString.brs
+++ b/test/e2e/resources/components/roString.brs
@@ -1,6 +1,9 @@
 sub main()
     ' direct creation
-    r = createObject("RoString", "foo")
+    r = createObject("RoString")
+
+    r.appendString("hello", 5) ' appends hello to the default empty string
+    print r.getString() ' => "hello"
 
     s = "bar"
     print s.getString() ' => "bar"


### PR DESCRIPTION
I found that when creating an string like this:
```
str = createObject("roString")
```
The intrinsic string doesn't have initial value because we were always expecting a second argument in the `createObject` syntax, then when we tried to use methods like `appendString` to the object they won't work because there is no initial string.
I made optional the argument in the `RoString` class constructor so it doesn't break the string boxing functionality but at the same time makes things consistent with the Roku implementation of `roString` which doesn't take a second argument.

Thanks to @adheus who find the bug

Fixes #513 