### PR TITLE
fix(int): Match RBI result when coercing Int64 to Int32

### DIFF
--- a/src/brsTypes/Int32.ts
+++ b/src/brsTypes/Int32.ts
@@ -22,7 +22,12 @@ export class Int32 implements Numeric, Comparable, Boxable {
      *              integer.
      */
     constructor(value: number | Long) {
-        if (value instanceof Long) value = value.toNumber();
+        if (value instanceof Long) {
+            // RBI ignores the 32 most significant bits when converting a 64-bit int to a 32-bit int, effectively
+            // performing a bitwise AND with `0x00000000FFFFFFFF`.  Since Long already tracks the lower and upper
+            // portions as separate 32-bit values, we can simply extract the least-significant portion.
+            value = value.low;
+        }
         this.value = Math.trunc(value);
     }
 

--- a/test/brsTypes/Int32.test.js
+++ b/test/brsTypes/Int32.test.js
@@ -10,23 +10,37 @@ const {
 } = require("../../lib/brsTypes");
 
 describe("Int32", () => {
-    it("truncates initial values to integers", () => {
-        let three = new Int32(3.4);
-        let four = new Int32(3.5);
-        expect(three.getValue()).toBe(3);
-        expect(four.getValue()).toBe(3);
-    });
+    describe("construction", () => {
+        it("truncates initial values to integers", () => {
+            let three = new Int32(3.4);
+            let four = new Int32(3.5);
+            expect(three.getValue()).toBe(3);
+            expect(four.getValue()).toBe(3);
+        });
 
-    it("creates base-10 integers from strings", () => {
-        let three = Int32.fromString("3.4");
-        let four = Int32.fromString("3.5");
-        expect(three.getValue()).toBe(3);
-        expect(four.getValue()).toBe(3);
-    });
+        it("creates base-10 integers from strings", () => {
+            let three = Int32.fromString("3.4");
+            let four = Int32.fromString("3.5");
+            expect(three.getValue()).toBe(3);
+            expect(four.getValue()).toBe(3);
+        });
 
-    it("creates base-16 integers from strings", () => {
-        let twoFiftyFive = Int32.fromString("&hFF");
-        expect(twoFiftyFive.getValue()).toBe(255);
+        it("creates base-16 integers from strings", () => {
+            let twoFiftyFive = Int32.fromString("&hFF");
+            expect(twoFiftyFive.getValue()).toBe(255);
+        });
+
+        it("ignores upper 32 bits of 64-bit input", () => {
+            let large = new Int64(2147483647119);
+            let truncated = new Int32(large.getValue());
+            expect(truncated.getValue()).toBe(-881);
+        });
+
+        it("doesn't modify 64-bit inputs that only require 32-bits for storage", () => {
+            let long = new Int64(11235813);
+            let int = new Int32(long.getValue());
+            expect(int.getValue()).toBe(11235813);
+        });
     });
 
     describe("addition", () => {


### PR DESCRIPTION
RBI appears to ignore the upper 32 bits when converting a 64-bit integer ("LongInteger") to a 32-bit integer ("integer"), which `brs` didn't previously do.  Use only the least-significant 32 bits when creating a 32-bit integer from an instance of `Long`.