### PR TITLE
Fixes many sorting issues with mixed arrays (fixes #591)

### DIFF
--- a/src/brsTypes/components/RoArray.ts
+++ b/src/brsTypes/components/RoArray.ts
@@ -26,8 +26,10 @@ function sortCompare(a: BrsType, b: BrsType, caseInsensitive: boolean = false): 
             }
             // roku does not use locale for sorting strings
             compare = aStr > bStr ? 1 : -1;
-        } else if ((isBrsNumber(a) && isBrsNumber(b)) || (isBrsBoolean(a) && isBrsBoolean(b))) {
+        } else if (isBrsNumber(a) && isBrsNumber(b)) {
             compare = (a as Comparable).greaterThan(b).toBoolean() ? 1 : -1;
+        } else if (isBrsBoolean(a) && isBrsBoolean(b)) {
+            compare = 0;
         } else {
             compare = a > b ? 1 : -1;
         }

--- a/src/brsTypes/components/RoArray.ts
+++ b/src/brsTypes/components/RoArray.ts
@@ -37,7 +37,7 @@ function getTypeSortIndex(a: BrsType): number {
  * @return compare value for array.sort()
  */
 function sortCompare(
-    originalArray: Array<BrsType>,
+    originalArray: BrsType[],
     a: BrsType,
     b: BrsType,
     caseInsensitive: boolean = false,

--- a/src/brsTypes/components/RoArray.ts
+++ b/src/brsTypes/components/RoArray.ts
@@ -27,11 +27,18 @@ function getTypeSortIndex(a: BrsType): number {
     return 3;
 }
 
+/**
+ * Sorts two BrsTypes in the order that ROku would sort them
+ * @param a
+ * @param b
+ * @param caseInsensitive Should strings be compared case insensitively? defaults to false
+ * @param sortInsideTypes Should two numbers or two strings be sorted? defaults to true
+ */
 function sortCompare(
     a: BrsType,
     b: BrsType,
     caseInsensitive: boolean = false,
-    sortInsideTypes = true
+    sortInsideTypes: boolean = true
 ): number {
     let compare = 0;
     if (a !== undefined && b !== undefined) {

--- a/src/brsTypes/components/RoArray.ts
+++ b/src/brsTypes/components/RoArray.ts
@@ -47,8 +47,6 @@ function sortCompare(
     if (a !== undefined && b !== undefined) {
         const aSortOrder = getTypeSortIndex(a);
         const bSortOrder = getTypeSortIndex(b);
-        const aOriginalIndex = originalArray.indexOf(a);
-        const bOriginalIndex = originalArray.indexOf(b);
         if (aSortOrder < bSortOrder) {
             compare = -1;
         } else if (bSortOrder < aSortOrder) {
@@ -68,9 +66,14 @@ function sortCompare(
                 }
                 // roku does not use locale for sorting strings
                 compare = aStr > bStr ? 1 : -1;
-            } else if (aOriginalIndex > -1 && bOriginalIndex > -1) {
+            } else {
                 // everything else is in the same order as the original
-                compare = aOriginalIndex - bOriginalIndex;
+
+                const aOriginalIndex = originalArray.indexOf(a);
+                const bOriginalIndex = originalArray.indexOf(b);
+                if (aOriginalIndex > -1 && bOriginalIndex > -1) {
+                    compare = aOriginalIndex - bOriginalIndex;
+                }
             }
         }
     }
@@ -313,13 +316,13 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
                 const caseInsensitive = flags.toString().indexOf("i") > -1;
                 const originalArrayCopy = [...this.elements];
                 this.elements = this.elements.sort((a, b) => {
-                    var compare = 0;
+                    let compare = 0;
                     if (a instanceof RoAssociativeArray && b instanceof RoAssociativeArray) {
-                        let aHasField = a.elements.has(fieldName.toString().toLowerCase()),
-                            bHasField = b.elements.has(fieldName.toString().toLowerCase());
+                        const aHasField = a.elements.has(fieldName.toString().toLowerCase());
+                        const bHasField = b.elements.has(fieldName.toString().toLowerCase());
                         if (aHasField && bHasField) {
-                            var valueA = a.get(fieldName);
-                            var valueB = b.get(fieldName);
+                            const valueA = a.get(fieldName);
+                            const valueB = b.get(fieldName);
                             compare = sortCompare(
                                 originalArrayCopy,
                                 valueA,

--- a/test/brsTypes/components/RoArray.test.js
+++ b/test/brsTypes/components/RoArray.test.js
@@ -303,11 +303,11 @@ describe("RoArray", () => {
 
         describe("sort", () => {
             it("sorts mixed elements properly", () => {
-                let a = new BrsString("a");
-                let aaa = new BrsString("aaa");
-                let b = new BrsString("b");
-                let baa = new BrsString("baa");
-                let c = new BrsString("c");
+                let strA = new BrsString("a");
+                let strAaa = new BrsString("aaa");
+                let strB = new BrsString("b");
+                let strBaa = new BrsString("baa");
+                let strC = new BrsString("c");
                 let i3 = new Int32(3);
                 let i1 = new Int32(1);
                 let f2_5 = new Float(2.5);
@@ -327,9 +327,9 @@ describe("RoArray", () => {
                 let ar = new RoArray([]);
 
                 let src = new RoArray([
-                    a,
-                    b,
-                    c,
+                    strA,
+                    strB,
+                    strC,
                     i3,
                     aa1,
                     i1,
@@ -338,8 +338,8 @@ describe("RoArray", () => {
                     f2_5,
                     bool_t,
                     ar,
-                    baa,
-                    aaa,
+                    strBaa,
+                    strAaa,
                     aa2,
                     bool_f,
                 ]);
@@ -347,21 +347,21 @@ describe("RoArray", () => {
                 let sort = src.getMethod("sort");
                 expect(sort).toBeTruthy();
                 expect(sort.call(interpreter)).toBe(BrsInvalid.Instance);
-                // numbers in order, strings in order (case sensitive - uppercase first), booleans
+                // numbers in order, strings in order (case sensitive - uppercase first), assocArrays, everything else
                 expect(src.elements).toEqual([
-                    i1,
-                    i2,
-                    f2_5,
-                    i3,
-                    i10,
-                    a,
-                    aaa,
-                    b,
-                    baa,
-                    c,
-                    aa1,
+                    i1, // numbers in order - value = 1
+                    i2, // value = 2
+                    f2_5, // value = 2.5
+                    i3, // value = 3
+                    i10, // value = 10
+                    strA, // strings in order - value = "a"
+                    strAaa, // value = "aaa"
+                    strB, // value = "b"
+                    strBaa, //value = "baa"
+                    strC, // value = "c"
+                    aa1, // assoc arrays in original order
                     aa2,
-                    bool_t,
+                    bool_t, // everything else in original order
                     ar,
                     bool_f,
                 ]);
@@ -729,11 +729,6 @@ describe("RoArray", () => {
             });
 
             it("sorts the array based on AA valid mixed field", () => {
-                let a3 = new RoAssociativeArray([
-                    { name: new BrsString("id"), value: new Int32(3) },
-                    { name: new BrsString("name"), value: new BrsString("Betty") },
-                    { name: new BrsString("data"), value: new BrsString("abc") },
-                ]);
                 let a1 = new RoAssociativeArray([
                     { name: new BrsString("id"), value: new Int32(1) },
                     { name: new BrsString("name"), value: new BrsString("Carol") },
@@ -744,33 +739,56 @@ describe("RoArray", () => {
                     { name: new BrsString("name"), value: new BrsString("anne") },
                     { name: new BrsString("data"), value: new Float(9.5) },
                 ]);
+                let a3 = new RoAssociativeArray([
+                    { name: new BrsString("id"), value: new Int32(3) },
+                    { name: new BrsString("name"), value: new BrsString("Betty") },
+                    { name: new BrsString("data"), value: new BrsString("abc") },
+                ]);
                 let a4 = new RoAssociativeArray([
                     { name: new BrsString("id"), value: new Int32(4) },
                     { name: new BrsString("name"), value: new BrsString("Dave") },
                     { name: new BrsString("data"), value: new BrsBoolean(true) },
                 ]);
-                let a = new BrsString("a");
-                let b = new BrsString("B");
+                let a5 = new RoAssociativeArray([
+                    { name: new BrsString("id"), value: new Int32(5) },
+                    { name: new BrsString("name"), value: new BrsString("Dave") },
+                ]);
+                let strA = new BrsString("a");
+                let strB = new BrsString("B");
                 let boolTrue = new BrsBoolean(true);
+                let boolFalse = new BrsBoolean(false);
                 let arr = new RoArray([]);
                 let i2 = new Int32(2);
                 let i1 = new Int32(1);
-                let boolFalse = new BrsBoolean(false);
-                let src = new RoArray([a3, a4, a1, a2, a, b, boolTrue, arr, i2, i1, boolFalse]);
+                let src = new RoArray([
+                    a3,
+                    a4,
+                    a5,
+                    a1,
+                    a2,
+                    strA,
+                    strB,
+                    boolTrue,
+                    arr,
+                    i2,
+                    i1,
+                    boolFalse,
+                ]);
 
                 let sortBy = src.getMethod("sortBy");
                 expect(sortBy).toBeTruthy();
                 expect(sortBy.call(interpreter, new BrsString("data"))).toBe(BrsInvalid.Instance);
                 expect(src.elements).toEqual([
-                    i2,
+                    i2, // numbers in original order
                     i1,
-                    a,
-                    b,
-                    a2,
-                    a1,
-                    a3,
-                    a4,
-                    boolTrue,
+                    strA, // strings in original order
+                    strB,
+                    a2, // data = 9.5
+                    a1, // data = 10
+                    a3, // data = "abc"
+                    a4, // data = true
+                    a5, // no data property
+                    boolTrue, // everything else in original order
                     arr,
                     boolFalse,
                 ]);

--- a/test/brsTypes/components/RoArray.test.js
+++ b/test/brsTypes/components/RoArray.test.js
@@ -335,9 +335,9 @@ describe("RoArray", () => {
                     i1,
                     i2,
                     i10,
-                    ar,
                     f2_5,
                     bool_t,
+                    ar,
                     baa,
                     aaa,
                     aa2,
@@ -361,8 +361,8 @@ describe("RoArray", () => {
                     c,
                     aa1,
                     aa2,
-                    ar,
                     bool_t,
+                    ar,
                     bool_f,
                 ]);
             });
@@ -751,15 +751,29 @@ describe("RoArray", () => {
                 ]);
                 let a = new BrsString("a");
                 let b = new BrsString("B");
-                let ar = new RoArray([]);
+                let boolTrue = new BrsBoolean(true);
+                let arr = new RoArray([]);
                 let i2 = new Int32(2);
                 let i1 = new Int32(1);
-                let src = new RoArray([a3, a4, a1, a2, a, b, ar, i2, i1]);
+                let boolFalse = new BrsBoolean(false);
+                let src = new RoArray([a3, a4, a1, a2, a, b, boolTrue, arr, i2, i1, boolFalse]);
 
                 let sortBy = src.getMethod("sortBy");
                 expect(sortBy).toBeTruthy();
                 expect(sortBy.call(interpreter, new BrsString("data"))).toBe(BrsInvalid.Instance);
-                expect(src.elements).toEqual([i2, i1, a, b, a2, a1, a3, a4, ar]);
+                expect(src.elements).toEqual([
+                    i2,
+                    i1,
+                    a,
+                    b,
+                    a2,
+                    a1,
+                    a3,
+                    a4,
+                    boolTrue,
+                    arr,
+                    boolFalse,
+                ]);
             });
 
             it("sorts the array based on AA valid numeric field with flags = r", () => {

--- a/test/brsTypes/components/RoArray.test.js
+++ b/test/brsTypes/components/RoArray.test.js
@@ -1,5 +1,5 @@
 const brs = require("brs");
-const { RoArray, RoAssociativeArray, BrsBoolean, BrsString, Int32, BrsInvalid } = brs.types;
+const { RoArray, RoAssociativeArray, BrsBoolean, BrsString, Int32, BrsInvalid, Float } = brs.types;
 const { Interpreter } = require("../../../lib/interpreter");
 const { createMockStreams } = require("../../e2e/E2ETests");
 
@@ -302,6 +302,42 @@ describe("RoArray", () => {
         });
 
         describe("sort", () => {
+            it("sorts number, string and boolean elements properly", () => {
+                let a = new BrsString("a");
+                let aaa = new BrsString("aaa");
+                let b = new BrsString("b");
+                let baa = new BrsString("baa");
+                let c = new BrsString("c");
+                let i3 = new Int32(3);
+                let i1 = new Int32(1);
+                let f2_5 = new Float(2.5);
+                let i2 = new Int32(2);
+                let i10 = new Int32(10);
+                let bool_t = new BrsBoolean(true);
+                let bool_f = new BrsBoolean(false);
+
+                let src = new RoArray([a, b, c, i3, i1, i2, i10, f2_5, baa, aaa, bool_f, bool_t]);
+
+                let sort = src.getMethod("sort");
+                expect(sort).toBeTruthy();
+                expect(sort.call(interpreter)).toBe(BrsInvalid.Instance);
+                // numbers in order, strings in order (case sensitive - uppercase first), booleans (true then false)
+                expect(src.elements).toEqual([
+                    i1,
+                    i2,
+                    f2_5,
+                    i3,
+                    i10,
+                    a,
+                    aaa,
+                    b,
+                    baa,
+                    c,
+                    bool_t,
+                    bool_f,
+                ]);
+            });
+
             it("sorts the elements of the array with no flags", () => {
                 let a = new BrsString("a");
                 let b = new BrsString("B");
@@ -661,6 +697,40 @@ describe("RoArray", () => {
                 expect(sortBy).toBeTruthy();
                 expect(sortBy.call(interpreter, new BrsString("id"))).toBe(BrsInvalid.Instance);
                 expect(src.elements).toEqual([i2, i1, a, b, a1, a2, a3, ar]);
+            });
+
+            it("sorts the array based on AA valid mixed field", () => {
+                let a3 = new RoAssociativeArray([
+                    { name: new BrsString("id"), value: new Int32(3) },
+                    { name: new BrsString("name"), value: new BrsString("Betty") },
+                    { name: new BrsString("data"), value: new BrsString("abc") },
+                ]);
+                let a1 = new RoAssociativeArray([
+                    { name: new BrsString("id"), value: new Int32(1) },
+                    { name: new BrsString("name"), value: new BrsString("Carol") },
+                    { name: new BrsString("data"), value: new Int32(10) },
+                ]);
+                let a2 = new RoAssociativeArray([
+                    { name: new BrsString("id"), value: new Int32(2) },
+                    { name: new BrsString("name"), value: new BrsString("anne") },
+                    { name: new BrsString("data"), value: new Float(9.5) },
+                ]);
+                let a4 = new RoAssociativeArray([
+                    { name: new BrsString("id"), value: new Int32(4) },
+                    { name: new BrsString("name"), value: new BrsString("Dave") },
+                    { name: new BrsString("data"), value: new BrsBoolean(true) },
+                ]);
+                let a = new BrsString("a");
+                let b = new BrsString("B");
+                let ar = new RoArray([]);
+                let i2 = new Int32(2);
+                let i1 = new Int32(1);
+                let src = new RoArray([a3, a4, a1, a2, a, b, ar, i2, i1]);
+
+                let sortBy = src.getMethod("sortBy");
+                expect(sortBy).toBeTruthy();
+                expect(sortBy.call(interpreter, new BrsString("data"))).toBe(BrsInvalid.Instance);
+                expect(src.elements).toEqual([i2, i1, a, b, a2, a1, a3, a4, ar]);
             });
 
             it("sorts the array based on AA valid numeric field with flags = r", () => {

--- a/test/brsTypes/components/RoArray.test.js
+++ b/test/brsTypes/components/RoArray.test.js
@@ -302,7 +302,7 @@ describe("RoArray", () => {
         });
 
         describe("sort", () => {
-            it("sorts number, string and boolean elements properly", () => {
+            it("sorts mixed elements properly", () => {
                 let a = new BrsString("a");
                 let aaa = new BrsString("aaa");
                 let b = new BrsString("b");
@@ -315,13 +315,39 @@ describe("RoArray", () => {
                 let i10 = new Int32(10);
                 let bool_t = new BrsBoolean(true);
                 let bool_f = new BrsBoolean(false);
+                let aa1 = new RoAssociativeArray([
+                    { name: new BrsString("id"), value: new Int32(1) },
+                    { name: new BrsString("name"), value: new BrsString("Carol") },
+                ]);
+                let aa2 = new RoAssociativeArray([
+                    { name: new BrsString("id"), value: new Int32(2) },
+                    { name: new BrsString("name"), value: new BrsString("Betty") },
+                ]);
 
-                let src = new RoArray([a, b, c, i3, i1, i2, i10, f2_5, baa, aaa, bool_f, bool_t]);
+                let ar = new RoArray([]);
+
+                let src = new RoArray([
+                    a,
+                    b,
+                    c,
+                    i3,
+                    aa1,
+                    i1,
+                    i2,
+                    i10,
+                    ar,
+                    f2_5,
+                    bool_t,
+                    baa,
+                    aaa,
+                    aa2,
+                    bool_f,
+                ]);
 
                 let sort = src.getMethod("sort");
                 expect(sort).toBeTruthy();
                 expect(sort.call(interpreter)).toBe(BrsInvalid.Instance);
-                // numbers in order, strings in order (case sensitive - uppercase first), booleans (true then false)
+                // numbers in order, strings in order (case sensitive - uppercase first), booleans
                 expect(src.elements).toEqual([
                     i1,
                     i2,
@@ -333,6 +359,9 @@ describe("RoArray", () => {
                     b,
                     baa,
                     c,
+                    aa1,
+                    aa2,
+                    ar,
                     bool_t,
                     bool_f,
                 ]);


### PR DESCRIPTION
Refactors roArray sort() and sortBy() so it more closely matches what Roku actually does.

Fixes #591

**array.sort()** example: 

```
Brightscript Debugger> 
arr=["a", 1, ["sub", "array"], 9, 10, "B", {obj: "foo"}, {obj: "bar"}, false, "c", true, false]

Brightscript Debugger> 
arr.sort()

Brightscript Debugger> 
?arr
<Component: roArray> =
[
    1
    9
    10
    "B"
    "a"
    "c"
    <Component: roAssociativeArray>
    <Component: roAssociativeArray>
    <Component: roArray>
    false
    true
    false
]

Brightscript Debugger> 
?arr[6]
<Component: roAssociativeArray> =
{
    obj: "foo"
}

Brightscript Debugger> 
?arr[7]
<Component: roAssociativeArray> =
{
    obj: "bar"
}

Brightscript Debugger> 
```

**Mixed Arrays seem to get sorted in this order (tested with Roku OS 9.4):
1. numbers in numeric order
2. strings in alphabetical order,
3. assocArrays in original order
4. everything else in original order**


.... 

here's another example:

```
Brightscript Debugger> 
arr = [{bar:"def"}, {bar:"abc"},{foo: "bar"}, {foo:"abc"},3,2,1,"def", "abc", false, true, false, ["sub","array"], {foo: "buz"}, false]

Brightscript Debugger> 
arr.sort():?arr

<Component: roArray> =
[
    1
    2
    3
    "abc"
    "def"
    <Component: roAssociativeArray>
    <Component: roAssociativeArray>
    <Component: roAssociativeArray>
    <Component: roAssociativeArray>
    <Component: roAssociativeArray>
    false
    true
    false
    <Component: roArray>
    false
]

Brightscript Debugger> 
?arr[5];arr[6]arr[7];arr[8]
<Component: roAssociativeArray> =
{
    bar: "def"
}<Component: roAssociativeArray> =
{
    bar: "abc"
}<Component: roAssociativeArray> =
{
    foo: "bar"
}<Component: roAssociativeArray> =
{
    foo: "abc"
}
```


**SortBy is a little different**


it goes : 

1. numbers in numeric order
2. strings in alphabetical order,
3. assocArrays
   1. any assoc array with the key, sorted by the value with that key
   2. any other assocArray, in original order 
4. everything else in original order


Here's a sortBy() example ---

```
Brightscript Debugger> 
arr = [{bar:"def"}, {bar:"abc"},{foo: "bar"}, {foo:"abc"},3,2,1,"def", "abc", false, true, false, ["sub","array"], {foo: "buz"}, false]

Brightscript Debugger> 
arr.sortBy("foo"):?arr
<Component: roArray> =
[
    3
    2
    1
    "def"
    "abc"
    <Component: roAssociativeArray>
    <Component: roAssociativeArray>
    <Component: roAssociativeArray>
    <Component: roAssociativeArray>
    <Component: roAssociativeArray>
    false
    true
    false
    <Component: roArray>
    false
]

Brightscript Debugger>
?arr[5];arr[6]arr[7];arr[8];arr[9]
<Component: roAssociativeArray> =
{
    foo: "abc"
}<Component: roAssociativeArray> =
{
    foo: "bar"
}<Component: roAssociativeArray> =
{
    foo: "buz"
}<Component: roAssociativeArray> =
{
    bar: "def"
}<Component: roAssociativeArray> =
{
    bar: "abc"
}

```

