### PR TITLE
feat(interp,exts): implement stack trace

### DIFF
--- a/src/extensions/GetStackTrace.ts
+++ b/src/extensions/GetStackTrace.ts
@@ -7,7 +7,7 @@ import {
     Int32,
     BrsInvalid,
     BrsType,
-    isBrsString
+    isBrsString,
 } from "../brsTypes";
 import type { Location } from "../lexer";
 import { Interpreter } from "../interpreter";
@@ -38,29 +38,27 @@ export const GetStackTrace = new Callable("GetStackTrace", {
 
         // Filter out any files that the consumer doesn't want to include
         if (excludePatterns instanceof RoArray) {
-            excludePatterns.getValue().forEach(pattern => {
+            excludePatterns.getValue().forEach((pattern) => {
                 if (isBrsString(pattern)) {
                     let regexFilter = new RegExp(pattern.value);
-                    stack = stack.filter(location => !regexFilter.test(location.file));
+                    stack = stack.filter((location) => !regexFilter.test(location.file));
                 }
             });
         } else if (!(excludePatterns instanceof BrsInvalid)) {
-            interpreter.stderr.write("Patterns to exclude argument must be an roArray")
+            interpreter.stderr.write("Patterns to exclude argument must be an roArray");
         }
 
         return new RoArray(
             stack
                 // Filter out any internal stack traces.
-                .filter(location => !INTERNAL_REGEX_FILTER.test(location.file))
+                .filter((location) => !INTERNAL_REGEX_FILTER.test(location.file))
                 // Remove any duplicate entries that appear next to each other in the stack.
                 .filter((location, index, locations) => {
                     if (index === 0) return true;
-                    let prevLocation = locations[index-1];
+                    let prevLocation = locations[index - 1];
                     return stringifyLocation(prevLocation) !== stringifyLocation(location);
                 })
-                .map((location) => {
-                    return new BrsString(`${location.file}:${location.start.line}:${location.start.column}`);
-                })
+                .map((location) => new BrsString(stringifyLocation(location)))
                 // Get the last item on the stack
                 .slice(-1 * numEntries.getValue())
         );

--- a/src/extensions/GetStackTrace.ts
+++ b/src/extensions/GetStackTrace.ts
@@ -1,0 +1,58 @@
+import {
+    BrsString,
+    RoArray,
+    Callable,
+    ValueKind,
+    StdlibArgument,
+    Int32,
+    BrsInvalid,
+    BrsType,
+    isBrsString,
+    escapeStringForRegex,
+} from "../brsTypes";
+import { Interpreter } from "../interpreter";
+
+const INTERNAL_REGEX_FILTER = /\(internal\)/;
+
+/**
+ * Returns a stack trace in the format:
+ * [
+ *   filename:line:column,
+ *   ...
+ * ]
+ */
+export const GetStackTrace = new Callable("GetStackTrace", {
+    signature: {
+        args: [
+            new StdlibArgument("numEntries", ValueKind.Int32, new Int32(10)),
+            new StdlibArgument("excludePatterns", ValueKind.Dynamic, BrsInvalid.Instance),
+        ],
+        returns: ValueKind.Object,
+    },
+    impl: (interpreter: Interpreter, numEntries: Int32, excludePatterns: BrsType) => {
+        let stack = interpreter.stack;
+
+        // Filter out any files that the consumer doesn't want to include
+        if (excludePatterns instanceof RoArray) {
+            excludePatterns.getValue().forEach(pattern => {
+                if (isBrsString(pattern)) {
+                    let regexFilter = new RegExp(pattern.value);
+                    stack = stack.filter(location => !regexFilter.test(location.file));
+                }
+            });
+        } else if (!(excludePatterns instanceof BrsInvalid)) {
+            interpreter.stderr.write("Patterns to exclude argument must be an roArray")
+        }
+
+        return new RoArray(
+            stack
+                // Filter out any internal stack traces.
+                .filter(location => !INTERNAL_REGEX_FILTER.test(location.file))
+                // Get the last item on the stack
+                .slice(-1 * numEntries.getValue())
+                .map((location) => {
+                    return new BrsString(`${location.file}:${location.start.line}:${location.start.column}`);
+                })
+        );
+    },
+});

--- a/src/extensions/GetStackTrace.ts
+++ b/src/extensions/GetStackTrace.ts
@@ -54,7 +54,12 @@ export const GetStackTrace = new Callable("GetStackTrace", {
                     let prevLocation = locations[index - 1];
                     return !Location.equalTo(location, prevLocation);
                 })
-                .map((location) => new BrsString(`${location.file}:${location.start.line}:${location.start.column}`))
+                .map(
+                    (location) =>
+                        new BrsString(
+                            `${location.file}:${location.start.line}:${location.start.column}`
+                        )
+                )
                 // Get the last item on the stack
                 .slice(-1 * numEntries.getValue())
         );

--- a/src/extensions/GetStackTrace.ts
+++ b/src/extensions/GetStackTrace.ts
@@ -9,14 +9,10 @@ import {
     BrsType,
     isBrsString,
 } from "../brsTypes";
-import type { Location } from "../lexer";
+import { Location } from "../lexer";
 import { Interpreter } from "../interpreter";
 
 const INTERNAL_REGEX_FILTER = /\(internal\)/;
-
-function stringifyLocation(location: Location) {
-    return `${location.file}:${location.start.line}:${location.start.column}`;
-}
 
 /**
  * Returns a stack trace in the format:
@@ -56,9 +52,9 @@ export const GetStackTrace = new Callable("GetStackTrace", {
                 .filter((location, index, locations) => {
                     if (index === 0) return true;
                     let prevLocation = locations[index - 1];
-                    return stringifyLocation(prevLocation) !== stringifyLocation(location);
+                    return !Location.equalTo(location, prevLocation);
                 })
-                .map((location) => new BrsString(stringifyLocation(location)))
+                .map((location) => new BrsString(`${location.file}:${location.start.line}:${location.start.column}`))
                 // Get the last item on the stack
                 .slice(-1 * numEntries.getValue())
         );

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -12,6 +12,7 @@ import {
     resetMockFunction,
 } from "./resetMocks";
 import { triggerKeyEvent } from "./triggerKeyEvent";
+import { GetStackTrace } from "./GetStackTrace";
 
 export const _brs_ = new RoAssociativeArray([
     { name: new BrsString("mockComponent"), value: mockComponent },
@@ -26,4 +27,5 @@ export const _brs_ = new RoAssociativeArray([
     { name: new BrsString("process"), value: Process },
     { name: new BrsString("global"), value: mGlobal },
     { name: new BrsString("triggerKeyEvent"), value: triggerKeyEvent },
+    { name: new BrsString("getStackTrace"), value: GetStackTrace },
 ]);

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -78,6 +78,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     readonly stderr: OutputProxy;
     readonly temporaryVolume: MemoryFileSystem = new MemoryFileSystem();
 
+    stack: Location[] = [];
     location: Location;
 
     /** Allows consumers to observe errors as they're detected. */
@@ -1632,14 +1633,24 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
     evaluate(this: Interpreter, expression: Expr.Expression): BrsType {
         this.location = expression.location;
+        this.stack.push(this.location);
         this.reportCoverageHit(expression);
-        return expression.accept<BrsType>(this);
+
+        let value = expression.accept<BrsType>(this);
+
+        this.stack.pop();
+        return value;
     }
 
     execute(this: Interpreter, statement: Stmt.Statement): BrsType {
         this.location = statement.location;
+        this.stack.push(this.location);
         this.reportCoverageHit(statement);
-        return statement.accept<BrsType>(this);
+
+        let value = statement.accept<BrsType>(this);
+
+        this.stack.pop();
+        return value;
     }
 
     /**

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -1636,9 +1636,13 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         this.stack.push(this.location);
         this.reportCoverageHit(expression);
 
-        let value = expression.accept<BrsType>(this);
+        let value;
+        try {
+            value = expression.accept<BrsType>(this);
+        } finally {
+            this.stack.pop();
+        }
 
-        this.stack.pop();
         return value;
     }
 
@@ -1647,9 +1651,13 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         this.stack.push(this.location);
         this.reportCoverageHit(statement);
 
-        let value = statement.accept<BrsType>(this);
+        let value;
+        try {
+            value = statement.accept<BrsType>(this);
+        } finally {
+            this.stack.pop();
+        }
 
-        this.stack.pop();
         return value;
     }
 

--- a/src/lexer/Token.ts
+++ b/src/lexer/Token.ts
@@ -37,6 +37,16 @@ export interface Location {
     file: string;
 }
 
+export namespace Location {
+    export function equalTo(loc1: Location, loc2: Location) {
+        return loc1.file === loc2.file
+            && loc1.start.line === loc2.start.line
+            && loc1.start.column === loc2.start.column
+            && loc1.end.line === loc2.end.line
+            && loc1.end.column === loc2.end.column;
+    }
+}
+
 /** A line-column pair. */
 type LineAndColumn = {
     /** A *one-indexed* line number. */

--- a/src/lexer/Token.ts
+++ b/src/lexer/Token.ts
@@ -39,11 +39,13 @@ export interface Location {
 
 export namespace Location {
     export function equalTo(loc1: Location, loc2: Location) {
-        return loc1.file === loc2.file
-            && loc1.start.line === loc2.start.line
-            && loc1.start.column === loc2.start.column
-            && loc1.end.line === loc2.end.line
-            && loc1.end.column === loc2.end.column;
+        return (
+            loc1.file === loc2.file &&
+            loc1.start.line === loc2.start.line &&
+            loc1.start.column === loc2.start.column &&
+            loc1.end.line === loc2.end.line &&
+            loc1.end.column === loc2.end.column
+        );
     }
 }
 

--- a/test/e2e/GetStackTrace.test.js
+++ b/test/e2e/GetStackTrace.test.js
@@ -14,12 +14,16 @@ describe("GetStackTrace", () => {
             [
                 resourceFile("components", "stack-trace", "@external", "package", "utils.brs"),
                 resourceFile("components", "stack-trace", "print.brs"),
-                resourceFile("components", "stack-trace", "main.brs")
+                resourceFile("components", "stack-trace", "main.brs"),
             ],
             outputStreams
         );
 
-        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n").map(line => line.replace(process.cwd(), ""))).toEqual([
+        expect(
+            allArgs(outputStreams.stdout.write)
+                .filter((arg) => arg !== "\n")
+                .map((line) => line.replace(process.cwd(), ""))
+        ).toEqual([
             "--- stack ---",
             "/test/e2e/resources/components/stack-trace/main.brs:2:4",
             "/test/e2e/resources/components/stack-trace/@external/package/utils.brs:2:4",

--- a/test/e2e/GetStackTrace.test.js
+++ b/test/e2e/GetStackTrace.test.js
@@ -1,0 +1,41 @@
+const { execute } = require("../../lib");
+const { createMockStreams, resourceFile, allArgs } = require("./E2ETests");
+
+describe("GetStackTrace", () => {
+    let outputStreams;
+
+    beforeAll(() => {
+        outputStreams = createMockStreams();
+        outputStreams.root = __dirname + "/resources";
+    });
+
+    test("components/stack-trace/main.brs", async () => {
+        await execute(
+            [
+                resourceFile("components", "stack-trace", "@external", "package", "utils.brs"),
+                resourceFile("components", "stack-trace", "print.brs"),
+                resourceFile("components", "stack-trace", "main.brs")
+            ],
+            outputStreams
+        );
+
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n").map(line => line.replace(process.cwd(), ""))).toEqual([
+            "--- stack ---",
+            "/test/e2e/resources/components/stack-trace/main.brs:2:4",
+            "/test/e2e/resources/components/stack-trace/@external/package/utils.brs:2:4",
+            "/test/e2e/resources/components/stack-trace/main.brs:6:4",
+            "/test/e2e/resources/components/stack-trace/print.brs:2:4",
+            "/test/e2e/resources/components/stack-trace/print.brs:2:12",
+            "--- stack ---",
+            "/test/e2e/resources/components/stack-trace/print.brs:4:12",
+            "--- stack ---",
+            "/test/e2e/resources/components/stack-trace/main.brs:2:4",
+            "/test/e2e/resources/components/stack-trace/main.brs:6:4",
+            "/test/e2e/resources/components/stack-trace/print.brs:6:4",
+            "/test/e2e/resources/components/stack-trace/print.brs:6:12",
+            "--- stack ---",
+            "/test/e2e/resources/components/stack-trace/main.brs:2:4",
+            "/test/e2e/resources/components/stack-trace/main.brs:6:4",
+        ]);
+    });
+});

--- a/test/e2e/resources/components/stack-trace/@external/package/utils.brs
+++ b/test/e2e/resources/components/stack-trace/@external/package/utils.brs
@@ -1,0 +1,3 @@
+function external()
+    foo()
+end function

--- a/test/e2e/resources/components/stack-trace/main.brs
+++ b/test/e2e/resources/components/stack-trace/main.brs
@@ -1,0 +1,7 @@
+sub main()
+    external()
+end sub
+
+function foo()
+    printStackTrace()
+end function

--- a/test/e2e/resources/components/stack-trace/print.brs
+++ b/test/e2e/resources/components/stack-trace/print.brs
@@ -1,0 +1,18 @@
+function printStackTrace()
+    stack = _brs_.getStackTrace()
+    stackTraceHelper(stack)
+    stack = _brs_.getStackTrace(1)
+    stackTraceHelper(stack)
+    stack = _brs_.getStackTrace(10, ["@external"])
+    stackTraceHelper(stack)
+    stack = _brs_.getStackTrace(10, ["print.brs", "@external"])
+    stackTraceHelper(stack)
+end function
+
+' Helper function for cleaner output in test case.
+function stackTraceHelper(stack)
+    print "--- stack ---"
+    for each line in stack
+        print line
+    end for
+end function

--- a/test/extensions/getStackTrace.test.js
+++ b/test/extensions/getStackTrace.test.js
@@ -61,5 +61,15 @@ describe("GetStackTrace", () => {
             "a/b/c.brs:5:6",
             "test/a/b/c.test.brs:1:2",
         ]);
+
+        result = GetStackTrace.call(
+            interpreter,
+            new Int32(10),
+            new RoArray([new BrsString("package")])
+        );
+        expect(result.getValue().map(line => line.value)).toEqual([
+            "a/b/c.brs:5:6",
+            "test/a/b/c.test.brs:1:2",
+        ]);
     });
 });

--- a/test/extensions/getStackTrace.test.js
+++ b/test/extensions/getStackTrace.test.js
@@ -14,22 +14,22 @@ describe("GetStackTrace", () => {
                 file: "a/b/c.brs",
                 start: {
                     line: 5,
-                    column: 6
-                }
+                    column: 6,
+                },
             },
             {
                 file: "@external/package/utils.brs",
                 start: {
                     line: 3,
-                    column: 4
-                }
+                    column: 4,
+                },
             },
             {
                 file: "test/a/b/c.test.brs",
                 start: {
                     line: 1,
-                    column: 2
-                }
+                    column: 2,
+                },
             },
         ];
     });
