### PR TITLE
fix(lex): Allow explicit double designator on literals > 10 characters

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -474,18 +474,13 @@ export class Lexer {
             let numberOfDigits = containsDecimal ? asString.length - 1 : asString.length;
             let designator = peek().toLowerCase();
 
-            if (numberOfDigits >= 10 && designator !== "&") {
-                // numeric literals over 10 digits with no type designator are implicitly Doubles
-                if (designator === "#") {
-                    // but it's legal to explicitly designate it a double anyway
-                    advance();
-                }
-                addToken(Lexeme.Double, Double.fromString(asString));
-                return;
-            } else if (designator === "#") {
+            if (designator === "#") {
                 // numeric literals ending with "#" are forced to Doubles
                 advance();
-                asString = source.slice(start, current);
+                addToken(Lexeme.Double, Double.fromString(asString));
+                return;
+            } else if (numberOfDigits >= 10 && designator !== "&") {
+                // numeric literals over 10 digits with no type designator are implicitly Doubles
                 addToken(Lexeme.Double, Double.fromString(asString));
                 return;
             } else if (designator === "d") {

--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -476,6 +476,10 @@ export class Lexer {
 
             if (numberOfDigits >= 10 && designator !== "&") {
                 // numeric literals over 10 digits with no type designator are implicitly Doubles
+                if (designator === "#") {
+                    // but it's legal to explicitly designate it a double anyway
+                    advance();
+                }
                 addToken(Lexeme.Double, Double.fromString(asString));
                 return;
             } else if (designator === "#") {

--- a/test/lexer/Lexer.test.js
+++ b/test/lexer/Lexer.test.js
@@ -152,6 +152,12 @@ describe("lexer", () => {
             expect(d.literal).toEqual(new Double(123));
         });
 
+        it("respects '#' suffix on very long literals", () => {
+            let d = Lexer.scan("0000000006#").tokens[0];
+            expect(d.kind).toBe(Lexeme.Double);
+            expect(d.literal).toEqual(new Double(6));
+        });
+
         it("forces literals >= 10 digits into doubles", () => {
             let d = Lexer.scan("0000000005").tokens[0];
             expect(d.kind).toBe(Lexeme.Double);


### PR DESCRIPTION
RBI forces all literal numbers to double-precision if they're longer than characters, and also allows such a number to be explicitly designated a double with a trailing `#`.  `brs` didn't.  Look for a trailing `#` when lexing long numeric literals, to avoid treating it like a conditional compilation string.

fixes #616