### PR TITLE
feat(stdlib): Add lookupCI for assocarray and Node

### DIFF
--- a/src/brsTypes/components/BrsComponent.ts
+++ b/src/brsTypes/components/BrsComponent.ts
@@ -58,9 +58,10 @@ export interface BrsIterable {
     /**
      * Retrieves an element from this component at the provided `index`.
      * @param index the index in this component from which to retrieve the desired element.
+     * @param isCaseSensitiveGet determinate whether operation of getting should be case sensitive or not.
      * @returns the element at `index` if one exists, otherwise throws an Error.
      */
-    get(index: BrsType): BrsType;
+    get(index: BrsType, isCaseSensitiveGet?: boolean): BrsType;
 
-    set(index: BrsType, value: BrsType): BrsInvalid;
+    set(index: BrsType, value: BrsType, isCaseSensitiveSet?: boolean): BrsInvalid;
 }

--- a/src/brsTypes/components/BrsComponent.ts
+++ b/src/brsTypes/components/BrsComponent.ts
@@ -58,10 +58,10 @@ export interface BrsIterable {
     /**
      * Retrieves an element from this component at the provided `index`.
      * @param index the index in this component from which to retrieve the desired element.
-     * @param isCaseSensitiveGet determinate whether operation of getting should be case sensitive or not.
+     * @param isCaseSensitive determinate whether operation of getting should be case sensitive or not.
      * @returns the element at `index` if one exists, otherwise throws an Error.
      */
-    get(index: BrsType, isCaseSensitiveGet?: boolean): BrsType;
+    get(index: BrsType, isCaseSensitive?: boolean): BrsType;
 
-    set(index: BrsType, value: BrsType, isCaseSensitiveSet?: boolean): BrsInvalid;
+    set(index: BrsType, value: BrsType, isCaseSensitive?: boolean): BrsInvalid;
 }

