### PR TITLE
fix(stdlib): callFunc should always return a value

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -638,9 +638,9 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
                         // Determine whether the function should get arguments or not.
                         if (functionToCall.getFirstSatisfiedSignature(functionargs)) {
-                            return functionToCall.call(subInterpreter, ...functionargs);
+                            return functionToCall.call(subInterpreter, ...functionargs) || BrsInvalid.Instance;
                         } else {
-                            return functionToCall.call(subInterpreter);
+                            return functionToCall.call(subInterpreter) || BrsInvalid.Instance;
                         }
                     }, componentDef.environment);
                 }

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -638,7 +638,10 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
                         // Determine whether the function should get arguments or not.
                         if (functionToCall.getFirstSatisfiedSignature(functionargs)) {
-                            return functionToCall.call(subInterpreter, ...functionargs) || BrsInvalid.Instance;
+                            return (
+                                functionToCall.call(subInterpreter, ...functionargs) ||
+                                BrsInvalid.Instance
+                            );
                         } else {
                             return functionToCall.call(subInterpreter) || BrsInvalid.Instance;
                         }

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -26,6 +26,7 @@ import { Environment } from "../../interpreter/Environment";
 import { roInvalid } from "./RoInvalid";
 import type * as MockNodeModule from "../../extensions/MockNode";
 import { BlockEnd } from "../../parser/Statement";
+import { Stmt } from "../../parser";
 
 interface BrsCallback {
     interpreter: Interpreter;
@@ -636,14 +637,19 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                         subInterpreter.environment.setM(this.m);
                         subInterpreter.environment.setRootM(this.m);
 
-                        // Determine whether the function should get arguments or not.
-                        if (functionToCall.getFirstSatisfiedSignature(functionargs)) {
-                            return (
-                                functionToCall.call(subInterpreter, ...functionargs) ||
-                                BrsInvalid.Instance
-                            );
-                        } else {
-                            return functionToCall.call(subInterpreter) || BrsInvalid.Instance;
+                        try {
+                            // Determine whether the function should get arguments or not.
+                            if (functionToCall.getFirstSatisfiedSignature(functionargs)) {
+                                return functionToCall.call(subInterpreter, ...functionargs);
+                            } else {
+                                return functionToCall.call(subInterpreter);
+                            }
+                        } catch (reason) {
+                            if (!(reason instanceof Stmt.ReturnValue)) {
+                                // re-throw interpreter errors
+                                throw reason;
+                            }
+                            return reason.value || BrsInvalid.Instance;
                         }
                     }, componentDef.environment);
                 }


### PR DESCRIPTION
# Change Summary

This fixes a bug where the interpreter throws a type mismatch when `CallFunc` doesn't return a value. Because `CallFunc` has a dynamic return type, the interpreter does not allow void.