### PR TITLE
fix(interp): don't mutate function call arguments while type-checking

### DIFF
--- a/src/brsTypes/Callable.ts
+++ b/src/brsTypes/Callable.ts
@@ -219,14 +219,15 @@ export class Callable implements Brs.BrsValue {
 
     getFirstSatisfiedSignature(args: Brs.BrsType[]): SignatureAndImplementation | undefined {
         return this.signatures.filter(
-            (sigAndImpl) => this.getSignatureMismatches(sigAndImpl.signature, args).length === 0
+            (sigAndImpl) =>
+                this.getSignatureMismatches(sigAndImpl.signature, [...args]).length === 0
         )[0];
     }
 
     getAllSignatureMismatches(args: Brs.BrsType[]): SignatureAndMismatches[] {
         return this.signatures.map((sigAndImpl) => ({
             signature: sigAndImpl.signature,
-            mismatches: this.getSignatureMismatches(sigAndImpl.signature, args),
+            mismatches: this.getSignatureMismatches(sigAndImpl.signature, [...args]),
         }));
     }
 
@@ -261,7 +262,9 @@ export class Callable implements Brs.BrsValue {
 
             if (
                 expected.type.kind === Brs.ValueKind.Float &&
-                received.kind === Brs.ValueKind.Int32
+                (received.kind === Brs.ValueKind.Int32 ||
+                    received.kind === Brs.ValueKind.Int64 ||
+                    received.kind === Brs.ValueKind.Double)
             ) {
                 args[index] = new Float(received.getValue());
                 return;
@@ -269,7 +272,9 @@ export class Callable implements Brs.BrsValue {
 
             if (
                 expected.type.kind === Brs.ValueKind.Int32 &&
-                received.kind === Brs.ValueKind.Float
+                (received.kind === Brs.ValueKind.Float ||
+                    received.kind === Brs.ValueKind.Int64 ||
+                    received.kind === Brs.ValueKind.Double)
             ) {
                 args[index] = new Int32(received.getValue());
                 return;
@@ -277,7 +282,9 @@ export class Callable implements Brs.BrsValue {
 
             if (
                 expected.type.kind === Brs.ValueKind.Double &&
-                received.kind === Brs.ValueKind.Float
+                (received.kind === Brs.ValueKind.Float ||
+                    received.kind === Brs.ValueKind.Int32 ||
+                    received.kind === Brs.ValueKind.Int64)
             ) {
                 args[index] = new Double(received.getValue());
                 return;
@@ -285,7 +292,9 @@ export class Callable implements Brs.BrsValue {
 
             if (
                 expected.type.kind === Brs.ValueKind.Int64 &&
-                received.kind === Brs.ValueKind.Int32
+                (received.kind === Brs.ValueKind.Float ||
+                    received.kind === Brs.ValueKind.Int32 ||
+                    received.kind === Brs.ValueKind.Double)
             ) {
                 args[index] = new Int64(received.getValue());
                 return;

--- a/test/brsTypes/Callable.test.js
+++ b/test/brsTypes/Callable.test.js
@@ -1,5 +1,6 @@
 const BrsTypes = require("../../lib/brsTypes");
 const { UCase, LCase } = require("../../lib/stdlib");
+const { Interpreter } = require("../../lib/interpreter");
 
 describe("Callable", () => {
     it("is less than nothing", () => {
@@ -127,6 +128,41 @@ describe("Callable", () => {
                 received: "Boolean",
                 argName: "foo",
             });
+        });
+
+        it("doesn't mutate args while checking for argument mismatches", () => {
+            let func = new BrsTypes.Callable(
+                "acceptsIntOrFloat",
+                {
+                    signature: {
+                        args: [
+                            new BrsTypes.StdlibArgument("input", BrsTypes.ValueKind.Int32),
+                            new BrsTypes.StdlibArgument("something_else", BrsTypes.ValueKind.Int32),
+                        ],
+                        returns: BrsTypes.Int32,
+                    },
+                    impl: (_interpreter, input) => input,
+                },
+                {
+                    signature: {
+                        args: [
+                            new BrsTypes.StdlibArgument("input", BrsTypes.ValueKind.Int32),
+                            new BrsTypes.StdlibArgument(
+                                "something_else",
+                                BrsTypes.ValueKind.Boolean
+                            ),
+                        ],
+                        returns: BrsTypes.Float,
+                    },
+                    impl: (_interpreter, input) => input,
+                }
+            );
+
+            let pi = new BrsTypes.Float(3.1415927);
+            let result = func.call(new Interpreter(), pi, BrsTypes.BrsBoolean.False);
+
+            // mutation between checks would cause `input` to be the integer 3 - make sure that doesn't happen
+            expect(result).toEqual(pi);
         });
 
         it("allows float to be passed to an integer argument", () => {


### PR DESCRIPTION
While it's a bit of an edge-case with "in the wild BrightScript", it was previously possible for `brs` to accidentally mutate the arguments passed to a function while type-checking those arguments.  Make a shallow copy of the provided arguments before performing type checking and type coercion.