### PR TITLE
fix(interp): Don't modify defaultExecutionOptions after creation

### DIFF
--- a/src/LexerParser.ts
+++ b/src/LexerParser.ts
@@ -18,7 +18,7 @@ export function getLexerParserFn(
     manifest: Map<string, ManifestValue>,
     options: Partial<ExecutionOptions>
 ) {
-    const executionOptions = Object.assign(defaultExecutionOptions, options);
+    const executionOptions = { ...defaultExecutionOptions, ...options };
     /**
      * Map file URIs to promises. The promises resolve to an array of that file's statements.
      * This allows us to only parse each file once.

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
 }
 
 async function loadFiles(options: Partial<ExecutionOptions>) {
-    const executionOptions = Object.assign(defaultExecutionOptions, options);
+    const executionOptions = { ...defaultExecutionOptions, ...options };
 
     let manifest = await PP.getManifest(executionOptions.root);
     let maybeLibraryName = options.isComponentLibrary
@@ -143,7 +143,8 @@ async function loadFiles(options: Partial<ExecutionOptions>) {
     let lexerParserFn = LexerParser.getLexerParserFn(manifest, options);
     const interpreter = await Interpreter.withSubEnvsFromComponents(
         componentDefinitions,
-        lexerParserFn
+        lexerParserFn,
+        executionOptions
     );
     if (!interpreter) {
         throw new Error("Unable to build interpreter.");
@@ -182,7 +183,7 @@ export function getCoverageResults() {
  * @returns the AST produced from lexing and parsing the provided files
  */
 export function lexParseSync(filenames: string[], options: Partial<ExecutionOptions>) {
-    const executionOptions = Object.assign(defaultExecutionOptions, options);
+    const executionOptions = { ...defaultExecutionOptions, ...options };
 
     let manifest = PP.getManifestSync(executionOptions.root);
 

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -68,6 +68,7 @@ export const defaultExecutionOptions: ExecutionOptions = {
     componentDirs: [],
     isComponentLibrary: false,
 };
+Object.freeze(defaultExecutionOptions);
 
 export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType> {
     private _environment = new Environment();


### PR DESCRIPTION
Using `Object.assign()` without an initial `{}` overwrote values in `defaultExecutionOptions` in a "last overwrite wins" pattern.  This caused the produced interpreter to execute functions like `ListFiles()` relative to the temporary directory the final component library is unzipped into, rather than relative to the process's current working directory.

Use the object spread syntax instead of `Object.assign()` since it's harder to get wrong, and freeze the `defaultExecutionOptions` variable after creation to prevent accidental modification.