### PR TITLE
fix(manifest): BREAKING-CHANGE Prevent precision loss in parsed manifest

### DIFF
--- a/src/preprocessor/Manifest.ts
+++ b/src/preprocessor/Manifest.ts
@@ -2,11 +2,14 @@ import * as fs from "fs";
 import * as path from "path";
 import { promisify } from "util";
 
-const access = promisify(fs.access);
 const readFile = promisify(fs.readFile);
 
-/** The set of possible value types in a `manifest` file's `key=value` pair. */
-export type ManifestValue = number | string | boolean;
+/**
+ * The set of possible value types in a `manifest` file's `key=value` pair.
+ *
+ * While numbers are allowed, they're not parsed here to avoid loss of precision.
+ */
+export type ManifestValue = string | boolean;
 
 /** A map containing the data from a `manifest` file. */
 export type Manifest = Map<string, ManifestValue>;
@@ -90,13 +93,7 @@ export function parseManifest(contents: string) {
                 return [key, false];
             }
 
-            let maybeNumber = Number(value);
-
-            // if it's not a number, it's just a string
-            if (Number.isNaN(maybeNumber)) {
-                return [key, value];
-            }
-            return [key, maybeNumber];
+            return [key, value];
         });
 
     return new Map<string, ManifestValue>(keyValuePairs);

--- a/test/preprocessor/Manifest.test.js
+++ b/test/preprocessor/Manifest.test.js
@@ -66,8 +66,8 @@ describe("manifest support", () => {
                 new Map([
                     ["foo", "bar=baz"],
                     ["lorem", true],
-                    ["five", 5],
-                    ["six", 6],
+                    ["five", "5"],
+                    ["six", "6.000"],
                     ["version", "1.2.3"],
                 ])
             );


### PR DESCRIPTION
Numbers are allowed in RBI's `manifest` file, but `brs` used to lose precision by parsing them as numbers.  This caused some subtle differences when a `manifest` was re-serialized after parsing, in which `1.0` was represented only as `1`.  It's unclear whether or not this caused issues with applications run in RBI using that rewritten `manifest`, but this was originally reported back in July 2019.  Stop parsing `manifest` values as numbers to prevent precision loss.

fixes #279