### PR TITLE
fix(infra): Rename default branch from `master` to `main`

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -2,10 +2,10 @@
   name: "PR & Push",
   on: {
     push: {
-      branches: [ "master" ]
+      branches: [ "main" ]
     },
     pull_request: {
-      branches: [ "master" ]
+      branches: [ "main" ]
     }
   },
   jobs: {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,6 @@ For guidelines on adding a component to `brs`, see [this doc](docs/AddingCompone
 
 There aren't to many mandatory things for pull requests, besides what you'd expect from any open-source project (e.g. "don't delete all the code", "don't delete a user's home directory at runtime"). The most important project-specific "must-haves" that we'll look for that are:
 
-1. Pull requests should be based on a pretty recent version of the `master` branch, to minimize merge conflicts.
+1. Pull requests should be based on a pretty recent version of the `main` branch, to minimize merge conflicts.
 1. All tests should pass (Travis CI will let us know if any fail).
 1. End to end tests written in BrightScript should be present to exercise the bug or new feature. These don't need to be exhaustive &mdash; just enough to ensure that the major use-cases are covered. More in-depth testing can happen via unit test.

--- a/docs/AddingComponents.md
+++ b/docs/AddingComponents.md
@@ -3,7 +3,7 @@
 This is aimed to be a quick guide for adding a component to `brs`. Note that this may not be comprehensive in all cases, but is a general plan of attack. Here are the steps you should take:
 
 1. Find the documentation for your component on [Roku's developer docs](https://developer.roku.com). For example, the documentation for the `Group` component can be found [here](https://developer.roku.com/en-gb/docs/references/scenegraph/layout-group-nodes/group.md).
-1. Create a file in the [components directory](https://github.com/sjbarag/brs/tree/master/src/brsTypes/components) called `<insert component name>.ts`.
+1. Create a file in the [components directory](https://github.com/sjbarag/brs/tree/main/src/brsTypes/components) called `<insert component name>.ts`.
 1. Copy the following code and paste it into your new file:
 
     ```
@@ -26,9 +26,9 @@ This is aimed to be a quick guide for adding a component to `brs`. Note that thi
     ```
 
 1. Replace all `<insert component name>` and `<insert parent component>` from above with your component name. Add any built-in fields and/or class functions that the Roku docs specify.
-1. Add a constructor definition to the [component factory](https://github.com/sjbarag/brs/blob/master/src/brsTypes/components/ComponentFactory.ts). This will allow instances of your new component to be created dynamically when it is encountered in XML or BrightScript code.
-1. Add a test case for your Typescript class in [the components test directory](https://github.com/sjbarag/brs/tree/master/test/brsTypes/components). Use the existing component test files in that directory as a model for what your test should look like.
+1. Add a constructor definition to the [component factory](https://github.com/sjbarag/brs/blob/main/src/brsTypes/components/ComponentFactory.ts). This will allow instances of your new component to be created dynamically when it is encountered in XML or BrightScript code.
+1. Add a test case for your Typescript class in [the components test directory](https://github.com/sjbarag/brs/tree/main/test/brsTypes/components). Use the existing component test files in that directory as a model for what your test should look like.
 1. Add an end-to-end test case.
-    - Create a file in [the end-to-end directory](https://github.com/sjbarag/brs/tree/master/test/e2e) called `<insert component name>.brs`. In the file, write BrightScript code that exercises your component functionality.
-    - Add an XML file to the [the components test directory](https://github.com/sjbarag/brs/tree/master/test/brsTypes/components) that uses your component.
-    - Add a test block to [BrsComponents.test.js](https://github.com/sjbarag/brs/blob/master/test/e2e/BrsComponents.test.js). In this block, verify that the code from your XML and Brightscript files is behaving as expected.
+    - Create a file in [the end-to-end directory](https://github.com/sjbarag/brs/tree/main/test/e2e) called `<insert component name>.brs`. In the file, write BrightScript code that exercises your component functionality.
+    - Add an XML file to the [the components test directory](https://github.com/sjbarag/brs/tree/main/test/brsTypes/components) that uses your component.
+    - Add a test block to [BrsComponents.test.js](https://github.com/sjbarag/brs/blob/main/test/e2e/BrsComponents.test.js). In this block, verify that the code from your XML and Brightscript files is behaving as expected.


### PR DESCRIPTION
Remove hurtful language by following the example of git [1] and GitHub [2], i.e. rename `master` to `main`.

[1] https://lore.kernel.org/git/pull.783.git.1604829561838.gitgitgadget@gmail.com/
[2] https://github.com/github/renaming