### PR TITLE
fix(stdlib): wait for async translations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
         throw new Error("Unable to build interpreter.");
     }
 
-    loadTranslationFiles(interpreter, executionOptions.root);
+    await loadTranslationFiles(interpreter, executionOptions.root);
 
     if (executionOptions.generateCoverage) {
         coverageCollector = new CoverageCollector(executionOptions.root, lexerParserFn);

--- a/src/stdlib/Localization.ts
+++ b/src/stdlib/Localization.ts
@@ -61,12 +61,10 @@ export async function loadTranslationFiles(interpreter: Interpreter, rootDir: st
                     let contents = await readFile(filePath, "utf-8");
                     let xmlStr = contents.toString().replace(/\r?\n|\r/g, "");
                     xmlNode = new XmlDocument(xmlStr);
+                    parseTranslations(xmlNode, locale);
                 } catch (err) {
                     interpreter.stderr.write(`Error reading translations file ${filePath}: ${err}`);
-                    return;
                 }
-
-                parseTranslations(xmlNode, locale);
             }
         })
     );

--- a/src/stdlib/Localization.ts
+++ b/src/stdlib/Localization.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import pSettle from "p-settle";
 import { promisify } from "util";
 const readFile = promisify(fs.readFile);
 
@@ -51,22 +52,24 @@ function parseTranslations(xmlNode: XmlDocument, locale: string) {
  * @param rootDir The root package directory
  */
 export async function loadTranslationFiles(interpreter: Interpreter, rootDir: string) {
-    locales.forEach(async (locale) => {
-        const filePath = path.join(rootDir, "locale", locale, "translations.ts");
-        if (fs.existsSync(filePath)) {
-            let xmlNode: XmlDocument;
-            try {
-                let contents = await readFile(filePath, "utf-8");
-                let xmlStr = contents.toString().replace(/\r?\n|\r/g, "");
-                xmlNode = new XmlDocument(xmlStr);
-            } catch (err) {
-                interpreter.stderr.write(`Error reading translations file ${filePath}: ${err}`);
-                return;
-            }
+    await pSettle(
+        Array.from(locales).map(async (locale) => {
+            const filePath = path.join(rootDir, "locale", locale, "translations.ts");
+            if (fs.existsSync(filePath)) {
+                let xmlNode: XmlDocument;
+                try {
+                    let contents = await readFile(filePath, "utf-8");
+                    let xmlStr = contents.toString().replace(/\r?\n|\r/g, "");
+                    xmlNode = new XmlDocument(xmlStr);
+                } catch (err) {
+                    interpreter.stderr.write(`Error reading translations file ${filePath}: ${err}`);
+                    return;
+                }
 
-            parseTranslations(xmlNode, locale);
-        }
-    });
+                parseTranslations(xmlNode, locale);
+            }
+        })
+    );
 }
 
 export const Tr = new Callable("Tr", {


### PR DESCRIPTION
# Change summary

Apparently I forgot how async code works. This fixes how we load the translation files, so that we actually _wait_ for them to load before executing.