### PR TITLE
fix(test): remove .only from test case

### DIFF
--- a/test/e2e/BrsMock.test.js
+++ b/test/e2e/BrsMock.test.js
@@ -51,7 +51,7 @@ describe("end to end brightscript functions", () => {
         ]);
     });
 
-    test.only("mock-functions-main.brs", async () => {
+    test("mock-functions-main.brs", async () => {
         let consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
         await execute([resourceFile("mock-functions-main.brs")], outputStreams);
 


### PR DESCRIPTION
# Change Summary

Removes the `.only` that I mistakenly left in the code in #541 😢 