### PR TITLE
fix(stdlib): only append flag once to RoRegex

### DIFF
--- a/src/brsTypes/components/RoRegex.ts
+++ b/src/brsTypes/components/RoRegex.ts
@@ -124,7 +124,10 @@ export class RoRegex extends BrsComponent implements BrsValue {
         },
         impl: (interpreter: Interpreter, str: BrsString, replacement: BrsString) => {
             const source = this.jsRegex.source;
-            const flags = this.jsRegex.flags + "g";
+            let flags = this.jsRegex.flags;
+            if (!flags.includes("g")) {
+                flags += "g";
+            }
             this.jsRegex = new RegExp(source, flags);
             const newStr = this.jsRegex[Symbol.replace](str.value, replacement.value);
 
@@ -153,7 +156,10 @@ export class RoRegex extends BrsComponent implements BrsValue {
         },
         impl: (interpreter: Interpreter, str: BrsString) => {
             const source = this.jsRegex.source;
-            const flags = this.jsRegex.flags + "g";
+            let flags = this.jsRegex.flags;
+            if (!flags.includes("g")) {
+                flags += "g";
+            }
             this.jsRegex = new RegExp(source, flags);
             let arr = [];
             let matches: string[] | null;

--- a/test/e2e/resources/components/roRegex.brs
+++ b/test/e2e/resources/components/roRegex.brs
@@ -8,13 +8,15 @@ sub main()
 
     print "Replacing ',' in 2019,03,26 by '-' on first occurrence: " regex.replace("2019,03,26", "-")
     print "Replacing ',' in 2019,03,26 by '-' on all occurrences: " regex.replaceall("2019,03,26", "-")
+    ' make sure we can call replaceall multiple times without error
+    regex.replaceall("2019,03,26", "-")
     parts = regex.split("2019,03,26")
     print "Split by ',': [ " parts[0] " " parts[1] " " parts[2] " ]"
 
     regex = createObject("roRegex", "\d+", "i")
 
     matches = regex.match("123 456 789")
-    print "First match: [ " matches[0] " ]" 
+    print "First match: [ " matches[0] " ]"
 
     matches = regex.matchall("123 456 789")
     print "All matches: [ "
@@ -22,4 +24,7 @@ sub main()
     print "[ " matches[1][0] " ]"
     print "[ " matches[2][0] " ]"
     print " ]"
+
+    ' make sure we can call matchall multiple times without error.
+    regex.matchall("123 456 789")
 end sub


### PR DESCRIPTION
# Change summary

Previously, if you tried to call `RoRegex#matchAll` or `RoRegex:replaceAll` multiple times using the same `RoRegex` instance, a Javascript error would be thrown because the `g` flag appeared multiple times in the Javascript regex constructor. This PR fixes that.