### PR TITLE
feat(rsg): Support adding new BrsObjects at Runtime

### DIFF
--- a/src/brsTypes/components/BrsObjects.ts
+++ b/src/brsTypes/components/BrsObjects.ts
@@ -16,6 +16,7 @@ import { Float } from "../Float";
 import { Int32 } from "../Int32";
 import { Interpreter } from "../../interpreter";
 import { roInvalid } from "./RoInvalid";
+import { BrsComponent } from "./BrsComponent";
 
 /** Map containing a list of brightscript components that can be created. */
 export const BrsObjects = new Map<string, Function>([
@@ -39,3 +40,26 @@ export const BrsObjects = new Map<string, Function>([
     ["roint", (_: Interpreter, literal: Int32) => new roInt(literal)],
     ["roinvalid", (_: Interpreter) => new roInvalid()],
 ]);
+
+/**
+ * Lets another software using BRS as a library to add/overwrite an implementation of a BrsObject.
+ *
+ * This is useful, for example, if another piece of software wanted to implement video playback or Draw2d functionality.
+ *
+ * In each element of the objectList param, it is pair:
+ * [name of the BrsObject (e.g. "roScreen", etc.), function (interpreter, ...additionalArgs) that returns a new object]
+ *
+ * @example
+ *
+ * AddAdditionalBrsObjects([
+ *   ["roScreen", (_interpreter) => {return new roScreen();}]
+ * ])
+ *
+ * @export
+ * @param {[string, Function][]} objectList - array of pairs: [name, constructor function]
+ */
+export function AddAdditionalBrsObjects(objectList: [string, () => BrsComponent][]): void {
+    objectList.forEach(([name, ctor]) => {
+        BrsObjects.set(name.toLowerCase(), ctor);
+    });
+}

--- a/src/brsTypes/components/BrsObjects.ts
+++ b/src/brsTypes/components/BrsObjects.ts
@@ -51,14 +51,13 @@ export const BrsObjects = new Map<string, Function>([
  *
  * @example
  *
- * AddAdditionalBrsObjects([
+ * extendBrsObjects([
  *   ["roScreen", (_interpreter) => {return new roScreen();}]
  * ])
  *
- * @export
- * @param {[string, Function][]} objectList - array of pairs: [name, constructor function]
+ * @param objectList array of pairs: [name, constructor function]
  */
-export function AddAdditionalBrsObjects(objectList: [string, () => BrsComponent][]): void {
+export function extendBrsObjects(objectList: [string, () => BrsComponent][]): void {
     objectList.forEach(([name, ctor]) => {
         BrsObjects.set(name.toLowerCase(), ctor);
     });

--- a/src/brsTypes/components/ComponentFactory.ts
+++ b/src/brsTypes/components/ComponentFactory.ts
@@ -13,6 +13,7 @@ import {
     Scene,
     MiniKeyboard,
     TextEditBox,
+    BrsComponent,
 } from "..";
 
 export enum BrsComponentName {
@@ -34,11 +35,33 @@ export enum BrsComponentName {
 
 // TODO: update with more components as they're implemented.
 export class ComponentFactory {
+    private static additionalComponents = new Map<string, (name: string) => RoSGNode>();
+
+    /**
+     * Adds additional components types to the factory, so other software can extend brs if necessary.
+     * This would allow other software using this to add other node/component types at runtime
+     * For example, adding custom implementations of the built-in types, or
+     * adding additional types (PinPad, BusySpinner, etc) that aren't here yet
+     *
+     * @static
+     * @param {[componentType: string, ctor: (name: string) => RoSGNode][]} types
+     * @memberof ComponentFactory
+     */
+    public static addComponentTypes(types: [string, (name: string) => RoSGNode][]) {
+        types.forEach(([componentType, ctor]) => {
+            this.additionalComponents.set(componentType.toLowerCase(), ctor);
+        });
+    }
+
     public static createComponent(
-        componentType: BrsComponentName,
+        componentType: BrsComponentName | string,
         componentName?: string
     ): RoSGNode | undefined {
         let name = componentName || componentType;
+        const additionalCtor = this.additionalComponents.get(componentType?.toLowerCase());
+        if (additionalCtor) {
+            return additionalCtor(name);
+        }
         switch (componentType) {
             case BrsComponentName.Group:
                 return new Group([], name);
@@ -71,5 +94,21 @@ export class ComponentFactory {
             default:
                 return;
         }
+    }
+
+    /**
+     * Checks to see if teh given component type can be resolved by the Factory
+     * That is, if it is a built in type or has been added at run time.
+     *
+     * @static
+     * @param {(BrsComponentName | string)} componentType
+     * @returns {boolean}
+     * @memberof ComponentFactory
+     */
+    public static canResolveComponentType(componentType: BrsComponentName | string): boolean {
+        return (
+            this.additionalComponents.has(componentType?.toLowerCase()) ||
+            componentType in BrsComponentName
+        );
     }
 }

--- a/src/brsTypes/components/ComponentFactory.ts
+++ b/src/brsTypes/components/ComponentFactory.ts
@@ -44,8 +44,7 @@ export class ComponentFactory {
      * adding additional types (PinPad, BusySpinner, etc) that aren't here yet
      *
      * @static
-     * @param {[componentType: string, ctor: (name: string) => RoSGNode][]} types
-     * @memberof ComponentFactory
+     * @param types Array of pairs of [componentTypeName, construction function], such that when a given componentType is requested, the construction function is called and returns one of those components
      */
     public static addComponentTypes(types: [string, (name: string) => RoSGNode][]) {
         types.forEach(([componentType, ctor]) => {
@@ -97,13 +96,12 @@ export class ComponentFactory {
     }
 
     /**
-     * Checks to see if teh given component type can be resolved by the Factory
+     * Checks to see if the given component type can be resolved by the Factory
      * That is, if it is a built in type or has been added at run time.
      *
      * @static
-     * @param {(BrsComponentName | string)} componentType
-     * @returns {boolean}
-     * @memberof ComponentFactory
+     * @param componentType The name of component to resolve
+     * @returns {boolean} true if that type is resolvable/constructable, false otherwise
      */
     public static canResolveComponentType(componentType: BrsComponentName | string): boolean {
         return (

--- a/src/brsTypes/index.ts
+++ b/src/brsTypes/index.ts
@@ -32,6 +32,7 @@ export * from "./Float";
 export * from "./Double";
 export * from "./BrsInterface";
 export * from "./Callable";
+export * from "./components/BrsComponent";
 export * from "./components/RoDeviceInfo";
 export * from "./components/ComponentFactory";
 export * from "./components/RoArray";

--- a/src/parser/ComponentScopeResolver.ts
+++ b/src/parser/ComponentScopeResolver.ts
@@ -1,7 +1,6 @@
 import { ComponentDefinition, ComponentScript } from "../componentprocessor";
 import * as Stmt from "./Statement";
 import pSettle from "p-settle";
-import { ExitForReason } from "./BlockEndReason";
 import { ComponentFactory } from "../brsTypes";
 
 export class ComponentScopeResolver {
@@ -14,7 +13,7 @@ export class ComponentScopeResolver {
     constructor(
         readonly componentMap: Map<string, ComponentDefinition>,
         readonly parserLexerFn: (filenames: string[]) => Promise<Stmt.Statement[]> // TODO: Remove and just build here?
-    ) { }
+    ) {}
 
     /**
      * Resolves the component functions in scope based on the extends hierarchy.

--- a/src/parser/ComponentScopeResolver.ts
+++ b/src/parser/ComponentScopeResolver.ts
@@ -1,8 +1,8 @@
 import { ComponentDefinition, ComponentScript } from "../componentprocessor";
 import * as Stmt from "./Statement";
-import { BrsComponentName } from "../brsTypes";
 import pSettle from "p-settle";
 import { ExitForReason } from "./BlockEndReason";
+import { ComponentFactory } from "../brsTypes";
 
 export class ComponentScopeResolver {
     private readonly excludedNames: string[] = ["init"];
@@ -14,7 +14,7 @@ export class ComponentScopeResolver {
     constructor(
         readonly componentMap: Map<string, ComponentDefinition>,
         readonly parserLexerFn: (filenames: string[]) => Promise<Stmt.Statement[]> // TODO: Remove and just build here?
-    ) {}
+    ) { }
 
     /**
      * Resolves the component functions in scope based on the extends hierarchy.
@@ -78,7 +78,7 @@ export class ComponentScopeResolver {
         let currentComponent: ComponentDefinition | undefined = component;
         while (currentComponent.extends) {
             // If this is a built-in component, then no work is needed and we can return.
-            if (currentComponent.extends in BrsComponentName) {
+            if (ComponentFactory.canResolveComponentType(currentComponent.extends)) {
                 return Promise.resolve();
             }
 

--- a/src/stdlib/CreateObject.ts
+++ b/src/stdlib/CreateObject.ts
@@ -16,13 +16,22 @@ const AdditionalBrsObjects = new Map<string, Function>();
 /**
  * Lets another software using BRS as a library to add/overwrite an implementation of a BrsObject.
  * This is useful, for example, if another piece of software wanted to implement video playback or Draw2d functionality
+ * In each element of the objectList param, it is pair:
+ * [the name of the BrsObject (e.g. "roScreen", etc.), a function (interpreter, ...additionalArgs) that returns a new object]
+ *
+ * @example
+ *
+ * AddAdditionalBrsObjects([
+ *   ["roScreen", (_interpreter) => {return new roScreen();}]
+ * ])
  *
  * @export
- * @param {string} name - the name of the BrsObject (e.g. "roScreen", etc.)
- * @param {Function} ctor  - a function (interpreter, ...additionalArgs) that returns a new object
+ * @param {[string, Function][]} objectList - array of pairs: [name, constructor function]
  */
-export function AddAdditionalBrsObject(name: string, ctor: Function): void {
-    AdditionalBrsObjects.set(name.toLowerCase(), ctor);
+export function AddAdditionalBrsObjects(objectList: [string, Function][]): void {
+    objectList.forEach(([name, ctor]) => {
+        AdditionalBrsObjects.set(name.toLowerCase(), ctor);
+    });
 }
 
 /** Creates a new instance of a given brightscript component (e.g. roAssociativeArray) */

--- a/src/stdlib/CreateObject.ts
+++ b/src/stdlib/CreateObject.ts
@@ -11,31 +11,6 @@ import { BrsObjects } from "../brsTypes/components/BrsObjects";
 import { Interpreter } from "../interpreter";
 import { MockNode } from "../extensions/MockNode";
 
-const AdditionalBrsObjects = new Map<string, Function>();
-
-/**
- * Lets another software using BRS as a library to add/overwrite an implementation of a BrsObject.
- *
- * This is useful, for example, if another piece of software wanted to implement video playback or Draw2d functionality.
- *
- * In each element of the objectList param, it is pair:
- * [name of the BrsObject (e.g. "roScreen", etc.), function (interpreter, ...additionalArgs) that returns a new object]
- *
- * @example
- *
- * AddAdditionalBrsObjects([
- *   ["roScreen", (_interpreter) => {return new roScreen();}]
- * ])
- *
- * @export
- * @param {[string, Function][]} objectList - array of pairs: [name, constructor function]
- */
-export function AddAdditionalBrsObjects(objectList: [string, Function][]): void {
-    objectList.forEach(([name, ctor]) => {
-        AdditionalBrsObjects.set(name.toLowerCase(), ctor);
-    });
-}
-
 /** Creates a new instance of a given brightscript component (e.g. roAssociativeArray) */
 export const CreateObject = new Callable("CreateObject", {
     signature: {
@@ -64,9 +39,7 @@ export const CreateObject = new Callable("CreateObject", {
         if (possibleMock instanceof RoAssociativeArray) {
             return new MockNode(possibleMock, objToMock);
         }
-        const objNameLookup = objName.value.toLowerCase();
-
-        let ctor = AdditionalBrsObjects.get(objNameLookup) || BrsObjects.get(objNameLookup);
+        let ctor = BrsObjects.get(objName.value.toLowerCase());
 
         return ctor ? ctor(interpreter, ...additionalArgs) : BrsInvalid.Instance;
     },

--- a/src/stdlib/CreateObject.ts
+++ b/src/stdlib/CreateObject.ts
@@ -15,9 +15,11 @@ const AdditionalBrsObjects = new Map<string, Function>();
 
 /**
  * Lets another software using BRS as a library to add/overwrite an implementation of a BrsObject.
- * This is useful, for example, if another piece of software wanted to implement video playback or Draw2d functionality
+ *
+ * This is useful, for example, if another piece of software wanted to implement video playback or Draw2d functionality.
+ *
  * In each element of the objectList param, it is pair:
- * [the name of the BrsObject (e.g. "roScreen", etc.), a function (interpreter, ...additionalArgs) that returns a new object]
+ * [name of the BrsObject (e.g. "roScreen", etc.), function (interpreter, ...additionalArgs) that returns a new object]
  *
  * @example
  *

--- a/test/brsTypes/components/ComponentFactory.test.js
+++ b/test/brsTypes/components/ComponentFactory.test.js
@@ -1,0 +1,59 @@
+const brs = require("brs");
+const { ComponentFactory, RoSGNode, Callable, ValueKind } = brs.types;
+
+describe("ComponentFactory", () => {
+    describe("createComponent", () => {
+        it("returns a properly constructed built in Node with default name", () => {
+            const component = ComponentFactory.createComponent("Rectangle");
+            expect(component.nodeSubtype).toBe("Rectangle");
+            expect(component.name).toBe("Rectangle");
+            expect(component.constructor.name).toBe("Rectangle");
+        });
+        it("returns a properly constructed built in Node with custom name", () => {
+            const component = ComponentFactory.createComponent("Poster", "Foo");
+            expect(component.nodeSubtype).toBe("Foo");
+            expect(component.constructor.name).toBe("Poster");
+        });
+    });
+
+    describe("addComponentType", () => {
+        class Foo extends RoSGNode {
+            constructor(initializedFields = [], name = "Foo") {
+                super([], name);
+                this.name = name;
+
+                this.registerDefaultFields(this.defaultFields);
+                this.registerInitializedFields(initializedFields);
+
+                this.sayHello = new Callable("sayHello", {
+                    signature: {
+                        args: [],
+                        returns: ValueKind.String,
+                    },
+                    impl: (_interpreter) => {
+                        return "Hello world";
+                    },
+                });
+
+                this.registerMethods({
+                    ifHelloWorld: [this.sayHello],
+                });
+            }
+        }
+
+        it("adds a new Component to be constructed", () => {
+            ComponentFactory.addComponentTypes([
+                [
+                    "Foo",
+                    (name) => {
+                        return new Foo([], name);
+                    },
+                ],
+            ]);
+            const component = ComponentFactory.createComponent("Foo");
+            expect(component.nodeSubtype).toBe("Foo");
+            expect(component.name).toBe("Foo");
+            expect(component.constructor.name).toBe("Foo");
+        });
+    });
+});

--- a/test/e2e/CustomComponents.test.js
+++ b/test/e2e/CustomComponents.test.js
@@ -1,0 +1,68 @@
+const { execute } = require("../../lib");
+const { createMockStreams, allArgs } = require("./E2ETests");
+const lolex = require("lolex");
+const brs = require("brs");
+const { RoSGNode, BrsString, Callable, ValueKind } = brs.types;
+const path = require("path");
+
+class Foo extends RoSGNode {
+    constructor(initializedFields = [], name = "Foo") {
+        super([], name);
+        this.name = name;
+
+        this.registerDefaultFields(this.defaultFields);
+        this.registerInitializedFields(initializedFields);
+
+        this.sayHello = new Callable("sayHello", {
+            signature: {
+                args: [],
+                returns: ValueKind.String,
+            },
+            impl: (_interpreter) => {
+                return new BrsString("Foo Says Hello world");
+            },
+        });
+
+        this.registerMethods({
+            ifHelloWorld: [this.sayHello],
+        });
+    }
+}
+
+describe("Extending custom components", () => {
+    let outputStreams;
+    let clock;
+
+    beforeAll(() => {
+        clock = lolex.install({ now: 1547072370937 });
+        brs.types.ComponentFactory.addComponentTypes([["Foo", (name) => new Foo([], name)]]);
+        brs.types.AddAdditionalBrsObjects([["Foo", (_interpreter) => new Foo()]]);
+
+        outputStreams = createMockStreams();
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    afterAll(() => {
+        clock.uninstall();
+        jest.restoreAllMocks();
+    });
+
+    test("components/ExtendCustom.brs", async () => {
+        outputStreams.root = __dirname + "/customResources";
+        let customFile = path.join(
+            __dirname,
+            "customResources",
+            "components",
+            "extendCustomMain.brs"
+        );
+        await execute([customFile], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
+            "ExtendCustom init",
+            "Foo Says Hello world",
+        ]);
+    });
+});

--- a/test/e2e/CustomComponents.test.js
+++ b/test/e2e/CustomComponents.test.js
@@ -31,12 +31,10 @@ class Foo extends RoSGNode {
 
 describe("Extending custom components", () => {
     let outputStreams;
-    let clock;
 
     beforeAll(() => {
-        clock = lolex.install({ now: 1547072370937 });
         brs.types.ComponentFactory.addComponentTypes([["Foo", (name) => new Foo([], name)]]);
-        brs.types.AddAdditionalBrsObjects([["Foo", (_interpreter) => new Foo()]]);
+        brs.types.extendBrsObjects([["Foo", (_interpreter) => new Foo()]]);
 
         outputStreams = createMockStreams();
     });
@@ -46,12 +44,11 @@ describe("Extending custom components", () => {
     });
 
     afterAll(() => {
-        clock.uninstall();
         jest.restoreAllMocks();
     });
 
     test("components/ExtendCustom.brs", async () => {
-        outputStreams.root = __dirname + "/customResources";
+        outputStreams.root = path.join(__dirname, "customResources");
         let customFile = path.join(
             __dirname,
             "customResources",

--- a/test/e2e/customResources/components/ExtendCustom.brs
+++ b/test/e2e/customResources/components/ExtendCustom.brs
@@ -1,0 +1,4 @@
+sub init()
+  print "ExtendCustom init"
+  print m.top.sayHello()
+end sub

--- a/test/e2e/customResources/components/ExtendCustom.xml
+++ b/test/e2e/customResources/components/ExtendCustom.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="ExtendCustom" extends="Foo">
+  <script type="text/brightscript" uri="ExtendCustom.brs" />
+  <interface>
+  </interface>
+  <children>
+  </children>
+</component>

--- a/test/e2e/customResources/components/extendCustomMain.brs
+++ b/test/e2e/customResources/components/extendCustomMain.brs
@@ -1,0 +1,3 @@
+sub Main()
+  node = CreateObject("RoSgNode", "ExtendCustom")
+end sub

--- a/test/stdlib/Runtime.test.js
+++ b/test/stdlib/Runtime.test.js
@@ -36,19 +36,21 @@ describe("global runtime functions", () => {
             class HelloWorld extends BrsComponent {
                 constructor() {
                     super("HelloWorld");
+
+                    this.sayHello = new Callable("sayHello", {
+                        signature: {
+                            args: [],
+                            returns: ValueKind.String,
+                        },
+                        impl: (_interpreter) => {
+                            return "Hello world";
+                        },
+                    });
+
                     this.registerMethods({
                         ifHelloWorld: [this.sayHello],
                     });
                 }
-                sayHello = new Callable("sayHello", {
-                    signature: {
-                        args: [],
-                        returns: ValueKind.String,
-                    },
-                    impl: (interpreter) => {
-                        return "Hello world";
-                    },
-                });
             }
 
             it.only("can return a new object defined at run time", () => {

--- a/test/stdlib/Runtime.test.js
+++ b/test/stdlib/Runtime.test.js
@@ -14,8 +14,9 @@ const {
     ValueKind,
     Callable,
     BrsComponent,
+    BrsObjects,
 } = brs.types;
-const { CreateObject, Type, AddAdditionalBrsObject } = require("../../lib/stdlib");
+const { CreateObject, Type, AddAdditionalBrsObjects } = require("../../lib/stdlib");
 const { Interpreter } = require("../../lib/interpreter");
 
 describe("global runtime functions", () => {
@@ -54,7 +55,7 @@ describe("global runtime functions", () => {
             }
 
             it.only("can return a new object defined at run time", () => {
-                AddAdditionalBrsObject("HelloWorld", (_interpreter) => new HelloWorld());
+                AddAdditionalBrsObjects([["HelloWorld", (_interpreter) => new HelloWorld()]]);
                 let obj = CreateObject.call(interpreter, new BrsString("HelloWorld"));
                 expect(obj.sayHello.call(interpreter)).toEqual("Hello world");
             });

--- a/test/stdlib/Runtime.test.js
+++ b/test/stdlib/Runtime.test.js
@@ -14,9 +14,9 @@ const {
     ValueKind,
     Callable,
     BrsComponent,
-    BrsObjects,
+    AddAdditionalBrsObjects,
 } = brs.types;
-const { CreateObject, Type, AddAdditionalBrsObjects } = require("../../lib/stdlib");
+const { CreateObject, Type } = require("../../lib/stdlib");
 const { Interpreter } = require("../../lib/interpreter");
 
 describe("global runtime functions", () => {
@@ -54,7 +54,7 @@ describe("global runtime functions", () => {
                 }
             }
 
-            it.only("can return a new object defined at run time", () => {
+            it("can return a new object defined at run time", () => {
                 AddAdditionalBrsObjects([["HelloWorld", (_interpreter) => new HelloWorld()]]);
                 let obj = CreateObject.call(interpreter, new BrsString("HelloWorld"));
                 expect(obj.sayHello.call(interpreter)).toEqual("Hello world");

--- a/test/stdlib/Runtime.test.js
+++ b/test/stdlib/Runtime.test.js
@@ -11,8 +11,12 @@ const {
     Float,
     Double,
     Uninitialized,
+    ValueKind,
+    RoString,
+    Callable,
+    BrsComponent,
 } = brs.types;
-const { CreateObject, Type } = require("../../lib/stdlib");
+const { CreateObject, Type, AddAdditionalBrsObject } = require("../../lib/stdlib");
 const { Interpreter } = require("../../lib/interpreter");
 
 describe("global runtime functions", () => {
@@ -27,6 +31,32 @@ describe("global runtime functions", () => {
         it("returns invalid for an undefined BrsObject", () => {
             let obj = CreateObject.call(interpreter, new BrsString("notAnObject"));
             expect(obj).toEqual(BrsInvalid.Instance);
+        });
+
+        describe("AdditionalBrsObjects", () => {
+            class HelloWorld extends BrsComponent {
+                constructor() {
+                    super("HelloWorld");
+                    this.registerMethods({
+                        ifHelloWorld: [this.sayHello],
+                    });
+                }
+                sayHello = new Callable("sayHello", {
+                    signature: {
+                        args: [],
+                        returns: ValueKind.String,
+                    },
+                    impl: (interpreter) => {
+                        return "Hello world";
+                    },
+                });
+            }
+
+            it.only("can return a new object defined at run time", () => {
+                AddAdditionalBrsObject("HelloWorld", (_interpreter) => new HelloWorld());
+                let obj = CreateObject.call(interpreter, new BrsString("HelloWorld"));
+                expect(obj.sayHello.call(interpreter)).toEqual("Hello world");
+            });
         });
     });
 

--- a/test/stdlib/Runtime.test.js
+++ b/test/stdlib/Runtime.test.js
@@ -12,7 +12,6 @@ const {
     Double,
     Uninitialized,
     ValueKind,
-    RoString,
     Callable,
     BrsComponent,
 } = brs.types;

--- a/test/stdlib/Runtime.test.js
+++ b/test/stdlib/Runtime.test.js
@@ -14,7 +14,7 @@ const {
     ValueKind,
     Callable,
     BrsComponent,
-    AddAdditionalBrsObjects,
+    extendBrsObjects,
 } = brs.types;
 const { CreateObject, Type } = require("../../lib/stdlib");
 const { Interpreter } = require("../../lib/interpreter");
@@ -33,7 +33,7 @@ describe("global runtime functions", () => {
             expect(obj).toEqual(BrsInvalid.Instance);
         });
 
-        describe("AdditionalBrsObjects", () => {
+        describe("extendBrsObjects", () => {
             class HelloWorld extends BrsComponent {
                 constructor() {
                     super("HelloWorld");
@@ -55,7 +55,7 @@ describe("global runtime functions", () => {
             }
 
             it("can return a new object defined at run time", () => {
-                AddAdditionalBrsObjects([["HelloWorld", (_interpreter) => new HelloWorld()]]);
+                extendBrsObjects([["HelloWorld", (_interpreter) => new HelloWorld()]]);
                 let obj = CreateObject.call(interpreter, new BrsString("HelloWorld"));
                 expect(obj.sayHello.call(interpreter)).toEqual("Hello world");
             });


### PR DESCRIPTION
This is a series of changes that allow other software using BRS as a library to add new BrsComponents or Scenegraph components (PinPad, BusySpinner, etc) at Runtime.

This is useful, for example, if another piece of software wanted to implement video playback or Draw2d functionality, and then it could do so by implementing those components locally and still leverage the BRS project.

While the BRS project is very useful as a parser/lexer/interpreter, it does not do any emulation or real-world display of Scenegraph nodes. If there were another piece of software the wanted to leverage BRS, but do that display piece, then being able to override/extend the built in implementation would be a good thing.