### PR TITLE
chore(infra): Don't publish new nightly version if nothing changed

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -12,16 +12,27 @@
       steps: [
         { uses: "actions/checkout@v2" },
         {
+          id: "commits_since_last_nightly",
+          name: "Check for commits since last night's build",
+          run: "test -n \"$(git log --oneline --since '25 hours ago')\"",
+          "continue-on-error": true
+        },
+        {
           name: "Set up node 12",
           uses: "actions/setup-node@v1",
+          if: "${{ job.commits_since_last_nightly.outcome == 'failure' }}",
           with: {
             registry-url: "https://registry.npmjs.com",
             node-version: "12"
           }
         },
-        { run: "yarn" },
+        {
+          run: "yarn",
+          if: "${{ job.commits_since_last_nightly.outcome == 'failure' }}"
+        },
         {
           run: "yarn publish --no-git-tag-version --new-version `node scripts/getNightlyVersion.js` --tag nightly",
+          if: "${{ job.commits_since_last_nightly.outcome == 'failure' }}",
           env: {
             NODE_AUTH_TOKEN: "${{ secrets.NPM_PUBLISH_TOKEN }}"
           }


### PR DESCRIPTION
We previously published a new nightly build every night, but there was no difference between many of those builds.  It's pretty silly to make npmjs.com keep storing the same package with a different version all the time.  Stop publishing nightly builds when there are no commits since last night's build.