### PR TITLE
fix(parse,interp): Support unary + operator for numbers

### DIFF
--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -1611,6 +1611,18 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                         )
                     );
                 }
+            case Lexeme.Plus:
+                if (isBrsNumber(right)) {
+                    return right;
+                } else {
+                    return this.addError(
+                        new BrsError(
+                            `Attempting to apply unary positive operator to non-numeric value.
+                            value type: ${ValueKind.toString(right.kind)}`,
+                            expression.operator.location
+                        )
+                    );
+                }
             case Lexeme.Not:
                 if (isBrsBoolean(right)) {
                     return right.not();

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1387,7 +1387,7 @@ export class Parser {
         }
 
         function prefixUnary(): Expression {
-            if (match(Lexeme.Not, Lexeme.Minus)) {
+            if (match(Lexeme.Not, Lexeme.Minus, Lexeme.Plus)) {
                 let operator = previous();
                 let right = relational();
                 return new Expr.Unary(operator, right);

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -68,6 +68,9 @@ describe("end to end syntax", () => {
             "16",
             "8",
             "4",
+            "-5", // unary + and -
+            "5",
+            "-5",
         ]);
     });
 

--- a/test/e2e/resources/arithmetic.brs
+++ b/test/e2e/resources/arithmetic.brs
@@ -35,3 +35,8 @@ print 32 << 3
 print 32 >> 1
 print 32 >> 2
 print 32 >> 3
+
+' unary operations
+print -5 ' => -5
+print +5 ' => 5
+print -+-+-+5 ' => -5

--- a/test/interpreter/Arithmetic.test.js
+++ b/test/interpreter/Arithmetic.test.js
@@ -97,6 +97,50 @@ describe("interpreter arithmetic", () => {
         expect(result.getValue()).toBe(35);
     });
 
+    it("supports positive and negative unary prefix operators", () => {
+        let ast = [
+            new Stmt.Expression(
+                new Expr.Unary(token(Lexeme.Minus), new Expr.Literal(new brs.types.Int32(4)))
+            ),
+            new Stmt.Expression(
+                new Expr.Unary(token(Lexeme.Plus), new Expr.Literal(new brs.types.Float(3.14159)))
+            ),
+        ];
+
+        let [minusFour, pi] = interpreter.exec(ast);
+        expect(minusFour.getValue()).toBe(-4);
+        expect(pi.getValue()).toBe(3.14159);
+    });
+
+    it("supports silly amounts of mixed unary prefix operators", () => {
+        let ast = [
+            new Stmt.Expression(
+                new Expr.Unary(
+                    token(Lexeme.Plus),
+                    new Expr.Unary(
+                        token(Lexeme.Minus),
+                        new Expr.Unary(
+                            token(Lexeme.Plus),
+                            new Expr.Unary(
+                                token(Lexeme.Minus),
+                                new Expr.Unary(
+                                    token(Lexeme.Plus),
+                                    new Expr.Unary(
+                                        token(Lexeme.Minus),
+                                        new Expr.Literal(new brs.types.Int32(3))
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+        ];
+
+        let [minusThree] = interpreter.exec(ast);
+        expect(minusThree.getValue()).toBe(-3);
+    });
+
     it("doesn't allow non-numeric negation", () => {
         let ast = new Stmt.Expression(
             new Expr.Unary(token(Lexeme.Minus), new Expr.Literal(new brs.types.BrsString("four")))

--- a/test/parser/expression/PrefixUnary.test.js
+++ b/test/parser/expression/PrefixUnary.test.js
@@ -79,6 +79,60 @@ describe("parser prefix unary expressions", () => {
         expect(statements).toMatchSnapshot();
     });
 
+    it("parses unary '+'", () => {
+        let { statements, errors } = parser.parse([
+            identifier("_"),
+            token(Lexeme.Equal, "="),
+            token(Lexeme.Plus, "+"),
+            token(Lexeme.Integer, "5", new Int32(5)),
+            EOF,
+        ]);
+
+        expect(errors).toEqual([]);
+        expect(statements).toBeDefined();
+        expect(statements).not.toBeNull();
+        expect(statements).toMatchSnapshot();
+    });
+
+    it("parses consecutive unary '+'", () => {
+        let { statements, errors } = parser.parse([
+            identifier("_"),
+            token(Lexeme.Equal, "="),
+            token(Lexeme.Plus, "+"),
+            token(Lexeme.Plus, "+"),
+            token(Lexeme.Plus, "+"),
+            token(Lexeme.Plus, "+"),
+            token(Lexeme.Plus, "+"),
+            token(Lexeme.Integer, "5", new Int32(5)),
+            EOF,
+        ]);
+
+        expect(errors).toEqual([]);
+        expect(statements).toBeDefined();
+        expect(statements).not.toBeNull();
+        expect(statements).toMatchSnapshot();
+    });
+
+    it("parses consecutive mixed unary operators", () => {
+        let { statements, errors } = parser.parse([
+            identifier("_"),
+            token(Lexeme.Equal, "="),
+            token(Lexeme.Plus, "-"),
+            token(Lexeme.Plus, "+"),
+            token(Lexeme.Plus, "-"),
+            token(Lexeme.Plus, "+"),
+            token(Lexeme.Plus, "-"),
+            token(Lexeme.Plus, "+"),
+            token(Lexeme.Integer, "5", new Int32(5)),
+            EOF,
+        ]);
+
+        expect(errors).toEqual([]);
+        expect(statements).toBeDefined();
+        expect(statements).not.toBeNull();
+        expect(statements).toMatchSnapshot();
+    });
+
     test("location tracking", () => {
         /**
          *    0   0   0   1   1   2

--- a/test/parser/expression/__snapshots__/PrefixUnary.test.js.snap
+++ b/test/parser/expression/__snapshots__/PrefixUnary.test.js.snap
@@ -1,5 +1,332 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parser prefix unary expressions parses consecutive mixed unary operators 1`] = `
+Array [
+  Assignment {
+    "name": Object {
+      "isReserved": false,
+      "kind": "Identifier",
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "text": "_",
+    },
+    "tokens": Object {
+      "equals": Object {
+        "isReserved": false,
+        "kind": "Equal",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "=",
+      },
+    },
+    "type": "Assignment",
+    "value": Unary {
+      "operator": Object {
+        "isReserved": false,
+        "kind": "Plus",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "-",
+      },
+      "right": Unary {
+        "operator": Object {
+          "isReserved": false,
+          "kind": "Plus",
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": -9,
+              "line": -9,
+            },
+            "start": Object {
+              "column": -9,
+              "line": -9,
+            },
+          },
+          "text": "+",
+        },
+        "right": Unary {
+          "operator": Object {
+            "isReserved": false,
+            "kind": "Plus",
+            "literal": undefined,
+            "location": Object {
+              "end": Object {
+                "column": -9,
+                "line": -9,
+              },
+              "start": Object {
+                "column": -9,
+                "line": -9,
+              },
+            },
+            "text": "-",
+          },
+          "right": Unary {
+            "operator": Object {
+              "isReserved": false,
+              "kind": "Plus",
+              "literal": undefined,
+              "location": Object {
+                "end": Object {
+                  "column": -9,
+                  "line": -9,
+                },
+                "start": Object {
+                  "column": -9,
+                  "line": -9,
+                },
+              },
+              "text": "+",
+            },
+            "right": Unary {
+              "operator": Object {
+                "isReserved": false,
+                "kind": "Plus",
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": -9,
+                    "line": -9,
+                  },
+                  "start": Object {
+                    "column": -9,
+                    "line": -9,
+                  },
+                },
+                "text": "-",
+              },
+              "right": Unary {
+                "operator": Object {
+                  "isReserved": false,
+                  "kind": "Plus",
+                  "literal": undefined,
+                  "location": Object {
+                    "end": Object {
+                      "column": -9,
+                      "line": -9,
+                    },
+                    "start": Object {
+                      "column": -9,
+                      "line": -9,
+                    },
+                  },
+                  "text": "+",
+                },
+                "right": Literal {
+                  "_location": Object {
+                    "end": Object {
+                      "column": -9,
+                      "line": -9,
+                    },
+                    "start": Object {
+                      "column": -9,
+                      "line": -9,
+                    },
+                  },
+                  "type": "Literal",
+                  "value": Int32 {
+                    "kind": 4,
+                    "value": 5,
+                  },
+                },
+                "type": "Unary",
+              },
+              "type": "Unary",
+            },
+            "type": "Unary",
+          },
+          "type": "Unary",
+        },
+        "type": "Unary",
+      },
+      "type": "Unary",
+    },
+  },
+]
+`;
+
+exports[`parser prefix unary expressions parses consecutive unary '+' 1`] = `
+Array [
+  Assignment {
+    "name": Object {
+      "isReserved": false,
+      "kind": "Identifier",
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "text": "_",
+    },
+    "tokens": Object {
+      "equals": Object {
+        "isReserved": false,
+        "kind": "Equal",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "=",
+      },
+    },
+    "type": "Assignment",
+    "value": Unary {
+      "operator": Object {
+        "isReserved": false,
+        "kind": "Plus",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "+",
+      },
+      "right": Unary {
+        "operator": Object {
+          "isReserved": false,
+          "kind": "Plus",
+          "literal": undefined,
+          "location": Object {
+            "end": Object {
+              "column": -9,
+              "line": -9,
+            },
+            "start": Object {
+              "column": -9,
+              "line": -9,
+            },
+          },
+          "text": "+",
+        },
+        "right": Unary {
+          "operator": Object {
+            "isReserved": false,
+            "kind": "Plus",
+            "literal": undefined,
+            "location": Object {
+              "end": Object {
+                "column": -9,
+                "line": -9,
+              },
+              "start": Object {
+                "column": -9,
+                "line": -9,
+              },
+            },
+            "text": "+",
+          },
+          "right": Unary {
+            "operator": Object {
+              "isReserved": false,
+              "kind": "Plus",
+              "literal": undefined,
+              "location": Object {
+                "end": Object {
+                  "column": -9,
+                  "line": -9,
+                },
+                "start": Object {
+                  "column": -9,
+                  "line": -9,
+                },
+              },
+              "text": "+",
+            },
+            "right": Unary {
+              "operator": Object {
+                "isReserved": false,
+                "kind": "Plus",
+                "literal": undefined,
+                "location": Object {
+                  "end": Object {
+                    "column": -9,
+                    "line": -9,
+                  },
+                  "start": Object {
+                    "column": -9,
+                    "line": -9,
+                  },
+                },
+                "text": "+",
+              },
+              "right": Literal {
+                "_location": Object {
+                  "end": Object {
+                    "column": -9,
+                    "line": -9,
+                  },
+                  "start": Object {
+                    "column": -9,
+                    "line": -9,
+                  },
+                },
+                "type": "Literal",
+                "value": Int32 {
+                  "kind": 4,
+                  "value": 5,
+                },
+              },
+              "type": "Unary",
+            },
+            "type": "Unary",
+          },
+          "type": "Unary",
+        },
+        "type": "Unary",
+      },
+      "type": "Unary",
+    },
+  },
+]
+`;
+
 exports[`parser prefix unary expressions parses consecutive unary '-' 1`] = `
 Array [
   Assignment {
@@ -301,6 +628,84 @@ Array [
           "type": "Unary",
         },
         "type": "Unary",
+      },
+      "type": "Unary",
+    },
+  },
+]
+`;
+
+exports[`parser prefix unary expressions parses unary '+' 1`] = `
+Array [
+  Assignment {
+    "name": Object {
+      "isReserved": false,
+      "kind": "Identifier",
+      "literal": undefined,
+      "location": Object {
+        "end": Object {
+          "column": -9,
+          "line": -9,
+        },
+        "start": Object {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "text": "_",
+    },
+    "tokens": Object {
+      "equals": Object {
+        "isReserved": false,
+        "kind": "Equal",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "=",
+      },
+    },
+    "type": "Assignment",
+    "value": Unary {
+      "operator": Object {
+        "isReserved": false,
+        "kind": "Plus",
+        "literal": undefined,
+        "location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "+",
+      },
+      "right": Literal {
+        "_location": Object {
+          "end": Object {
+            "column": -9,
+            "line": -9,
+          },
+          "start": Object {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "type": "Literal",
+        "value": Int32 {
+          "kind": 4,
+          "value": 5,
+        },
       },
       "type": "Unary",
     },


### PR DESCRIPTION
BrightScript, like JavaScript and several other languages, supports a leading `+` sign before numeric literals (and variables, incidentally). Check for `+` tokens when parsing unary expressions, and evaluate them at runtime (no-op).

fixes #227