### PR TITLE
Reverse stack trace

### DIFF
--- a/src/extensions/GetStackTrace.ts
+++ b/src/extensions/GetStackTrace.ts
@@ -62,6 +62,7 @@ export const GetStackTrace = new Callable("GetStackTrace", {
                 )
                 // Get the last item on the stack
                 .slice(-1 * numEntries.getValue())
+                .reverse()
         );
     },
 });

--- a/test/e2e/GetStackTrace.test.js
+++ b/test/e2e/GetStackTrace.test.js
@@ -25,21 +25,21 @@ describe("GetStackTrace", () => {
                 .map((line) => line.replace(process.cwd(), ""))
         ).toEqual([
             "--- stack ---",
-            "/test/e2e/resources/components/stack-trace/main.brs:2:4",
-            "/test/e2e/resources/components/stack-trace/@external/package/utils.brs:2:4",
-            "/test/e2e/resources/components/stack-trace/main.brs:6:4",
-            "/test/e2e/resources/components/stack-trace/print.brs:2:4",
             "/test/e2e/resources/components/stack-trace/print.brs:2:12",
+            "/test/e2e/resources/components/stack-trace/print.brs:2:4",
+            "/test/e2e/resources/components/stack-trace/main.brs:6:4",
+            "/test/e2e/resources/components/stack-trace/@external/package/utils.brs:2:4",
+            "/test/e2e/resources/components/stack-trace/main.brs:2:4",
             "--- stack ---",
             "/test/e2e/resources/components/stack-trace/print.brs:4:12",
             "--- stack ---",
-            "/test/e2e/resources/components/stack-trace/main.brs:2:4",
-            "/test/e2e/resources/components/stack-trace/main.brs:6:4",
-            "/test/e2e/resources/components/stack-trace/print.brs:6:4",
             "/test/e2e/resources/components/stack-trace/print.brs:6:12",
-            "--- stack ---",
-            "/test/e2e/resources/components/stack-trace/main.brs:2:4",
+            "/test/e2e/resources/components/stack-trace/print.brs:6:4",
             "/test/e2e/resources/components/stack-trace/main.brs:6:4",
+            "/test/e2e/resources/components/stack-trace/main.brs:2:4",
+            "--- stack ---",
+            "/test/e2e/resources/components/stack-trace/main.brs:6:4",
+            "/test/e2e/resources/components/stack-trace/main.brs:2:4",
         ]);
     });
 });

--- a/test/extensions/getStackTrace.test.js
+++ b/test/extensions/getStackTrace.test.js
@@ -38,9 +38,9 @@ describe("GetStackTrace", () => {
         let result = GetStackTrace.call(interpreter);
         expect(result).toBeInstanceOf(RoArray);
         expect(result.getValue().map((line) => line.value)).toEqual([
-            "a/b/c.brs:5:6",
-            "@external/package/utils.brs:3:4",
             "test/a/b/c.test.brs:1:2",
+            "@external/package/utils.brs:3:4",
+            "a/b/c.brs:5:6",
         ]);
     });
 
@@ -56,8 +56,8 @@ describe("GetStackTrace", () => {
             new RoArray([new BrsString("@external/package")])
         );
         expect(result.getValue().map((line) => line.value)).toEqual([
-            "a/b/c.brs:5:6",
             "test/a/b/c.test.brs:1:2",
+            "a/b/c.brs:5:6",
         ]);
 
         result = GetStackTrace.call(
@@ -66,8 +66,8 @@ describe("GetStackTrace", () => {
             new RoArray([new BrsString("package")])
         );
         expect(result.getValue().map((line) => line.value)).toEqual([
-            "a/b/c.brs:5:6",
             "test/a/b/c.test.brs:1:2",
+            "a/b/c.brs:5:6",
         ]);
     });
 });


### PR DESCRIPTION
# Change summary

It probably makes more sense for the stack trace to be formatted so that the 0th element is the most recent. It allows for easier traversal for consumers. This also lines up with [Javascript error stack](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack), for example.