### PR TITLE
fix(rsg): Ensure hostNode set in <function> implementation

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -636,6 +636,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
                         subInterpreter.environment.setM(this.m);
                         subInterpreter.environment.setRootM(this.m);
+                        subInterpreter.environment.hostNode = this;
 
                         try {
                             // Determine whether the function should get arguments or not.

--- a/test/e2e/CallFunc.test.js
+++ b/test/e2e/CallFunc.test.js
@@ -52,6 +52,7 @@ describe("callFunc", () => {
             "component: inside privateFunction",
             "private return value",
             "component: overriding parent func",
+            "callFunc can trigger observeField",
             "main: mocked component voidFuncNoArgs return value:",
             "this is a mock",
         ]);

--- a/test/e2e/resources/components/call-func/CallFuncTestbed.xml
+++ b/test/e2e/resources/components/call-func/CallFuncTestbed.xml
@@ -6,5 +6,6 @@
         <function name="voidFuncFiveArgs" />
         <function name="returnValFuncOneArg" />
         <function name="overridenParentFunc" />
+        <function name="testObserve" />
     </interface>
 </component>

--- a/test/e2e/resources/components/call-func/scripts/CallFuncTestbed.brs
+++ b/test/e2e/resources/components/call-func/scripts/CallFuncTestbed.brs
@@ -1,5 +1,9 @@
 sub init()
     m.componentField = "componentField value"
+    m.emptyNode = createObject("roSGNode", "ContentNode")
+    m.emptyNode.update({
+        observeMe: false
+    }, true)
 end sub
 
 function returnValFuncOneArg(args as object) as object
@@ -31,3 +35,12 @@ end function
 function overridenParentFunc() as string
     return "component: overriding parent func"
 end function
+
+sub testObserve()
+    m.emptyNode.observeField("observeMe", "onObserveMeChanged")
+    m.emptyNode.observeMe = true
+end sub
+
+sub onObserveMeChanged(event as object)
+    print "callFunc can trigger observeField"
+end sub

--- a/test/e2e/resources/components/call-func/scripts/main.brs
+++ b/test/e2e/resources/components/call-func/scripts/main.brs
@@ -19,6 +19,8 @@ sub main()
 
     print node.callFunc("overridenParentFunc")
 
+    node.callFunc("testObserve")
+
     _brs_.mockComponent("CallFuncTestbed", {
         voidFuncNoArgs: function() as string
             return "this is a mock"


### PR DESCRIPTION
When a function is executed via `callFunc(name, ...args)`, we were accidentally losing the hostNode because we use interpreter.inSubEnv with the optional second parameter to pass in a custom environment. That environment is based on the prototype-like environment created for each component's definition, which can't include an accurate hostnode
based on runtime control flow.  Manually set a hostNode when calling functions via `callFunc`.

fixes #585