@@ -37,7 +37,7 @@ describe("GetStackTrace", () => {
     it("returns a correctly formatted stack trace", () => {
         let result = GetStackTrace.call(interpreter);
         expect(result).toBeInstanceOf(RoArray);
-        expect(result.getValue().map(line => line.value)).toEqual([
+        expect(result.getValue().map((line) => line.value)).toEqual([
             "a/b/c.brs:5:6",
             "@external/package/utils.brs:3:4",
             "test/a/b/c.test.brs:1:2",
@@ -46,9 +46,7 @@ describe("GetStackTrace", () => {
 
     it("returns the correct number of lines when specified", () => {
         let result = GetStackTrace.call(interpreter, new Int32(1));
-        expect(result.getValue().map(line => line.value)).toEqual([
-            "test/a/b/c.test.brs:1:2"
-        ]);
+        expect(result.getValue().map((line) => line.value)).toEqual(["test/a/b/c.test.brs:1:2"]);
     });
 
     it("filters lines correctly", () => {
@@ -57,7 +55,7 @@ describe("GetStackTrace", () => {
             new Int32(10),
             new RoArray([new BrsString("@external/package")])
         );
-        expect(result.getValue().map(line => line.value)).toEqual([
+        expect(result.getValue().map((line) => line.value)).toEqual([
             "a/b/c.brs:5:6",
             "test/a/b/c.test.brs:1:2",
         ]);
@@ -67,7 +65,7 @@ describe("GetStackTrace", () => {
             new Int32(10),
             new RoArray([new BrsString("package")])
         );
-        expect(result.getValue().map(line => line.value)).toEqual([
+        expect(result.getValue().map((line) => line.value)).toEqual([
             "a/b/c.brs:5:6",
             "test/a/b/c.test.brs:1:2",
         ]);

--- a/test/extensions/getStackTrace.test.js
+++ b/test/extensions/getStackTrace.test.js
@@ -1,0 +1,65 @@
+const brs = require("brs");
+const { Int32 } = require("../../lib/brsTypes/Int32");
+const { Callable, BrsString, BrsInvalid, RoArray, RoAssociativeArray, ValueKind } = brs.types;
+const { GetStackTrace } = require("../../lib/extensions/GetStackTrace");
+const { Interpreter } = require("../../lib/interpreter");
+
+describe("GetStackTrace", () => {
+    let interpreter;
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+        interpreter.stack = [
+            {
+                file: "a/b/c.brs",
+                start: {
+                    line: 5,
+                    column: 6
+                }
+            },
+            {
+                file: "@external/package/utils.brs",
+                start: {
+                    line: 3,
+                    column: 4
+                }
+            },
+            {
+                file: "test/a/b/c.test.brs",
+                start: {
+                    line: 1,
+                    column: 2
+                }
+            },
+        ];
+    });
+
+    it("returns a correctly formatted stack trace", () => {
+        let result = GetStackTrace.call(interpreter);
+        expect(result).toBeInstanceOf(RoArray);
+        expect(result.getValue().map(line => line.value)).toEqual([
+            "a/b/c.brs:5:6",
+            "@external/package/utils.brs:3:4",
+            "test/a/b/c.test.brs:1:2",
+        ]);
+    });
+
+    it("returns the correct number of lines when specified", () => {
+        let result = GetStackTrace.call(interpreter, new Int32(1));
+        expect(result.getValue().map(line => line.value)).toEqual([
+            "test/a/b/c.test.brs:1:2"
+        ]);
+    });
+
+    it("filters lines correctly", () => {
+        let result = GetStackTrace.call(
+            interpreter,
+            new Int32(10),
+            new RoArray([new BrsString("@external/package")])
+        );
+        expect(result.getValue().map(line => line.value)).toEqual([
+            "a/b/c.brs:5:6",
+            "test/a/b/c.test.brs:1:2",
+        ]);
+    });
+});


### PR DESCRIPTION
# Summary

This implements an extension `_brs_.getStackTrace`, which, as you might expect, gets the stack trace.

Also, I cleaned up the `README` a little -- reorganized the extensions alphabetically.