### PR TITLE
add double support to Str() (#581)

### DIFF
--- a/src/stdlib/String.ts
+++ b/src/stdlib/String.ts
@@ -144,11 +144,11 @@ export const Mid = new Callable(
 );
 
 /**
- * Return a string from a float. If it is positive, prefix it with a space.
+ * Return a string from a float/double. If it is positive, prefix it with a space.
  */
 export const Str = new Callable("Str", {
     signature: {
-        args: [new StdlibArgument("value", ValueKind.Float)],
+        args: [new StdlibArgument("value", ValueKind.Double)],
         returns: ValueKind.String,
     },
     impl: (interpreter: Interpreter, value: Float): BrsString => {

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -50,6 +50,7 @@ describe("end to end standard libary", () => {
             "7",
             "10",
             " 3.4",
+            " 9.7",
             "-3",
             "12.34",
             "Mary and Bob",

--- a/test/e2e/resources/stdlib/strings.brs
+++ b/test/e2e/resources/stdlib/strings.brs
@@ -13,6 +13,7 @@ print Mid(mixedCase, 4, 2) ' "ed"
 print Instr(0, mixedCase, "Case") ' 7
 print Instr(6, mixedCase, "e") ' 10
 print Str(3.4) ' " 3.4"
+print Str(9.7#) ' " 9.7"
 print StrI(-3) ' "-3"
 print Val("12.34") ' 12.34
 print Substitute("{0} and {1}", "Mary", "Bob")


### PR DESCRIPTION
This addresses #581, where only floats are accepted by the Str() function. 

**Change**
The implementation for floats and doubles is identical where they need to be converted to a string, and if positive add a space beforehand. The simplest fix was to change the input type to double, so both floats and doubles would be supported. 

Fixes #581
