### PR TITLE
feat(execution): create function to execute with scope

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,7 @@ export async function createExecuteWithScope(
         let returnValue = interpreter.inSubEnv((subInterpreter) => {
             let value = subInterpreter.exec(ast, ...args)[0] || BrsTypes.BrsInvalid.Instance;
             execErrors = subInterpreter.errors;
+            subInterpreter.errors = [];
             return value;
         });
 

--- a/test/e2e/createExecuteWithScope.test.js
+++ b/test/e2e/createExecuteWithScope.test.js
@@ -1,0 +1,76 @@
+const brs = require("brs");
+const { createExecuteWithScope } = brs;
+const { RoArray, BrsString } = brs.types;
+let { createMockStreams, resourceFile, allArgs } = require("./E2ETests");
+
+resourceFile = resourceFile.bind(null, "execute-with-scope");
+
+describe("createExecuteWithScope", () => {
+    let outputStreams;
+
+    beforeAll(() => {
+        outputStreams = createMockStreams();
+        outputStreams.root = __dirname + "/resources";
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("returns a function that executes a file", async () => {
+        let execute = await createExecuteWithScope([resourceFile("in-scope.brs")], outputStreams);
+
+        expect(execute).toBeTruthy();
+
+        let returnValue = execute([resourceFile("main.brs")], [new BrsString("argz4main")]);
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
+            "main:arg:argz4main",
+            "main:commonUtil",
+            "main:onlyInScopeForMain",
+        ]);
+        expect(returnValue).toBeInstanceOf(BrsString);
+        expect(returnValue.value).toEqual("main return value");
+    });
+
+    test("code defined in earlier execution calls is not accessible to subsequent executions", async () => {
+        let execute = await createExecuteWithScope([resourceFile("in-scope.brs")], outputStreams);
+
+        // main defines a function
+        execute([resourceFile("main.brs")], [new BrsString("argz4main")]);
+
+        // main2 tries to call that function, and fails
+        expect(() => execute([resourceFile("main2.brs")], [])).toThrow();
+
+        // the output from both files should be there
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
+            "main:arg:argz4main",
+            "main:commonUtil",
+            "main:onlyInScopeForMain",
+            "main2:commonUtil",
+        ]);
+    });
+
+    test("interpreter errors in earlier executions don't affect subsequent executions", async () => {
+        let execute = await createExecuteWithScope([resourceFile("in-scope.brs")], outputStreams);
+
+        // main2 throws an error
+        expect(() => execute([resourceFile("main2.brs")], [])).toThrow();
+
+        // main should be error-free still
+        expect(() =>
+            execute([resourceFile("main.brs")], [new BrsString("argz4main")])
+        ).not.toThrow();
+
+        // the output from both files should be there
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
+            "main2:commonUtil",
+            "main:arg:argz4main",
+            "main:commonUtil",
+            "main:onlyInScopeForMain",
+        ]);
+    });
+});

--- a/test/e2e/resources/execute-with-scope/in-scope.brs
+++ b/test/e2e/resources/execute-with-scope/in-scope.brs
@@ -1,0 +1,3 @@
+function commonUtil()
+    return "commonUtil"
+end function

--- a/test/e2e/resources/execute-with-scope/main.brs
+++ b/test/e2e/resources/execute-with-scope/main.brs
@@ -1,0 +1,11 @@
+function main(arg)
+    print "main:arg:" + arg
+    print "main:" + commonUtil()
+    print "main:" + onlyInScopeForMain()
+
+    return "main return value"
+end function
+
+function onlyInScopeForMain()
+    return "onlyInScopeForMain"
+end function

--- a/test/e2e/resources/execute-with-scope/main2.brs
+++ b/test/e2e/resources/execute-with-scope/main2.brs
@@ -1,0 +1,4 @@
+sub main()
+    print "main2:" + commonUtil()
+    print "main2:" + onlyInScopeForMain()
+end sub


### PR DESCRIPTION
# Change Summary

This creates a function that generates an "execution scope" by executing a given set of files. Then, it returns a function that will execute other files in that execution scope.

This is similar to the existing `runInScope` extension in that it allows us to lex/parse a set of files once, then use those results for future executions. The benefit of this, though, is that we can use this capability in JS, whereas `runInScope` is called from Brightscript files.

We can use this in `roca` to run through our test suite in JS, which will allow us more flexibility in reporting, CLI options, and better error handling.