### PR TITLE
fix(lexer): Add support for explicit integer literals

### DIFF
--- a/src/lexer/Lexer.ts
+++ b/src/lexer/Lexer.ts
@@ -543,6 +543,9 @@ export class Lexer {
                 addToken(Lexeme.LongInteger, Int64.fromString(asString));
                 return;
             } else {
+                if (designator === "%") {
+                    advance();
+                } // consume the "%"
                 // otherwise, it's a regular integer
                 addToken(Lexeme.Integer, Int32.fromString(asString));
                 return;

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -30,6 +30,7 @@ describe("end to end syntax", () => {
             "true",
             "false",
             "5",
+            "6",
             "7",
             "30",
             "40",

--- a/test/e2e/resources/printLiterals.brs
+++ b/test/e2e/resources/printLiterals.brs
@@ -3,6 +3,7 @@ print true
 print false
 
 print 5   ' a 32-bit integer
+print 6%  ' a 32-bit expicit integer
 print 7&  ' a 64-bit integer
 print 3e1 ' a float
 ? 4d1     ' a double

--- a/test/lexer/Lexer.test.js
+++ b/test/lexer/Lexer.test.js
@@ -244,6 +244,12 @@ describe("lexer", () => {
             expect(i.literal).toEqual(new Int32(255));
         });
 
+        it("supports '%' suffix", () => {
+            let i = Lexer.scan("123%").tokens[0];
+            expect(i.kind).toBe(Lexeme.Integer);
+            expect(i.literal).toEqual(new Int32(123));
+        });
+
         it("falls back to a regular integer", () => {
             let i = Lexer.scan("123").tokens[0];
             expect(i.kind).toBe(Lexeme.Integer);


### PR DESCRIPTION
 this PR resolves #627 issue
what were done:

- added support for `%` suffix in integer literals
- added unit test for imlementation(lexer)
- added e2e test.