### PR TITLE
fix(interpreter): allow dynamic functions to return void

### DIFF
--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -1114,7 +1114,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                     );
                 }
 
-                if (!returnedValue && satisfiedSignature.signature.returns !== ValueKind.Void) {
+                if (!returnedValue && satisfiedSignature.signature.returns !== ValueKind.Void && satisfiedSignature.signature.returns !== ValueKind.Dynamic) {
                     this.addError(
                         new Stmt.Runtime(
                             `Attempting to return void value from function ${callee.getName()} with non-void return type.`,

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -1114,7 +1114,11 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                     );
                 }
 
-                if (!returnedValue && satisfiedSignature.signature.returns !== ValueKind.Void && satisfiedSignature.signature.returns !== ValueKind.Dynamic) {
+                if (
+                    !returnedValue &&
+                    satisfiedSignature.signature.returns !== ValueKind.Void &&
+                    satisfiedSignature.signature.returns !== ValueKind.Dynamic
+                ) {
                     this.addError(
                         new Stmt.Runtime(
                             `Attempting to return void value from function ${callee.getName()} with non-void return type.`,

--- a/test/interpreter/Call.test.js
+++ b/test/interpreter/Call.test.js
@@ -298,4 +298,37 @@ describe("interpreter calls", () => {
 
         expect(() => interpreter.exec(ast)).toThrow(/Attempting to return void value/);
     });
+
+    it("allows dynamic functions to not return a value", () => {
+        const ast = [
+            new Stmt.Function(
+                identifier("foo"),
+                new Expr.Function(
+                    [],
+                    ValueKind.Dynamic,
+                    new Stmt.Block(
+                        [new Stmt.Return({ return: token(Lexeme.Return, "return") })],
+                        token(Lexeme.Newline, "\n")
+                    ),
+                    FUNCTION,
+                    END_FUNCTION
+                )
+            ),
+            new Stmt.Assignment(
+                { equals: token(Lexeme.Equals, "=") },
+                identifier("result"),
+                new Stmt.Expression(
+                    new Expr.Call(
+                        new Expr.Variable(identifier("foo")),
+                        token(Lexeme.RightParen, ")"),
+                        [] // no args required
+                    )
+                )
+            ),
+        ];
+
+        interpreter.exec(ast);
+        let result = interpreter.environment.get(identifier("result"));
+        expect(result).toEqual(BrsInvalid.Instance);
+    });
 });


### PR DESCRIPTION
# Change Summary

Currently, when a function uses `return` without a value, we treat it as returning `void`. This is a problem for functions with a `dynamic` return type, because void is currently not accepted as a valid return type for dynamic functions. This PR enables `dynamic` functions to accept `void` as a return type.

Alternatively, we could instead evaluate `return` as `return invalid`; but this would require additional logic to handle this case for `sub`s, which (because they're void functions) are _only_ supposed to accept void return types.