### PR TITLE
fix: minor naming collision with eslint/estree spec

### DIFF
--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -77,7 +77,7 @@ export class Function extends AstNode implements Expression {
         readonly keyword: Token,
         readonly endKeyword: Token
     ) {
-        super("Function");
+        super("Expr_Function");
     }
 
     accept<R>(visitor: Visitor<R>): R {

--- a/src/parser/Expression.ts
+++ b/src/parser/Expression.ts
@@ -75,7 +75,7 @@ export class Function extends AstNode implements Expression {
         readonly returns: ValueKind,
         readonly body: Block,
         readonly keyword: Token,
-        readonly end: Token
+        readonly endKeyword: Token
     ) {
         super("Function");
     }
@@ -88,7 +88,7 @@ export class Function extends AstNode implements Expression {
         return {
             file: this.keyword.location.file,
             start: this.keyword.location.start,
-            end: this.end.location.end,
+            end: this.endKeyword.location.end,
         };
     }
 }

--- a/src/parser/Statement.ts
+++ b/src/parser/Statement.ts
@@ -38,7 +38,7 @@ let statementTypes = new Set<string>([
     "For",
     "ForEach",
     "While",
-    "Function",
+    "Stmt_Function",
     "Return",
     "DottedSet",
     "IndexedSet",
@@ -52,9 +52,6 @@ let statementTypes = new Set<string>([
  * @param obj object to check
  */
 export function isStatement(obj: Expr.Expression | Statement): obj is Statement {
-    if (obj.type === "Function") {
-        return obj instanceof Function;
-    }
     return statementTypes.has(obj.type);
 }
 
@@ -180,7 +177,7 @@ export class ExitWhile extends AstNode implements Statement {
 
 export class Function extends AstNode implements Statement {
     constructor(readonly name: Identifier, readonly func: Expr.Function) {
-        super("Function");
+        super("Stmt_Function");
     }
 
     accept<R>(visitor: Visitor<R>): BrsType {

--- a/test/e2e/__snapshots__/Coverage.test.js.snap
+++ b/test/e2e/__snapshots__/Coverage.test.js.snap
@@ -160,13 +160,13 @@ Object {
     },
   },
   "f": Object {
-    "expr:Function:9,13-11,15": 1,
-    "stmt:Function:17,0-19,7": 0,
-    "stmt:Function:2,0-14,7": 1,
-    "stmt:Function:22,0-44,7": 1,
+    "expr:Expr_Function:9,13-11,15": 1,
+    "stmt:Stmt_Function:17,0-19,7": 0,
+    "stmt:Stmt_Function:2,0-14,7": 1,
+    "stmt:Stmt_Function:22,0-44,7": 1,
   },
   "fnMap": Object {
-    "expr:Function:9,13-11,15": Object {
+    "expr:Expr_Function:9,13-11,15": Object {
       "decl": Object {
         "end": Object {
           "column": 16,
@@ -192,7 +192,7 @@ Object {
       },
       "name": "[Function]",
     },
-    "stmt:Function:17,0-19,7": Object {
+    "stmt:Stmt_Function:17,0-19,7": Object {
       "decl": Object {
         "end": Object {
           "column": 14,
@@ -218,7 +218,7 @@ Object {
       },
       "name": "unusedFunc",
     },
-    "stmt:Function:2,0-14,7": Object {
+    "stmt:Stmt_Function:2,0-14,7": Object {
       "decl": Object {
         "end": Object {
           "column": 8,
@@ -244,7 +244,7 @@ Object {
       },
       "name": "main",
     },
-    "stmt:Function:22,0-44,7": Object {
+    "stmt:Stmt_Function:22,0-44,7": Object {
       "decl": Object {
         "end": Object {
           "column": 12,

--- a/test/parser/controlFlow/__snapshots__/If.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/If.test.js.snap
@@ -1881,7 +1881,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -2309,7 +2309,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -6089,7 +6089,7 @@ Array [
               ],
               "type": "Block",
             },
-            "end": Object {
+            "endKeyword": Object {
               "isReserved": false,
               "kind": "EndSub",
               "literal": undefined,
@@ -6578,7 +6578,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,

--- a/test/parser/controlFlow/__snapshots__/If.test.js.snap
+++ b/test/parser/controlFlow/__snapshots__/If.test.js.snap
@@ -1917,7 +1917,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -1936,7 +1936,7 @@ Array [
       },
       "text": "a",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -2345,7 +2345,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -2364,7 +2364,7 @@ Array [
       },
       "text": "missingendif",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -6125,7 +6125,7 @@ Array [
             },
             "parameters": Array [],
             "returns": 11,
-            "type": "Function",
+            "type": "Expr_Function",
           },
         },
       ],
@@ -6614,7 +6614,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -6633,7 +6633,7 @@ Array [
       },
       "text": "main",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;

--- a/test/parser/expression/__snapshots__/AssociativeArrayLiterals.test.js.snap
+++ b/test/parser/expression/__snapshots__/AssociativeArrayLiterals.test.js.snap
@@ -288,7 +288,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,

--- a/test/parser/expression/__snapshots__/AssociativeArrayLiterals.test.js.snap
+++ b/test/parser/expression/__snapshots__/AssociativeArrayLiterals.test.js.snap
@@ -322,7 +322,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -340,7 +340,7 @@ Array [
       },
       "text": "main",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;

--- a/test/parser/expression/__snapshots__/Call.test.js.snap
+++ b/test/parser/expression/__snapshots__/Call.test.js.snap
@@ -242,7 +242,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -261,7 +261,7 @@ Array [
       },
       "text": "DoThingOne",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
   Function {
     "func": Function {
@@ -316,7 +316,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -335,7 +335,7 @@ Array [
       },
       "text": "DoThingTwo",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -395,7 +395,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -414,7 +414,7 @@ Array [
       },
       "text": "DoThingOne",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
   Function {
     "func": Function {
@@ -469,7 +469,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -488,7 +488,7 @@ Array [
       },
       "text": "DoThingTwo",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;

--- a/test/parser/expression/__snapshots__/Call.test.js.snap
+++ b/test/parser/expression/__snapshots__/Call.test.js.snap
@@ -206,7 +206,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -280,7 +280,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -359,7 +359,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -433,7 +433,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,

--- a/test/parser/expression/__snapshots__/Function.test.js.snap
+++ b/test/parser/expression/__snapshots__/Function.test.js.snap
@@ -95,7 +95,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -189,7 +189,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -502,7 +502,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -685,7 +685,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -909,7 +909,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -1160,7 +1160,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -1295,7 +1295,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -1389,7 +1389,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -1483,7 +1483,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -1618,7 +1618,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -1712,7 +1712,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -2025,7 +2025,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -2208,7 +2208,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -2432,7 +2432,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -2724,7 +2724,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -2826,7 +2826,7 @@ Array [
             ],
             "type": "Block",
           },
-          "end": Object {
+          "endKeyword": Object {
             "isReserved": false,
             "kind": "EndFunction",
             "literal": undefined,

--- a/test/parser/expression/__snapshots__/Function.test.js.snap
+++ b/test/parser/expression/__snapshots__/Function.test.js.snap
@@ -129,7 +129,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -442,7 +442,7 @@ Array [
         },
       ],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -625,7 +625,7 @@ Array [
         },
       ],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -849,7 +849,7 @@ Array [
         },
       ],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -1100,7 +1100,7 @@ Array [
         },
       ],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -1194,7 +1194,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -1329,7 +1329,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -1423,7 +1423,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -1517,7 +1517,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -1652,7 +1652,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -1965,7 +1965,7 @@ Array [
         },
       ],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -2148,7 +2148,7 @@ Array [
         },
       ],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -2372,7 +2372,7 @@ Array [
         },
       ],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -2623,7 +2623,7 @@ Array [
         },
       ],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -2758,7 +2758,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -2860,7 +2860,7 @@ Array [
           },
           "parameters": Array [],
           "returns": 10,
-          "type": "Function",
+          "type": "Expr_Function",
         },
       ],
       "callee": Variable {

--- a/test/parser/statement/__snapshots__/Block.test.js.snap
+++ b/test/parser/statement/__snapshots__/Block.test.js.snap
@@ -246,7 +246,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -383,7 +383,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -770,7 +770,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,

--- a/test/parser/statement/__snapshots__/Block.test.js.snap
+++ b/test/parser/statement/__snapshots__/Block.test.js.snap
@@ -282,7 +282,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -301,7 +301,7 @@ Array [
       },
       "text": "Main",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -419,7 +419,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -438,7 +438,7 @@ Array [
       },
       "text": "Main",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -806,7 +806,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -825,7 +825,7 @@ Array [
       },
       "text": "Main",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;

--- a/test/parser/statement/__snapshots__/Function.test.js.snap
+++ b/test/parser/statement/__snapshots__/Function.test.js.snap
@@ -67,7 +67,7 @@ Object {
           ],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndFunction",
           "literal": undefined,
@@ -182,7 +182,7 @@ Object {
           ],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndFunction",
           "literal": undefined,
@@ -297,7 +297,7 @@ Object {
           ],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndFunction",
           "literal": undefined,
@@ -412,7 +412,7 @@ Object {
           ],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndFunction",
           "literal": undefined,
@@ -492,7 +492,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -787,7 +787,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -952,7 +952,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -1115,7 +1115,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -1348,7 +1348,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -1465,7 +1465,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -1541,7 +1541,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -1664,7 +1664,7 @@ Object {
           ],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -1738,7 +1738,7 @@ Object {
           "statements": Array [],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -1825,7 +1825,7 @@ Object {
           "statements": Array [],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -1899,7 +1899,7 @@ Object {
           "statements": Array [],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -1973,7 +1973,7 @@ Object {
           "statements": Array [],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -2047,7 +2047,7 @@ Object {
           "statements": Array [],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -2127,7 +2127,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -2244,7 +2244,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -2320,7 +2320,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -2615,7 +2615,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -2780,7 +2780,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -2943,7 +2943,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -3223,7 +3223,7 @@ Object {
           ],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndFunction",
           "literal": undefined,
@@ -3297,7 +3297,7 @@ Object {
           "statements": Array [],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,

--- a/test/parser/statement/__snapshots__/Function.test.js.snap
+++ b/test/parser/statement/__snapshots__/Function.test.js.snap
@@ -103,7 +103,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 10,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -122,7 +122,7 @@ Object {
         },
         "text": "StringFunc#",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
     Function {
       "func": Function {
@@ -218,7 +218,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 10,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -237,7 +237,7 @@ Object {
         },
         "text": "IntegerFunc%",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
     Function {
       "func": Function {
@@ -333,7 +333,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 10,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -352,7 +352,7 @@ Object {
         },
         "text": "FloatFunc!",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
     Function {
       "func": Function {
@@ -448,7 +448,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 10,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -467,7 +467,7 @@ Object {
         },
         "text": "DoubleFunc#",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
   ],
 }
@@ -745,7 +745,7 @@ Array [
         },
       ],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -763,7 +763,7 @@ Array [
       },
       "text": "add",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -910,7 +910,7 @@ Array [
         },
       ],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -928,7 +928,7 @@ Array [
       },
       "text": "add2",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -1073,7 +1073,7 @@ Array [
         },
       ],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -1091,7 +1091,7 @@ Array [
       },
       "text": "repeat",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -1306,7 +1306,7 @@ Array [
         },
       ],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -1324,7 +1324,7 @@ Array [
       },
       "text": "add",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -1382,7 +1382,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -1400,7 +1400,7 @@ Array [
       },
       "text": "foo",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -1499,7 +1499,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -1517,7 +1517,7 @@ Array [
       },
       "text": "foo",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -1575,7 +1575,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -1593,7 +1593,7 @@ Array [
       },
       "text": "foo",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -1700,7 +1700,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 10,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -1719,7 +1719,7 @@ Object {
         },
         "text": "Main",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
     Function {
       "func": Function {
@@ -1774,7 +1774,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -1793,7 +1793,7 @@ Object {
         },
         "text": "DoSomething",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
   ],
 }
@@ -1861,7 +1861,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -1880,7 +1880,7 @@ Object {
         },
         "text": "StringSub#",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
     Function {
       "func": Function {
@@ -1935,7 +1935,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -1954,7 +1954,7 @@ Object {
         },
         "text": "IntegerSub%",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
     Function {
       "func": Function {
@@ -2009,7 +2009,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -2028,7 +2028,7 @@ Object {
         },
         "text": "FloatSub!",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
     Function {
       "func": Function {
@@ -2083,7 +2083,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -2102,7 +2102,7 @@ Object {
         },
         "text": "DoubleSub#",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
   ],
 }
@@ -2161,7 +2161,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -2179,7 +2179,7 @@ Array [
       },
       "text": "bar",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -2278,7 +2278,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -2296,7 +2296,7 @@ Array [
       },
       "text": "foo",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -2573,7 +2573,7 @@ Array [
         },
       ],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -2591,7 +2591,7 @@ Array [
       },
       "text": "add",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -2738,7 +2738,7 @@ Array [
         },
       ],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -2756,7 +2756,7 @@ Array [
       },
       "text": "add2",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -2901,7 +2901,7 @@ Array [
         },
       ],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -2919,7 +2919,7 @@ Array [
       },
       "text": "repeat",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -3134,7 +3134,7 @@ Array [
         },
       ],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -3152,7 +3152,7 @@ Array [
       },
       "text": "add",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -3259,7 +3259,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -3278,7 +3278,7 @@ Object {
         },
         "text": "Main",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
     Function {
       "func": Function {
@@ -3333,7 +3333,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -3352,7 +3352,7 @@ Object {
         },
         "text": "DoSomething",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
   ],
 }

--- a/test/parser/statement/__snapshots__/Goto.test.js.snap
+++ b/test/parser/statement/__snapshots__/Goto.test.js.snap
@@ -137,7 +137,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,

--- a/test/parser/statement/__snapshots__/Goto.test.js.snap
+++ b/test/parser/statement/__snapshots__/Goto.test.js.snap
@@ -173,7 +173,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -192,7 +192,7 @@ Array [
       },
       "text": "Main",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;

--- a/test/parser/statement/__snapshots__/Increment.test.js.snap
+++ b/test/parser/statement/__snapshots__/Increment.test.js.snap
@@ -58,7 +58,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,

--- a/test/parser/statement/__snapshots__/Increment.test.js.snap
+++ b/test/parser/statement/__snapshots__/Increment.test.js.snap
@@ -92,7 +92,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -110,7 +110,7 @@ Array [
       },
       "text": "foo",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;

--- a/test/parser/statement/__snapshots__/LibraryStatement.test.js.snap
+++ b/test/parser/statement/__snapshots__/LibraryStatement.test.js.snap
@@ -23,7 +23,7 @@ Object {
           "statements": Array [],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -192,7 +192,7 @@ Object {
           ],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -377,7 +377,7 @@ Object {
           ],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -517,7 +517,7 @@ Object {
           ],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -682,7 +682,7 @@ Object {
           ],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -791,7 +791,7 @@ Object {
           "statements": Array [],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -915,7 +915,7 @@ Object {
           "statements": Array [],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,
@@ -1081,7 +1081,7 @@ Object {
           "statements": Array [],
           "type": "Block",
         },
-        "end": Object {
+        "endKeyword": Object {
           "isReserved": false,
           "kind": "EndSub",
           "literal": undefined,

--- a/test/parser/statement/__snapshots__/LibraryStatement.test.js.snap
+++ b/test/parser/statement/__snapshots__/LibraryStatement.test.js.snap
@@ -59,7 +59,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -78,7 +78,7 @@ Object {
         },
         "text": "main",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
     Library {
       "tokens": Object {
@@ -228,7 +228,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -247,7 +247,7 @@ Object {
         },
         "text": "main",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
   ],
 }
@@ -413,7 +413,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -432,7 +432,7 @@ Object {
         },
         "text": "main",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
   ],
 }
@@ -553,7 +553,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -572,7 +572,7 @@ Object {
         },
         "text": "main",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
   ],
 }
@@ -718,7 +718,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -737,7 +737,7 @@ Object {
         },
         "text": "main",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
   ],
 }
@@ -827,7 +827,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -846,7 +846,7 @@ Object {
         },
         "text": "main",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
   ],
 }
@@ -951,7 +951,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -970,7 +970,7 @@ Object {
         },
         "text": "main",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
   ],
 }
@@ -1117,7 +1117,7 @@ Object {
         },
         "parameters": Array [],
         "returns": 11,
-        "type": "Function",
+        "type": "Expr_Function",
       },
       "name": Object {
         "isReserved": false,
@@ -1136,7 +1136,7 @@ Object {
         },
         "text": "main",
       },
-      "type": "Function",
+      "type": "Stmt_Function",
     },
   ],
 }

--- a/test/parser/statement/__snapshots__/Misc.test.js.snap
+++ b/test/parser/statement/__snapshots__/Misc.test.js.snap
@@ -122,7 +122,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -224,7 +224,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -361,7 +361,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -3534,7 +3534,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,
@@ -4070,7 +4070,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,

--- a/test/parser/statement/__snapshots__/Misc.test.js.snap
+++ b/test/parser/statement/__snapshots__/Misc.test.js.snap
@@ -158,7 +158,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -177,7 +177,7 @@ Array [
       },
       "text": "Main",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -260,7 +260,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -279,7 +279,7 @@ Array [
       },
       "text": "Main",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -397,7 +397,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -416,7 +416,7 @@ Array [
       },
       "text": "Main",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -3570,7 +3570,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -3589,7 +3589,7 @@ Array [
       },
       "text": "Main",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -4106,7 +4106,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -4125,7 +4125,7 @@ Array [
       },
       "text": "Main",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;

--- a/test/parser/statement/__snapshots__/ReturnStatement.test.js.snap
+++ b/test/parser/statement/__snapshots__/ReturnStatement.test.js.snap
@@ -80,7 +80,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -186,7 +186,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -285,7 +285,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,

--- a/test/parser/statement/__snapshots__/ReturnStatement.test.js.snap
+++ b/test/parser/statement/__snapshots__/ReturnStatement.test.js.snap
@@ -114,7 +114,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -132,7 +132,7 @@ Array [
       },
       "text": "foo",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -220,7 +220,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -238,7 +238,7 @@ Array [
       },
       "text": "foo",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;
@@ -319,7 +319,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -337,7 +337,7 @@ Array [
       },
       "text": "foo",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;

--- a/test/parser/statement/__snapshots__/Set.test.js.snap
+++ b/test/parser/statement/__snapshots__/Set.test.js.snap
@@ -223,7 +223,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,
@@ -548,7 +548,7 @@ Array [
         "statements": Array [],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndFunction",
         "literal": undefined,

--- a/test/parser/statement/__snapshots__/Set.test.js.snap
+++ b/test/parser/statement/__snapshots__/Set.test.js.snap
@@ -257,7 +257,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]
@@ -582,7 +582,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 10,
-      "type": "Function",
+      "type": "Expr_Function",
     },
   },
 ]

--- a/test/parser/statement/__snapshots__/Stop.test.js.snap
+++ b/test/parser/statement/__snapshots__/Stop.test.js.snap
@@ -180,7 +180,7 @@ Array [
         ],
         "type": "Block",
       },
-      "end": Object {
+      "endKeyword": Object {
         "isReserved": false,
         "kind": "EndSub",
         "literal": undefined,

--- a/test/parser/statement/__snapshots__/Stop.test.js.snap
+++ b/test/parser/statement/__snapshots__/Stop.test.js.snap
@@ -216,7 +216,7 @@ Array [
       },
       "parameters": Array [],
       "returns": 11,
-      "type": "Function",
+      "type": "Expr_Function",
     },
     "name": Object {
       "isReserved": false,
@@ -235,7 +235,7 @@ Array [
       },
       "text": "Main",
     },
-    "type": "Function",
+    "type": "Stmt_Function",
   },
 ]
 `;


### PR DESCRIPTION
- Rename Function.end to Function.endKeyword

AST nodes should not have a start or end property.
https://github.com/eslint/eslint/pull/8984