--- a/src/brsTypes/components/ComponentFactory.ts
+++ b/src/brsTypes/components/ComponentFactory.ts
@@ -18,6 +18,7 @@ import {
 
 export enum BrsComponentName {
     Node = "Node",
+    Node_lowerCase = "node",
     Group = "Group",
     LayoutGroup = "LayoutGroup",
     Rectangle = "Rectangle",
@@ -67,6 +68,8 @@ export class ComponentFactory {
             case BrsComponentName.LayoutGroup:
                 return new LayoutGroup([], name);
             case BrsComponentName.Node:
+                return new RoSGNode([], name);
+            case BrsComponentName.Node_lowerCase:
                 return new RoSGNode([], name);
             case BrsComponentName.Rectangle:
                 return new Rectangle([], name);

--- a/src/brsTypes/components/ComponentFactory.ts
+++ b/src/brsTypes/components/ComponentFactory.ts
@@ -18,7 +18,6 @@ import {
 
 export enum BrsComponentName {
     Node = "Node",
-    Node_lowerCase = "node",
     Group = "Group",
     LayoutGroup = "LayoutGroup",
     Rectangle = "Rectangle",
@@ -68,8 +67,6 @@ export class ComponentFactory {
             case BrsComponentName.LayoutGroup:
                 return new LayoutGroup([], name);
             case BrsComponentName.Node:
-                return new RoSGNode([], name);
-            case BrsComponentName.Node_lowerCase:
                 return new RoSGNode([], name);
             case BrsComponentName.Rectangle:
                 return new Rectangle([], name);

--- a/src/brsTypes/components/RoAssociativeArray.ts
+++ b/src/brsTypes/components/RoAssociativeArray.ts
@@ -259,7 +259,7 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
 
     /** Given a key, returns the value associated with that key.
      * This method is case insensitive either-or case sensitive, depends on whether `setModeCasesensitive` was called or not.
-     * */
+     */
     private lookup = new Callable("lookup", {
         signature: {
             args: [new StdlibArgument("key", ValueKind.String)],

--- a/src/brsTypes/components/RoAssociativeArray.ts
+++ b/src/brsTypes/components/RoAssociativeArray.ts
@@ -76,7 +76,7 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
             .map((value: BrsType) => value);
     }
 
-    get(index: BrsType, isCaseSensitiveGet = false) {
+    get(index: BrsType, isCaseSensitive = false) {
         if (index.kind !== ValueKind.String) {
             throw new Error("Associative array indexes must be strings");
         }
@@ -93,13 +93,13 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
         // That'd allow roArrays to have methods with the methods not accessible via `arr["count"]`.
         // Same with RoAssociativeArrays I guess.
         return (
-            this.findElement(index.value, isCaseSensitiveGet) ||
+            this.findElement(index.value, isCaseSensitive) ||
             this.getMethod(index.value) ||
             BrsInvalid.Instance
         );
     }
 
-    set(index: BrsType, value: BrsType, isCaseSensitiveSet = false) {
+    set(index: BrsType, value: BrsType, isCaseSensitive = false) {
         if (index.kind !== ValueKind.String) {
             throw new Error("Associative array indexes must be strings");
         }
@@ -109,10 +109,11 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
             this.elements.delete(oldKey);
         }
 
-        let indexValue = isCaseSensitiveSet ? index.value : index.value.toLowerCase();
+        let indexValue = isCaseSensitive ? index.value : index.value.toLowerCase();
         this.elements.set(indexValue, value);
         return BrsInvalid.Instance;
     }
+
     /** if AA is in insensitive mode, it means that we should do insensitive search of real key */
     private findElementKey(elementKey: string, isCaseSensitiveFind = false) {
         let useCaseSensitiveSearch = this.modeCaseSensitive && isCaseSensitiveFind;

--- a/src/brsTypes/components/RoAssociativeArray.ts
+++ b/src/brsTypes/components/RoAssociativeArray.ts
@@ -17,8 +17,8 @@ export interface AAMember {
 export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIterable {
     readonly kind = ValueKind.Object;
     elements = new Map<string, BrsType>();
-    /** keyMap - maps lowercased key to original one which used in this.elements to store value
-     * Main benefit of it is fast case insensitive access
+    /** Maps lowercased element name to original name used in this.elements.
+     * Main benefit of it is fast, case-insensitive access.
      */
     keyMap = new Map<string, string>();
     private modeCaseSensitive: boolean = false;
@@ -161,7 +161,7 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
             if (this.keyMap.get(lKey) === key) {
                 this.keyMap.delete(lKey);
                 // if we have {"DD": 0, "dD": 0},  keyMap["dd"] is pointed to "DD",
-                // and we delets it, then we should find another value for case insensitive accessing ("dD")
+                // and we delete it, then we should find another value for case insensitive accessing ("dD")
                 if (this.modeCaseSensitive) {
                     for (let key of this.elements.keys()) {
                         if (key.toLowerCase() === lKey) {
@@ -187,7 +187,7 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
             returns: ValueKind.Void,
         },
         impl: (interpreter: Interpreter, key: BrsString, value: BrsType) => {
-            this.set(key, value, true);
+            this.set(key, value, /* isCaseSensitive */ true);
             return BrsInvalid.Instance;
         },
     });

--- a/src/brsTypes/components/RoAssociativeArray.ts
+++ b/src/brsTypes/components/RoAssociativeArray.ts
@@ -36,6 +36,7 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
                 this.keys,
                 this.items,
                 this.lookup,
+                this.lookupCI,
                 this.setmodecasesensitive,
             ],
             ifEnum: [this.isEmpty],
@@ -77,7 +78,7 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
             .map((value: BrsType) => value);
     }
 
-    get(index: BrsType) {
+    get(index: BrsType, forceCaseInsensitive = false) {
         if (index.kind !== ValueKind.String) {
             throw new Error("Associative array indexes must be strings");
         }
@@ -93,7 +94,10 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
         // method with the desired name separately? That last bit would work but it's pretty gross.
         // That'd allow roArrays to have methods with the methods not accessible via `arr["count"]`.
         // Same with RoAssociativeArrays I guess.
-        let indexValue = this.modeCaseSensitive ? index.value : index.value.toLowerCase();
+        let indexValue =
+            this.modeCaseSensitive && !forceCaseInsensitive
+                ? index.value
+                : index.value.toLowerCase();
         return this.elements.get(indexValue) || this.getMethod(index.value) || BrsInvalid.Instance;
     }
 
@@ -232,6 +236,17 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
         impl: (interpreter: Interpreter, key: BrsString) => {
             let lKey = key.value;
             return this.get(new BrsString(lKey));
+        },
+    });
+
+    private lookupCI = new Callable("lookupCI", {
+        signature: {
+            args: [new StdlibArgument("key", ValueKind.String)],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (interpreter: Interpreter, key: BrsString) => {
+            let lKey = key.value;
+            return this.get(new BrsString(lKey), true);
         },
     });
 

--- a/src/brsTypes/components/RoAssociativeArray.ts
+++ b/src/brsTypes/components/RoAssociativeArray.ts
@@ -156,20 +156,21 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
         impl: (interpreter: Interpreter, str: BrsString) => {
             let key = this.findElementKey(str.value, this.modeCaseSensitive);
             let deleted = key ? this.elements.delete(key) : false;
-            this.keyMap.delete(str.value.toLowerCase());
 
-            // if we have {"DD": 0, "dD": 0},  keyMap["dd"] is pointed to "DD",
-            // and we delets it, then we should find another value for case insensitive accessing ("dD")
-            if (this.modeCaseSensitive) {
-                let lKey = str.value.toLowerCase();
-                for (let key of this.elements.keys()) {
-                    if (key.toLowerCase() === lKey) {
-                        this.keyMap.set(lKey, key);
-                        break;
+            let lKey = str.value.toLowerCase();
+            if (this.keyMap.get(lKey) === key) {
+                this.keyMap.delete(lKey);
+                // if we have {"DD": 0, "dD": 0},  keyMap["dd"] is pointed to "DD",
+                // and we delets it, then we should find another value for case insensitive accessing ("dD")
+                if (this.modeCaseSensitive) {
+                    for (let key of this.elements.keys()) {
+                        if (key.toLowerCase() === lKey) {
+                            this.keyMap.set(lKey, key);
+                            break;
+                        }
                     }
                 }
             }
-
             return BrsBoolean.from(deleted);
         },
     });

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -301,7 +301,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     readonly defaultFields: FieldModel[] = [
         { name: "change", type: "roAssociativeArray" },
         { name: "focusable", type: "boolean" },
-        { name: "focusedChild", type: "node", alwaysNotify: true },
+        { name: "focusedchild", type: "node", alwaysNotify: true },
         { name: "id", type: "string" },
     ];
     m: RoAssociativeArray = new RoAssociativeArray([]);

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -436,7 +436,39 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         return this.getMethod(index.value) || BrsInvalid.Instance;
     }
 
-    set(index: BrsType, value: BrsType, alwaysNotify: boolean = false, kind?: FieldKind) {
+    set(index: BrsType, value: BrsType) {
+        if (index.kind !== ValueKind.String) {
+            throw new Error("RoSGNode indexes must be strings");
+        }
+
+        let mapKey = index.value.toLowerCase();
+        let field = this.fields.get(mapKey);
+
+        if (!field) {
+            // TODO: change to using interpreter.stderr
+            console.warn(
+                `=================================================================\n` +
+                    `Warning occurred while setting a field of an RoSGNode\n` +
+                    `-- Tried to set nonexistent field "${mapKey}" of a "${this.nodeSubtype}" node\n` +
+                    `=================================================================\n`
+            );
+        } else if (field.canAcceptValue(value)) {
+            // Fields are not overwritten if they haven't the same type.
+            field.setValue(value);
+            this.fields.set(mapKey, field);
+        } else {
+            console.warn(`BRIGHTSCRIPT: ERROR: roSGNode.AddReplace: "${field}": Type mismatch`);
+        }
+
+        return BrsInvalid.Instance;
+    }
+
+    private _addField(
+        index: BrsType,
+        value: BrsType,
+        alwaysNotify: boolean = false,
+        kind?: FieldKind
+    ) {
         if (index.kind !== ValueKind.String) {
             throw new Error("RoSGNode indexes must be strings");
         }
@@ -445,19 +477,10 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         let fieldType = kind || FieldKind.fromBrsType(value);
         let field = this.fields.get(mapKey);
 
-        if (!field) {
-            // RBI does not create a new field if the value isn't valid.
-            if (fieldType) {
-                field = new Field(value, fieldType, alwaysNotify);
-                this.fields.set(mapKey, field);
-            }
-        } else if (field.canAcceptValue(value)) {
-            // Fields are not overwritten if they haven't the same type.
-            field.setValue(value);
+        if (!field && fieldType) {
+            field = new Field(value, fieldType, alwaysNotify);
             this.fields.set(mapKey, field);
         }
-
-        return BrsInvalid.Instance;
     }
 
     getParent() {
@@ -802,6 +825,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
     });
 
+    /** Given a key, returns the value associated with that key. This method is case insensitive. */
     private lookupCI = new Callable("lookupCI", this.lookup.signatures[0]);
 
     /** Adds a new field to the node, if the field already exists it doesn't change the current value. */
@@ -824,7 +848,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             let fieldKind = FieldKind.fromString(type.value);
 
             if (defaultValue !== Uninitialized.Instance && !this.fields.has(fieldname.value)) {
-                this.set(fieldname, defaultValue, alwaysnotify.toBoolean(), fieldKind);
+                this._addField(fieldname, defaultValue, alwaysnotify.toBoolean(), fieldKind);
             }
 
             return BrsBoolean.True;
@@ -845,7 +869,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             fields.getValue().forEach((value, key) => {
                 let fieldName = new BrsString(key);
                 if (!this.fields.has(key)) {
-                    this.set(fieldName, value);
+                    this._addField(fieldName, value);
                 }
             });
 

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -327,6 +327,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                 this.keys,
                 this.items,
                 this.lookup,
+                this.lookupCI,
             ],
             ifSGNodeField: [
                 this.addfield,
@@ -800,6 +801,8 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             return this.get(new BrsString(lKey));
         },
     });
+
+    private lookupCI = new Callable("lookupCI", this.lookup.signatures[0]);
 
     /** Adds a new field to the node, if the field already exists it doesn't change the current value. */
     private addfield = new Callable("addfield", {

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -1278,7 +1278,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         }
 
         try {
-            return source.get(index);
+            return source.get(index, true);
         } catch (err) {
             return this.addError(new BrsError(err.message, expression.closingSquare.location));
         }
@@ -1537,7 +1537,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         let value = this.evaluate(statement.value);
 
         try {
-            source.set(index, value);
+            source.set(index, value, true);
         } catch (err) {
             return this.addError(new BrsError(err.message, statement.closingSquare.location));
         }

--- a/test/brsTypes/components/RoAssociativeArray.test.js
+++ b/test/brsTypes/components/RoAssociativeArray.test.js
@@ -372,6 +372,20 @@ describe("RoAssociativeArray", () => {
 
                 result2 = aa.get(new BrsString("KeY2"));
                 expect(result2).toBe(v2);
+
+                // check lookupCI method
+                let lookupCI = aa.getMethod("lookupCI");
+                expect(lookupCI).toBeTruthy();
+
+                addreplace.call(interpreter, new BrsString("key2"), v1);
+                let result = lookup.call(interpreter, new BrsString("key2"));
+                expect(result).toBe(v1);
+
+                result = lookupCI.call(interpreter, new BrsString("KEY2"));
+                expect(result).toBe(v1);
+
+                result = lookupCI.call(interpreter, new BrsString("Key2"));
+                expect(result).toBe(v1);
             });
         });
     });

--- a/test/brsTypes/components/RoAssociativeArray.test.js
+++ b/test/brsTypes/components/RoAssociativeArray.test.js
@@ -396,7 +396,7 @@ describe("RoAssociativeArray", () => {
 
                 // check lookupCI method
                 let lookupCI = aa.getMethod("lookupCI");
-                // RBI uses last value for key when uses lookupCI, if do not set new value it will use old v2 value
+
                 addreplace.call(interpreter, new BrsString("Key1"), v3);
                 expect(lookupCI).toBeTruthy();
 
@@ -407,10 +407,10 @@ describe("RoAssociativeArray", () => {
                 expect(result).toBe(v2);
 
                 result = lookupCI.call(interpreter, new BrsString("kEy1"));
-                expect(result).toBe(v3);
+                expect(result).toBe(v1);
 
                 result = lookupCI.call(interpreter, new BrsString("KeY1"));
-                expect(result).toBe(v3);
+                expect(result).toBe(v1);
             });
         });
     });

--- a/test/brsTypes/components/RoAssociativeArray.test.js
+++ b/test/brsTypes/components/RoAssociativeArray.test.js
@@ -374,6 +374,7 @@ describe("RoAssociativeArray", () => {
                 expect(result2).toBe(v2);
             });
         });
+
         describe("lookupCI", () => {
             it("changes lookups to case sensitive mode", () => {
                 let v1 = new BrsString("value1");

--- a/test/brsTypes/components/RoAssociativeArray.test.js
+++ b/test/brsTypes/components/RoAssociativeArray.test.js
@@ -379,6 +379,7 @@ describe("RoAssociativeArray", () => {
             it("changes lookups to case sensitive mode", () => {
                 let v1 = new BrsString("value1");
                 let v2 = new BrsString("value2");
+                let v3 = new BrsString("value3");
 
                 let aa = new RoAssociativeArray([{ name: new BrsString("key1"), value: v1 }]);
 
@@ -395,6 +396,8 @@ describe("RoAssociativeArray", () => {
 
                 // check lookupCI method
                 let lookupCI = aa.getMethod("lookupCI");
+                // RBI uses last value for key when uses lookupCI, if do not set new value it will use old v2 value
+                addreplace.call(interpreter, new BrsString("Key1"), v3);
                 expect(lookupCI).toBeTruthy();
 
                 let result = lookup.call(interpreter, new BrsString("key1"));
@@ -404,10 +407,10 @@ describe("RoAssociativeArray", () => {
                 expect(result).toBe(v2);
 
                 result = lookupCI.call(interpreter, new BrsString("kEy1"));
-                expect(result).toBe(v1);
+                expect(result).toBe(v3);
 
                 result = lookupCI.call(interpreter, new BrsString("KeY1"));
-                expect(result).toBe(v1);
+                expect(result).toBe(v3);
             });
         });
     });

--- a/test/brsTypes/components/RoAssociativeArray.test.js
+++ b/test/brsTypes/components/RoAssociativeArray.test.js
@@ -372,19 +372,40 @@ describe("RoAssociativeArray", () => {
 
                 result2 = aa.get(new BrsString("KeY2"));
                 expect(result2).toBe(v2);
+            });
+        });
+        describe("lookupCI", () => {
+            it("changes lookups to case sensitive mode", () => {
+                let v1 = new BrsString("value1");
+                let v2 = new BrsString("value2");
+
+                let aa = new RoAssociativeArray([{ name: new BrsString("key1"), value: v1 }]);
+
+                let setModeCaseSensitive = aa.getMethod("setmodecasesensitive");
+                expect(setModeCaseSensitive).toBeTruthy();
+                setModeCaseSensitive.call(interpreter);
+
+                let addreplace = aa.getMethod("addreplace");
+                expect(addreplace).toBeTruthy();
+                addreplace.call(interpreter, new BrsString("KEY1"), v2);
+
+                let lookup = aa.getMethod("lookup");
+                expect(lookup).toBeTruthy();
 
                 // check lookupCI method
                 let lookupCI = aa.getMethod("lookupCI");
                 expect(lookupCI).toBeTruthy();
 
-                addreplace.call(interpreter, new BrsString("key2"), v1);
-                let result = lookup.call(interpreter, new BrsString("key2"));
+                let result = lookup.call(interpreter, new BrsString("key1"));
                 expect(result).toBe(v1);
 
-                result = lookupCI.call(interpreter, new BrsString("KEY2"));
+                result = lookup.call(interpreter, new BrsString("KEY1"));
+                expect(result).toBe(v2);
+
+                result = lookupCI.call(interpreter, new BrsString("kEy1"));
                 expect(result).toBe(v1);
 
-                result = lookupCI.call(interpreter, new BrsString("Key2"));
+                result = lookupCI.call(interpreter, new BrsString("KeY1"));
                 expect(result).toBe(v1);
             });
         });

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -528,7 +528,7 @@ describe("RoSGNode", () => {
                 let expected = new RoAssociativeArray([
                     { name: new BrsString("change"), value: new RoAssociativeArray([]) },
                     { name: new BrsString("focusable"), value: BrsBoolean.False },
-                    { name: new BrsString("focusedChild"), value: BrsInvalid.Instance },
+                    { name: new BrsString("focusedchild"), value: BrsInvalid.Instance },
                     { name: new BrsString("id"), value: new BrsString("") },
                 ]);
                 result.elements.forEach((value, name) => {

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -60,6 +60,8 @@ describe("end to end brightscript functions", () => {
             "true",
             "can look up elements (brackets): ",
             "true",
+            "can case insensitive look up elements: ",
+            "true",
             "can check for existence: ",
             "true",
             "items() example key: ",

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -76,6 +76,14 @@ describe("end to end brightscript functions", () => {
             "value1",
             "can empty itself: ",
             "true",
+            "saved key: ",
+            "DD",
+            "saved key after accessing by dot: ",
+            "dd",
+            "saved key after accessing by index: ",
+            "Dd",
+            "AA keys size: ",
+            "1",
         ]);
     });
 

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -74,6 +74,8 @@ describe("end to end brightscript functions", () => {
             "value1",
             "lookup uses mode case too",
             "value1",
+            "lookupCI ignore mode case",
+            "value1",
             "can empty itself: ",
             "true",
             "saved key: ",

--- a/test/e2e/Iterables.test.js
+++ b/test/e2e/Iterables.test.js
@@ -37,7 +37,7 @@ describe("end to end iterables", () => {
             // iterate through keys
             "has-second-layer",
             "level",
-            "secondlayer",
+            "secondLayer",
 
             // twoDimensional.secondLayer.level
             "2",

--- a/test/e2e/RoSGNode.test.js
+++ b/test/e2e/RoSGNode.test.js
@@ -103,6 +103,8 @@ describe("components/roSGNode", () => {
             "true",
             "can look up elements (brackets): ",
             "true",
+            "can case insensitive look up elements: ",
+            "true",
             "can check for existence: ",
             "true",
             "can empty itself: ",

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -195,7 +195,7 @@ describe("end to end syntax", () => {
 
         expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
             // note: associative array keys are sorted before iteration
-            "createobject",
+            "createObject",
             "in",
             "run",
             "stop",

--- a/test/e2e/resources/components/roAssociativeArray.brs
+++ b/test/e2e/resources/components/roAssociativeArray.brs
@@ -22,6 +22,7 @@ sub main()
     print "key is not found if sensitive mode is enabled" aa.doesExist("key1") ' => false
     print "key exits with correct casing" aa["KeY1"] ' => value1
     print "lookup uses mode case too" aa.lookup("KeY1") ' => value1
+    print "lookupCI ignore mode case " aa.lookupCI("kEy1") ' => value1
 
     aa.clear()
     print "can empty itself: " aa.isEmpty()                     ' => true

--- a/test/e2e/resources/components/roAssociativeArray.brs
+++ b/test/e2e/resources/components/roAssociativeArray.brs
@@ -22,7 +22,7 @@ sub main()
     print "key is not found if sensitive mode is enabled" aa.doesExist("key1") ' => false
     print "key exits with correct casing" aa["KeY1"] ' => value1
     print "lookup uses mode case too" aa.lookup("KeY1") ' => value1
-    print "lookupCI ignore mode case " aa.lookupCI("kEy1") ' => value1
+    print "lookupCI ignore mode case" aa.lookupCI("kEy1") ' => value1
 
     aa.clear()
     print "can empty itself: " aa.isEmpty()                     ' => true

--- a/test/e2e/resources/components/roAssociativeArray.brs
+++ b/test/e2e/resources/components/roAssociativeArray.brs
@@ -11,6 +11,7 @@ sub main()
     print "can delete elements: " aa.delete("baz")              ' => true
     print "can look up elements: " aa.lookup("foo") = "foo"     ' => true
     print "can look up elements (brackets): " aa["foo"] = "foo" ' => true
+    print "can case insensitive look up elements: " aa.lookupCI("foO") = "foo" ' => true
     print "can check for existence: " aa.doesExist("bar")       ' => true
     print "items() example key: " aa.items()[0].key             ' => bar
     print "items() example value: " aa.items()[0].value         ' => 5

--- a/test/e2e/resources/components/roAssociativeArray.brs
+++ b/test/e2e/resources/components/roAssociativeArray.brs
@@ -25,4 +25,13 @@ sub main()
 
     aa.clear()
     print "can empty itself: " aa.isEmpty()                     ' => true
+
+    ' check mimic of RBI AA keys saving logic
+    aa = {"dd": 0, "DD":1}
+    print "saved key: "aa.keys()[0] ' => DD
+    aa.dd = 2
+    print "saved key after accessing by dot: "aa.keys()[0] ' => dd
+    aa["Dd"] = 3
+    print "saved key after accessing by index: "aa.keys()[0] ' => Dd
+    print "AA keys size: " aa.keys().count() ' => 1
 end sub

--- a/test/e2e/resources/components/roSGNode/roSGNode.brs
+++ b/test/e2e/resources/components/roSGNode/roSGNode.brs
@@ -12,6 +12,7 @@ sub init()
     print "can delete elements: " node1.delete("baz")              ' => true
     print "can look up elements: " node1.lookup("foo") = "foo"     ' => true
     print "can look up elements (brackets): " node1["foo"] = "foo" ' => true
+    print "can case insensitive look up elements: " node1.lookupCI("foO") = "foo" ' => true
     print "can check for existence: " node1.doesExist("bar")       ' => true
 
     node1.clear()


### PR DESCRIPTION
solution $629 issue
what were done:
- fixed `CreateObject("roSGNode", "node")`
- added support for `lookupCI` for AA and Nodes
- added UT and e2e tests

resolves #629  

UPD:
 - Fixed logic of using/saving keys in AA (saving last key used by `[]`, or lowercase key if accessed by `.`)
