### PR TITLE
fix(mocks, stdlib): mocked component callFunc works now

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -545,6 +545,14 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
                 // Only allow public functions (defined in the interface) to be called.
                 if (componentDef && functionname.value in componentDef.functions) {
+                    // Use the mocked component functions instead of the real one, if it's a mocked component.
+                    if (interpreter.environment.isMockedObject(this.nodeSubtype.toLowerCase())) {
+                        let maybeMethod = this.getMethod(functionname.value);
+                        return (
+                            maybeMethod?.call(interpreter, ...functionargs) || BrsInvalid.Instance
+                        );
+                    }
+
                     return interpreter.inSubEnv((subInterpreter) => {
                         let functionToCall = subInterpreter.getCallableFunction(functionname.value);
                         if (!functionToCall) {

--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -275,6 +275,14 @@ export class Environment {
     }
 
     /**
+     * returns true if the variable has a mocked object
+     * @param objName the object to mock
+     */
+    public isMockedObject(objName: string): boolean {
+        return this.mockObjects.has(objName);
+    }
+
+    /**
      * retrieves mocked object if it exists
      * @param objName the object to mock
      */

--- a/test/e2e/CallFunc.test.js
+++ b/test/e2e/CallFunc.test.js
@@ -52,6 +52,8 @@ describe("callFunc", () => {
             "component: inside privateFunction",
             "private return value",
             "component: overriding parent func",
+            "main: mocked component voidFuncNoArgs return value:",
+            "this is a mock",
         ]);
 
         expect(allArgs(outputStreams.stderr.write).filter((arg) => arg !== "\n")).toEqual([

--- a/test/e2e/resources/components/call-func/scripts/main.brs
+++ b/test/e2e/resources/components/call-func/scripts/main.brs
@@ -18,4 +18,13 @@ sub main()
     print node.callFunc("parentFunc")
 
     print node.callFunc("overridenParentFunc")
+
+    _brs_.mockComponent("CallFuncTestbed", {
+        voidFuncNoArgs: function() as string
+            return "this is a mock"
+        end function
+    })
+    node = createObject("RoSGNode", "CallFuncTestbed")
+    result = node.callFunc("voidFuncNoArgs")
+    print "main: mocked component voidFuncNoArgs return value:" result ' => "this is a mock"
 end sub


### PR DESCRIPTION
# Change summary

Yep, you guessed it... more `callFunc` updates! This time, we need to account for mocked components in `callFunc` calls.