### PR TITLE
feat(mocks): return a spy from _brs_.mockFunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ print mock.results ' => [ "foo", "bar" ]
 
 ##### `mock.getMockName()`
 
-Returns the name of the mock.
+Returns the name of the mocked function.
 
 ```brightscript
 mock = _brs_.mockFunction("fooBar", function()

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ print mock.results ' => [ "foo", "bar" ]
 
 Returns the name of the mock.
 
-```
+```brightscript
 mock = _brs_.mockFunction("fooBar", function()
     return "hello, world"
 end function)

--- a/README.md
+++ b/README.md
@@ -174,12 +174,67 @@ _brs_.mockComponent("ComponentName", {
 
 ### `_brs_.mockFunction`
 
-Allows you to mock a function. Usage:
+Allows you to mock a function. It also returns a Mock Function Node (also known as a "spy") that keeps track of calls and return values. Usage:
 
 ```brightscript
-_brs_.mockFunction("FunctionName", sub()
+mock = _brs_.mockFunction("FunctionName", sub()
     print "foobar"
 end sub)
+```
+
+#### Mock Function Node API
+
+The Mock Function Node API is modeled after [Jest's `mockFn` API](https://jestjs.io/docs/en/mock-function-api). Methods:
+
+##### `mock.calls`
+
+An array containing the arguments of each call to this function. Each item in the array is an array of the arguments for that call.
+
+For example:
+```brightscript
+mock = _brs_.mockFunction("fooBar", function(arg1 as string, arg2 as integer)
+    print "fooBar"
+end function)
+
+fooBar("baz", 123)
+print mock.calls
+' [
+'     ["baz", 123]
+' ]
+
+fooBar("lorem", 456)
+print mock.calls
+' [
+'     ["baz", 123]
+'     ["lorem", 456]
+' ]
+```
+
+##### `mock.results`
+
+An array containing the return value for each call to this function. For example:
+```brightscript
+mock = _brs_.mockFunction("fooBar", function(arg as boolean)
+    if arg then return "foo" : else return "bar" : end if
+end function)
+
+fooBar(true)
+print mock.results ' => [ "foo" ]
+
+fooBar(false)
+print mock.results ' => [ "foo", "bar" ]
+```
+
+##### `mock.getMockName()`
+
+Returns the name of the mock.
+
+```
+mock = _brs_.mockFunction("fooBar", function()
+    return "hello, world"
+end function)
+
+print mock.getMockName() ' => "fooBar"
 ```
 
 ### `_brs_.resetMocks`

--- a/README.md
+++ b/README.md
@@ -174,67 +174,86 @@ _brs_.mockComponent("ComponentName", {
 
 ### `_brs_.mockFunction`
 
-Allows you to mock a function. It also returns a Mock Function Node (also known as a "spy") that keeps track of calls and return values. Usage:
+Allows you to mock a function. It also returns an associative array "spy" that keeps track of calls and return values. Usage:
 
 ```brightscript
-mock = _brs_.mockFunction("FunctionName", sub()
+spy = _brs_.mockFunction("FunctionName", sub()
     print "foobar"
 end sub)
 ```
 
-#### Mock Function Node API
+#### Spy API
 
-The Mock Function Node API is modeled after [Jest's `mockFn` API](https://jestjs.io/docs/en/mock-function-api). Methods:
+The Spy API is modeled after [Jest's `mockFn` API](https://jestjs.io/docs/en/mock-function-api). Methods:
 
-##### `mock.calls`
+##### `spy.calls`
 
 An array containing the arguments of each call to this function. Each item in the array is an array of the arguments for that call.
 
 For example:
 ```brightscript
-mock = _brs_.mockFunction("fooBar", function(arg1 as string, arg2 as integer)
+spy = _brs_.mockFunction("fooBar", function(arg1 as string, arg2 as integer)
     print "fooBar"
 end function)
 
 fooBar("baz", 123)
-print mock.calls
+print spy.calls
 ' [
 '     ["baz", 123]
 ' ]
 
 fooBar("lorem", 456)
-print mock.calls
+print spy.calls
 ' [
 '     ["baz", 123]
 '     ["lorem", 456]
 ' ]
 ```
 
-##### `mock.results`
+##### `spy.results`
 
 An array containing the return value for each call to this function. For example:
+
 ```brightscript
-mock = _brs_.mockFunction("fooBar", function(arg as boolean)
+spy = _brs_.mockFunction("fooBar", function(arg as boolean)
     if arg then return "foo" : else return "bar" : end if
 end function)
 
 fooBar(true)
-print mock.results ' => [ "foo" ]
+print spy.results ' => [ "foo" ]
 
 fooBar(false)
-print mock.results ' => [ "foo", "bar" ]
+print spy.results ' => [ "foo", "bar" ]
 ```
 
-##### `mock.getMockName()`
+##### `spy.clearMock()`
+
+Clears the `calls` and `results` arrays. Does not affect the mock implementation.
+
+```brightscript
+spy = _brs_.mockFunction("fooBar", function()
+    return "hello, world"
+end function)
+
+fooBar()
+print spy.calls.count()   ' => 1
+print spy.results.count() ' => 1
+
+spy.clearMock()
+print spy.calls.count()   ' => 0
+print spy.results.count() ' => 0
+```
+
+##### `spy.getMockName()`
 
 Returns the name of the mocked function.
 
 ```brightscript
-mock = _brs_.mockFunction("fooBar", function()
+spy = _brs_.mockFunction("fooBar", function()
     return "hello, world"
 end function)
 
-print mock.getMockName() ' => "fooBar"
+print spy.getMockName() ' => "fooBar"
 ```
 
 ### `_brs_.resetMocks`

--- a/README.md
+++ b/README.md
@@ -174,86 +174,86 @@ _brs_.mockComponent("ComponentName", {
 
 ### `_brs_.mockFunction`
 
-Allows you to mock a function. It also returns an associative array "spy" that keeps track of calls and return values. Usage:
+Allows you to mock a function. It also returns an associative array mock function (also known as a "spy" or "stub") that keeps track of calls and return values. Usage:
 
 ```brightscript
-spy = _brs_.mockFunction("FunctionName", sub()
+mock = _brs_.mockFunction("FunctionName", sub()
     print "foobar"
 end sub)
 ```
 
-#### Spy API
+#### Mock Function API
 
-The Spy API is modeled after [Jest's `mockFn` API](https://jestjs.io/docs/en/mock-function-api). Methods:
+The Mock Function API is modeled after [Jest's `mockFn` API](https://jestjs.io/docs/en/mock-function-api). Methods:
 
-##### `spy.calls`
+##### `mock.calls`
 
 An array containing the arguments of each call to this function. Each item in the array is an array of the arguments for that call.
 
 For example:
 ```brightscript
-spy = _brs_.mockFunction("fooBar", function(arg1 as string, arg2 as integer)
+mock = _brs_.mockFunction("fooBar", function(arg1 as string, arg2 as integer)
     print "fooBar"
 end function)
 
 fooBar("baz", 123)
-print spy.calls
+print mock.calls
 ' [
 '     ["baz", 123]
 ' ]
 
 fooBar("lorem", 456)
-print spy.calls
+print mock.calls
 ' [
 '     ["baz", 123]
 '     ["lorem", 456]
 ' ]
 ```
 
-##### `spy.results`
+##### `mock.results`
 
 An array containing the return value for each call to this function. For example:
 
 ```brightscript
-spy = _brs_.mockFunction("fooBar", function(arg as boolean)
+mock = _brs_.mockFunction("fooBar", function(arg as boolean)
     if arg then return "foo" : else return "bar" : end if
 end function)
 
 fooBar(true)
-print spy.results ' => [ "foo" ]
+print mock.results ' => [ "foo" ]
 
 fooBar(false)
-print spy.results ' => [ "foo", "bar" ]
+print mock.results ' => [ "foo", "bar" ]
 ```
 
-##### `spy.clearMock()`
+##### `mock.clearMock()`
 
 Clears the `calls` and `results` arrays. Does not affect the mock implementation.
 
 ```brightscript
-spy = _brs_.mockFunction("fooBar", function()
+mock = _brs_.mockFunction("fooBar", function()
     return "hello, world"
 end function)
 
 fooBar()
-print spy.calls.count()   ' => 1
-print spy.results.count() ' => 1
+print mock.calls.count()   ' => 1
+print mock.results.count() ' => 1
 
-spy.clearMock()
-print spy.calls.count()   ' => 0
-print spy.results.count() ' => 0
+mock.clearMock()
+print mock.calls.count()   ' => 0
+print mock.results.count() ' => 0
 ```
 
-##### `spy.getMockName()`
+##### `mock.getMockName()`
 
 Returns the name of the mocked function.
 
 ```brightscript
-spy = _brs_.mockFunction("fooBar", function()
+mock = _brs_.mockFunction("fooBar", function()
     return "hello, world"
 end function)
 
-print spy.getMockName() ' => "fooBar"
+print mock.getMockName() ' => "fooBar"
 ```
 
 ### `_brs_.resetMocks`

--- a/src/extensions/mockFunction.ts
+++ b/src/extensions/mockFunction.ts
@@ -1,5 +1,109 @@
-import { BrsInvalid, BrsType, Callable, StdlibArgument, ValueKind } from "../brsTypes";
+import {
+    BrsInvalid,
+    BrsType,
+    Callable,
+    StdlibArgument,
+    ValueKind,
+    RoSGNode,
+    FieldModel,
+    SignatureAndImplementation,
+    BrsString,
+    RoArray,
+} from "../brsTypes";
 import { Interpreter } from "../interpreter";
+import { Stmt } from "../parser";
+
+export class MockFunction extends RoSGNode {
+    readonly defaultFields: FieldModel[] = [
+        { name: "calls", type: "array" },
+        { name: "results", type: "array" },
+    ];
+    private func: Callable;
+    private name: BrsString;
+
+    constructor(name: BrsString, func: Callable) {
+        super([], "MockFunction");
+        this.name = name;
+        this.func = func;
+
+        this.registerDefaultFields(this.defaultFields);
+        this.appendMethods([this.mockReset, this.getMockName]);
+    }
+
+    private addCall(interpreter: Interpreter, args: any[]) {
+        let calls = this.get(new BrsString("calls"));
+        if (calls instanceof RoArray) {
+            let push = calls.getMethod("push");
+            push?.call(interpreter, new RoArray(args));
+        }
+    }
+
+    private addResult(interpreter: Interpreter, value: BrsType) {
+        let results = this.get(new BrsString("results"));
+        if (results instanceof RoArray) {
+            let push = results.getMethod("push");
+            push?.call(interpreter, value);
+        }
+    }
+
+    /**
+     * Wraps the original function implementation so that it can keep track of each call.
+     */
+    createMockFunction(): Callable {
+        let signatures: SignatureAndImplementation[] = this.func.signatures.map((sigAndImpl) => {
+            return {
+                signature: sigAndImpl.signature,
+                impl: (interpreter: Interpreter, ...args: any[]) => {
+                    this.addCall(interpreter, args);
+                    let result: BrsType = BrsInvalid.Instance;
+                    try {
+                        result = this.func.call(interpreter, ...args);
+                    } catch (err) {
+                        if (err instanceof Stmt.ReturnValue && err.value) {
+                            this.addResult(interpreter, err.value);
+                        }
+                        // re-throw error to continue normal execution
+                        throw err;
+                    }
+
+                    this.addResult(interpreter, result);
+                    return result;
+                },
+            };
+        });
+        return new Callable(this.name.value, ...signatures);
+    }
+
+    /** Clears the calls array and results array. */
+    private mockReset = new Callable("mockReset", {
+        signature: {
+            args: [],
+            returns: ValueKind.Invalid,
+        },
+        impl: (interpreter: Interpreter) => {
+            ["calls", "results"].forEach((fieldName) => {
+                let field = this.get(new BrsString(fieldName));
+                if (field instanceof RoArray) {
+                    let clear = field.getMethod("clear");
+                    clear?.call(interpreter);
+                }
+            });
+
+            return BrsInvalid.Instance;
+        },
+    });
+
+    /** Returns the name of the function that's being mocked. */
+    private getMockName = new Callable("getMockName", {
+        signature: {
+            args: [],
+            returns: ValueKind.String,
+        },
+        impl: (interpreter: Interpreter) => {
+            return this.name;
+        },
+    });
+}
 
 export const mockFunction = new Callable("mockFunction", {
     signature: {
@@ -9,8 +113,13 @@ export const mockFunction = new Callable("mockFunction", {
         ],
         returns: ValueKind.Invalid,
     },
-    impl: (interpreter: Interpreter, functionToMock: BrsType, mock: Callable) => {
-        interpreter.environment.setMockFunction(functionToMock.toString(), mock);
-        return BrsInvalid.Instance;
+    impl: (interpreter: Interpreter, functionToMock: BrsString, mock: Callable) => {
+        let mockFunctionNode = new MockFunction(functionToMock, mock);
+        interpreter.environment.setMockFunction(
+            functionToMock.toString(),
+            mockFunctionNode.createMockFunction()
+        );
+
+        return mockFunctionNode;
     },
 });

--- a/test/e2e/BrsMock.test.js
+++ b/test/e2e/BrsMock.test.js
@@ -51,7 +51,7 @@ describe("end to end brightscript functions", () => {
         ]);
     });
 
-    test("mock-functions-main.brs", async () => {
+    test.only("mock-functions-main.brs", async () => {
         let consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
         await execute([resourceFile("mock-functions-main.brs")], outputStreams);
 
@@ -75,6 +75,8 @@ describe("end to end brightscript functions", () => {
             "456",
             "2",
             "mocked implementation!",
+            "0",
+            "0",
         ]);
 
         // split the warning because the line number output is user-specific.

--- a/test/e2e/BrsMock.test.js
+++ b/test/e2e/BrsMock.test.js
@@ -62,6 +62,7 @@ describe("end to end brightscript functions", () => {
             "--inline foo--",
             "--inline foo--",
             "doesn't exist in source yet here i am",
+            "spyOnMe",
             "1",
             "2",
             "first string",

--- a/test/e2e/BrsMock.test.js
+++ b/test/e2e/BrsMock.test.js
@@ -62,6 +62,18 @@ describe("end to end brightscript functions", () => {
             "--inline foo--",
             "--inline foo--",
             "doesn't exist in source yet here i am",
+            "1",
+            "2",
+            "first string",
+            "123",
+            "1",
+            "mocked implementation!",
+            "2",
+            "2",
+            "second string",
+            "456",
+            "2",
+            "mocked implementation!",
         ]);
 
         // split the warning because the line number output is user-specific.

--- a/test/e2e/resources/components/scripts/BrsMockFunctions.brs
+++ b/test/e2e/resources/components/scripts/BrsMockFunctions.brs
@@ -35,6 +35,26 @@ sub init()
 
     ' Will trigger a console.error warning that it doesn't exist in source.
     print thisFuncDoesNotExist() ' => "doesn't exist in source yet here i am"
+
+    spy = _brs_.mockFunction("spyOnMe", function(arg1 as string, arg2 as integer) as string
+        return "mocked implementation!"
+    end function)
+
+    spyOnMe("first string", 123)
+    print spy.calls.count() ' => 1
+    print spy.calls[0].count() ' => 2
+    print spy.calls[0][0] ' => "first string"
+    print spy.calls[0][1] ' => 123
+    print spy.results.count() ' => 1
+    print spy.results[0] ' => "mocked implementation!"
+
+    spyOnMe("second string", 456)
+    print spy.calls.count() ' => 2
+    print spy.calls[1].count() ' => 2
+    print spy.calls[1][0] ' => "second string"
+    print spy.calls[1][1] ' => 456
+    print spy.results.count() ' => 2
+    print spy.results[1] ' => "mocked implementation!"
 end sub
 
 function mockMe()
@@ -43,4 +63,8 @@ end function
 
 function foo()
     return "Named foo"
+end function
+
+function spyOnMe(arg1 as string, arg2 as integer)
+    return "original return value!"
 end function

--- a/test/e2e/resources/components/scripts/BrsMockFunctions.brs
+++ b/test/e2e/resources/components/scripts/BrsMockFunctions.brs
@@ -36,31 +36,31 @@ sub init()
     ' Will trigger a console.error warning that it doesn't exist in source.
     print thisFuncDoesNotExist() ' => "doesn't exist in source yet here i am"
 
-    spy = _brs_.mockFunction("spyOnMe", function(arg1 as string, arg2 as integer) as string
+    mock = _brs_.mockFunction("spyOnMe", function(arg1 as string, arg2 as integer) as string
         return "mocked implementation!"
     end function)
 
-    print spy.getMockName() ' => "spyOnMe"
+    print mock.getMockName() ' => "spyOnMe"
 
     spyOnMe("first string", 123)
-    print spy.calls.count() ' => 1
-    print spy.calls[0].count() ' => 2
-    print spy.calls[0][0] ' => "first string"
-    print spy.calls[0][1] ' => 123
-    print spy.results.count() ' => 1
-    print spy.results[0] ' => "mocked implementation!"
+    print mock.calls.count() ' => 1
+    print mock.calls[0].count() ' => 2
+    print mock.calls[0][0] ' => "first string"
+    print mock.calls[0][1] ' => 123
+    print mock.results.count() ' => 1
+    print mock.results[0] ' => "mocked implementation!"
 
     spyOnMe("second string", 456)
-    print spy.calls.count() ' => 2
-    print spy.calls[1].count() ' => 2
-    print spy.calls[1][0] ' => "second string"
-    print spy.calls[1][1] ' => 456
-    print spy.results.count() ' => 2
-    print spy.results[1] ' => "mocked implementation!"
+    print mock.calls.count() ' => 2
+    print mock.calls[1].count() ' => 2
+    print mock.calls[1][0] ' => "second string"
+    print mock.calls[1][1] ' => 456
+    print mock.results.count() ' => 2
+    print mock.results[1] ' => "mocked implementation!"
 
-    spy.clearMock()
-    print spy.calls.count() ' => 0
-    print spy.results.count() ' => 0
+    mock.clearMock()
+    print mock.calls.count() ' => 0
+    print mock.results.count() ' => 0
 end sub
 
 function mockMe()

--- a/test/e2e/resources/components/scripts/BrsMockFunctions.brs
+++ b/test/e2e/resources/components/scripts/BrsMockFunctions.brs
@@ -40,6 +40,8 @@ sub init()
         return "mocked implementation!"
     end function)
 
+    print spy.getMockName() ' => "spyOnMe"
+
     spyOnMe("first string", 123)
     print spy.calls.count() ' => 1
     print spy.calls[0].count() ' => 2

--- a/test/e2e/resources/components/scripts/BrsMockFunctions.brs
+++ b/test/e2e/resources/components/scripts/BrsMockFunctions.brs
@@ -57,6 +57,10 @@ sub init()
     print spy.calls[1][1] ' => 456
     print spy.results.count() ' => 2
     print spy.results[1] ' => "mocked implementation!"
+
+    spy.clearMock()
+    print spy.calls.count() ' => 0
+    print spy.results.count() ' => 0
 end sub
 
 function mockMe()

--- a/test/extensions/MockFunction.test.js
+++ b/test/extensions/MockFunction.test.js
@@ -1,5 +1,5 @@
 const brs = require("brs");
-const { ValueKind, Callable, BrsString } = brs.types;
+const { ValueKind, Callable, BrsString, RoSGNode, StdlibArgument } = brs.types;
 const { Interpreter } = require("../../lib/interpreter");
 const { mockFunction } = require("../../lib/extensions/mockFunction");
 
@@ -26,7 +26,79 @@ describe("MockFunction", () => {
                 const mockArgs = [mockName, mock];
                 mockFunction.getAllSignatureMismatches(mockArgs);
                 mockFunction.call(interpreter, ...mockArgs);
-                expect(interpreter.environment.getMockFunction("testfunction")).toBe(mock);
+                expect(interpreter.environment.getMockFunction("testfunction")).toBeInstanceOf(
+                    Callable
+                );
+            });
+        });
+
+        describe("spy", () => {
+            let mockName;
+            let mockImpl;
+            let mockSpy;
+            let mockArgs;
+
+            beforeEach(() => {
+                mockName = new BrsString("testFunction");
+                mockImpl = new Callable("testFunction", {
+                    signature: {
+                        args: [new StdlibArgument("arg", ValueKind.String)],
+                        returns: ValueKind.String,
+                    },
+                    impl: (interpreter, arg) => {
+                        return new BrsString("foo");
+                    },
+                });
+                mockArgs = [mockName, mockImpl];
+                mockFunction.getAllSignatureMismatches(mockArgs);
+                mockSpy = mockFunction.call(interpreter, ...mockArgs);
+            });
+
+            it("should return a MockFunction node", () => {
+                expect(mockSpy).toBeInstanceOf(RoSGNode);
+            });
+
+            it("getMockName", () => {
+                let calculatedName = mockSpy.get(new BrsString("getMockName")).call(interpreter);
+                expect(calculatedName.value).toEqual(mockName.value);
+            });
+
+            it("adds calls", () => {
+                let mockFromInterpreter = interpreter.environment.getMockFunction("testfunction");
+                mockFromInterpreter.getAllSignatureMismatches(mockArgs);
+                mockFromInterpreter.call(interpreter, new BrsString("bar"));
+
+                let calls = mockSpy.get(new BrsString("calls")).getElements();
+                expect(calls.length).toEqual(1);
+
+                let firstCallArgs = calls[0].getElements();
+                expect(firstCallArgs.length).toEqual(1);
+                expect(firstCallArgs[0].value).toEqual("bar");
+            });
+
+            it("adds results", () => {
+                let mockFromInterpreter = interpreter.environment.getMockFunction("testfunction");
+                mockFromInterpreter.getAllSignatureMismatches(mockArgs);
+                mockFromInterpreter.call(interpreter, new BrsString("bar"));
+
+                let results = mockSpy.get(new BrsString("results")).getElements();
+                expect(results.length).toEqual(1);
+                expect(results[0].value).toEqual("foo");
+            });
+
+            it("mockReset", () => {
+                let mockFromInterpreter = interpreter.environment.getMockFunction("testfunction");
+                mockFromInterpreter.getAllSignatureMismatches(mockArgs);
+                mockFromInterpreter.call(interpreter, new BrsString("bar"));
+
+                let mockReset = mockSpy.get(new BrsString("mockReset"));
+                mockReset.getAllSignatureMismatches([new BrsString("mockReset")]);
+                mockReset.call(interpreter);
+
+                let results = mockSpy.get(new BrsString("results")).getElements();
+                let calls = mockSpy.get(new BrsString("calls")).getElements();
+                expect(results.length).toEqual(0);
+                expect(calls.length).toEqual(0);
             });
         });
     });

--- a/test/extensions/MockFunction.test.js
+++ b/test/extensions/MockFunction.test.js
@@ -2,6 +2,7 @@ const brs = require("brs");
 const { ValueKind, Callable, BrsString, RoSGNode, StdlibArgument } = brs.types;
 const { Interpreter } = require("../../lib/interpreter");
 const { mockFunction } = require("../../lib/extensions/mockFunction");
+const { RoAssociativeArray } = require("../../lib/brsTypes/components/RoAssociativeArray");
 
 describe("MockFunction", () => {
     describe("methods", () => {
@@ -54,8 +55,8 @@ describe("MockFunction", () => {
                 mockSpy = mockFunction.call(interpreter, ...mockArgs);
             });
 
-            it("should return a MockFunction node", () => {
-                expect(mockSpy).toBeInstanceOf(RoSGNode);
+            it("should return an associative array", () => {
+                expect(mockSpy).toBeInstanceOf(RoAssociativeArray);
             });
 
             it("getMockName", () => {
@@ -86,14 +87,14 @@ describe("MockFunction", () => {
                 expect(results[0].value).toEqual("foo");
             });
 
-            it("mockReset", () => {
+            it("clearMock", () => {
                 let mockFromInterpreter = interpreter.environment.getMockFunction("testfunction");
                 mockFromInterpreter.getAllSignatureMismatches(mockArgs);
                 mockFromInterpreter.call(interpreter, new BrsString("bar"));
 
-                let mockReset = mockSpy.get(new BrsString("mockReset"));
-                mockReset.getAllSignatureMismatches([new BrsString("mockReset")]);
-                mockReset.call(interpreter);
+                let clearMock = mockSpy.get(new BrsString("clearMock"));
+                clearMock.getAllSignatureMismatches([new BrsString("clearMock")]);
+                clearMock.call(interpreter);
 
                 let results = mockSpy.get(new BrsString("results")).getElements();
                 let calls = mockSpy.get(new BrsString("calls")).getElements();


### PR DESCRIPTION
# Change Summary

This implements a `MockFunction` spy that gets returned from `_brs_.mockFunction`. The spy keeps track of the calls and return values of the mocked function. The API for it is inspired by [Jest's mockFn API](https://jestjs.io/docs/en/mock-function-api).