### PR TITLE
fix(lex): Allow JS object properties as identifiers

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -617,12 +617,10 @@ export class Lexer {
                     advance();
                 } // read the next word
 
-                let twoWords = source.slice(start, current);
-                //replace all of the whitespace with a single space character so we can properly match keyword token types
-                twoWords = twoWords.replace(whitespace, " ");
-                let maybeTokenType = KeyWords[twoWords.toLowerCase()];
-                if (maybeTokenType) {
-                    addToken(maybeTokenType);
+                // replace all of the whitespace with a single space character so we can properly match keyword token types
+                let twoWords = source.slice(start, current).replace(whitespace, " ").toLowerCase();
+                if (KeyWords.hasOwnProperty(twoWords)) {
+                    addToken(KeyWords[twoWords]);
                     return;
                 } else {
                     // reset if the last word and the current word didn't form a multi-word Lexeme
@@ -639,7 +637,10 @@ export class Lexer {
                 advance();
             }
 
-            let tokenType = KeyWords[text.toLowerCase()] || Lexeme.Identifier;
+            let textLower = text.toLowerCase();
+            let tokenType = KeyWords.hasOwnProperty(textLower)
+                ? KeyWords[textLower]
+                : Lexeme.Identifier;
             if (tokenType === KeyWords.rem) {
                 //the rem keyword can be used as an identifier on objects,
                 //so do a quick look-behind to see if there's a preceeding dot

--- a/test/lexer/Lexer.test.js
+++ b/test/lexer/Lexer.test.js
@@ -317,6 +317,18 @@ describe("lexer", () => {
                 "amet&",
             ]);
         });
+
+        it("allows JS keywords as identifiers", () => {
+            let { tokens } = Lexer.scan("constructor valueOf toString __proto__");
+            let identifiers = tokens.filter((t) => t.kind !== Lexeme.Eof);
+            expect(identifiers.every((t) => t.kind === Lexeme.Identifier)).toBe(true);
+            expect(identifiers.map((t) => t.text)).toEqual([
+                "constructor",
+                "valueOf",
+                "toString",
+                "__proto__",
+            ]);
+        });
     });
 
     describe("conditional compilation", () => {


### PR DESCRIPTION
By using an identifier in a BrightScript file as an index into that object, we accidentally leaked non-Token properties on the `KeyWords` JS object from the lexer, e.g. `return KeyWords["constructor"]`.  Use `hasOwnProperty()` to check if an identifier is a BrightScript keyword to avoid returning JavaScript internals as Tokens.

fixes #613