### PR TITLE
Issue #416 toString() method not printing string fields with quotes

### DIFF
--- a/src/brsTypes/BrsType.ts
+++ b/src/brsTypes/BrsType.ts
@@ -255,6 +255,7 @@ export class BrsString implements BrsValue, Comparable, Boxable {
     }
 
     toString(parent?: BrsType) {
+        if (parent) return `"${this.value}"`;
         return this.value;
     }
 

--- a/src/brsTypes/components/RoString.ts
+++ b/src/brsTypes/components/RoString.ts
@@ -92,8 +92,8 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
         return this.intrinsic;
     }
 
-    toString(_parent?: BrsType): string {
-        return this.intrinsic.toString();
+    toString(parent?: BrsType): string {
+        return this.intrinsic.toString(parent);
     }
 
     /**

--- a/test/brsTypes/components/ArrayGrid.test.js
+++ b/test/brsTypes/components/ArrayGrid.test.js
@@ -12,21 +12,21 @@ describe("ArrayGrid", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
+    id: ""
     visible: true
     opacity: 1
     translation: <Component: roArray>
     rotation: 0
     scale: <Component: roArray>
     scalerotatecenter: <Component: roArray>
-    childrenderorder: renderLast
+    childrenderorder: "renderLast"
     inheritparenttransform: true
     inheritparentopacity: true
     clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
-    rendertracking: disabled
+    rendertracking: "disabled"
     content: invalid
     itemsize: <Component: roArray>
     itemspacing: <Component: roArray>
@@ -34,17 +34,17 @@ describe("ArrayGrid", () => {
     numcolumns: 0
     focusrow: 0
     focuscolumn: 0
-    horizfocusanimationstyle: floatingFocus
-    vertfocusanimationstyle: floatingFocus
+    horizfocusanimationstyle: "floatingFocus"
+    vertfocusanimationstyle: "floatingFocus"
     drawfocusfeedbackontop: false
     drawfocusfeedback: true
     fadefocusfeedbackwhenautoscrolling: false
     currfocusfeedbackopacity: NaN
-    focusbitmapuri: 
-    focusfootprintbitmapuri: 
-    focusbitmapblendcolor: 0xFFFFFFFF
-    focusfootprintblendcolor: 0xFFFFFFFF
-    wrapdividerbitmapuri: 
+    focusbitmapuri: ""
+    focusfootprintbitmapuri: ""
+    focusbitmapblendcolor: "0xFFFFFFFF"
+    focusfootprintblendcolor: "0xFFFFFFFF"
+    wrapdividerbitmapuri: ""
     wrapdividerwidth: 0
     wrapdividerheight: 36
     fixedlayout: false
@@ -53,9 +53,9 @@ describe("ArrayGrid", () => {
     columnwidths: <Component: roArray>
     rowspacings: <Component: roArray>
     columnspacings: <Component: roArray>
-    sectiondividerbitmapuri: 
+    sectiondividerbitmapuri: ""
     sectiondividerfont: invalid
-    sectiondividertextcolor: 
+    sectiondividertextcolor: ""
     sectiondividerspacing: 0
     sectiondividerwidth: 0
     sectiondividerheight: 0

--- a/test/brsTypes/components/ContentNode.test.js
+++ b/test/brsTypes/components/ContentNode.test.js
@@ -13,7 +13,7 @@ describe("ContentNode.js", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
+    id: ""
 }`
             );
         });
@@ -145,8 +145,8 @@ describe("ContentNode.js", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
-    DESCRIPTION: 
+    id: ""
+    DESCRIPTION: ""
 }`
                 );
             });
@@ -163,8 +163,8 @@ describe("ContentNode.js", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
-    DESCRIPTION: 
+    id: ""
+    DESCRIPTION: ""
 }`
                 );
             });
@@ -185,8 +185,8 @@ describe("ContentNode.js", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
-    DESCRIPTION: new value
+    id: ""
+    DESCRIPTION: "new value"
 }`
                 );
             });
@@ -208,8 +208,8 @@ describe("ContentNode.js", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
-    DESCRIPTION: new value
+    id: ""
+    DESCRIPTION: "new value"
 }`
                 );
             });
@@ -226,8 +226,8 @@ describe("ContentNode.js", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
-    DESCRIPTION: 
+    id: ""
+    DESCRIPTION: ""
 }`
                 );
             });
@@ -244,8 +244,8 @@ describe("ContentNode.js", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
-    DESCRIPTION: 
+    id: ""
+    DESCRIPTION: ""
 }`
                 );
             });

--- a/test/brsTypes/components/Font.test.js
+++ b/test/brsTypes/components/Font.test.js
@@ -12,10 +12,10 @@ describe("Font", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
-    uri: 
+    id: ""
+    uri: ""
     size: 1
-    fallbackglyph: 
+    fallbackglyph: ""
 }`
             );
         });

--- a/test/brsTypes/components/Group.test.js
+++ b/test/brsTypes/components/Group.test.js
@@ -12,21 +12,21 @@ describe("Group", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
+    id: ""
     visible: true
     opacity: 1
     translation: <Component: roArray>
     rotation: 0
     scale: <Component: roArray>
     scalerotatecenter: <Component: roArray>
-    childrenderorder: renderLast
+    childrenderorder: "renderLast"
     inheritparenttransform: true
     inheritparentopacity: true
     clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
-    rendertracking: disabled
+    rendertracking: "disabled"
 }`
             );
         });

--- a/test/brsTypes/components/Label.test.js
+++ b/test/brsTypes/components/Label.test.js
@@ -12,26 +12,26 @@ describe("Label", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
+    id: ""
     visible: true
     opacity: 1
     translation: <Component: roArray>
     rotation: 0
     scale: <Component: roArray>
     scalerotatecenter: <Component: roArray>
-    childrenderorder: renderLast
+    childrenderorder: "renderLast"
     inheritparenttransform: true
     inheritparentopacity: true
     clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
-    rendertracking: disabled
-    text: 
-    color: 0xddddddff
+    rendertracking: "disabled"
+    text: ""
+    color: "0xddddddff"
     font: invalid
-    horizalign: left
-    vertalign: top
+    horizalign: "left"
+    vertalign: "top"
     width: 0
     height: 0
     numlines: 0
@@ -40,9 +40,9 @@ describe("Label", () => {
     linespacing: 0
     displaypartiallines: false
     ellipsizeonboundary: false
-    truncateondelimiter: 
-    wordbreakchars: 
-    ellipsistext: 
+    truncateondelimiter: ""
+    wordbreakchars: ""
+    ellipsistext: ""
     istextellipsized: false
 }`
             );

--- a/test/brsTypes/components/LayoutGroup.test.js
+++ b/test/brsTypes/components/LayoutGroup.test.js
@@ -12,24 +12,24 @@ describe("LayoutGroup", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
+    id: ""
     visible: true
     opacity: 1
     translation: <Component: roArray>
     rotation: 0
     scale: <Component: roArray>
     scalerotatecenter: <Component: roArray>
-    childrenderorder: renderLast
+    childrenderorder: "renderLast"
     inheritparenttransform: true
     inheritparentopacity: true
     clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
-    rendertracking: disabled
-    layoutdirection: vert
-    horizalignment: left
-    vertalignment: top
+    rendertracking: "disabled"
+    layoutdirection: "vert"
+    horizalignment: "left"
+    vertalignment: "top"
     itemspacings: <Component: roArray>
     additemspacingafterchild: true
 }`

--- a/test/brsTypes/components/MarkupGrid.test.js
+++ b/test/brsTypes/components/MarkupGrid.test.js
@@ -12,21 +12,21 @@ describe("MarkupGrid", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
+    id: ""
     visible: true
     opacity: 1
     translation: <Component: roArray>
     rotation: 0
     scale: <Component: roArray>
     scalerotatecenter: <Component: roArray>
-    childrenderorder: renderLast
+    childrenderorder: "renderLast"
     inheritparenttransform: true
     inheritparentopacity: true
     clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
-    rendertracking: disabled
+    rendertracking: "disabled"
     content: invalid
     itemsize: <Component: roArray>
     itemspacing: <Component: roArray>
@@ -34,17 +34,17 @@ describe("MarkupGrid", () => {
     numcolumns: 0
     focusrow: 0
     focuscolumn: 0
-    horizfocusanimationstyle: floatingFocus
-    vertfocusanimationstyle: floatingFocus
+    horizfocusanimationstyle: "floatingFocus"
+    vertfocusanimationstyle: "floatingFocus"
     drawfocusfeedbackontop: false
     drawfocusfeedback: true
     fadefocusfeedbackwhenautoscrolling: false
     currfocusfeedbackopacity: NaN
-    focusbitmapuri: 
-    focusfootprintbitmapuri: 
-    focusbitmapblendcolor: 0xFFFFFFFF
-    focusfootprintblendcolor: 0xFFFFFFFF
-    wrapdividerbitmapuri: 
+    focusbitmapuri: ""
+    focusfootprintbitmapuri: ""
+    focusbitmapblendcolor: "0xFFFFFFFF"
+    focusfootprintblendcolor: "0xFFFFFFFF"
+    wrapdividerbitmapuri: ""
     wrapdividerwidth: 0
     wrapdividerheight: 0
     fixedlayout: false
@@ -53,9 +53,9 @@ describe("MarkupGrid", () => {
     columnwidths: <Component: roArray>
     rowspacings: <Component: roArray>
     columnspacings: <Component: roArray>
-    sectiondividerbitmapuri: 
+    sectiondividerbitmapuri: ""
     sectiondividerfont: invalid
-    sectiondividertextcolor: 0xDDDDDDFF
+    sectiondividertextcolor: "0xDDDDDDFF"
     sectiondividerspacing: 10
     sectiondividerwidth: 0
     sectiondividerheight: 40
@@ -70,8 +70,8 @@ describe("MarkupGrid", () => {
     currfocusrow: 0
     currfocuscolumn: 0
     currfocussection: 0
-    itemcomponentname: 
-    imagewellbitmapuri: 
+    itemcomponentname: ""
+    imagewellbitmapuri: ""
 }`
             );
         });

--- a/test/brsTypes/components/MiniKeyboard.test.js
+++ b/test/brsTypes/components/MiniKeyboard.test.js
@@ -12,26 +12,26 @@ describe("MiniKeyboard", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
+    id: ""
     visible: true
     opacity: 1
     translation: <Component: roArray>
     rotation: 0
     scale: <Component: roArray>
     scalerotatecenter: <Component: roArray>
-    childrenderorder: renderLast
+    childrenderorder: "renderLast"
     inheritparenttransform: true
     inheritparentopacity: true
     clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
-    rendertracking: disabled
-    text: 
-    keycolor: 0x000000FF
-    focusedkeycolor: 0x000000FF
-    keyboardbitmapuri: 
-    focusbitmapuri: 
+    rendertracking: "disabled"
+    text: ""
+    keycolor: "0x000000FF"
+    focusedkeycolor: "0x000000FF"
+    keyboardbitmapuri: ""
+    focusbitmapuri: ""
     texteditbox: <Component: roSGNode:TextEditBox>
     showtexteditbox: true
     lowercase: true

--- a/test/brsTypes/components/Poster.test.js
+++ b/test/brsTypes/components/Poster.test.js
@@ -12,38 +12,38 @@ describe("Poster", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
+    id: ""
     visible: true
     opacity: 1
     translation: <Component: roArray>
     rotation: 0
     scale: <Component: roArray>
     scalerotatecenter: <Component: roArray>
-    childrenderorder: renderLast
+    childrenderorder: "renderLast"
     inheritparenttransform: true
     inheritparentopacity: true
     clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
-    rendertracking: disabled
-    uri: 
+    rendertracking: "disabled"
+    uri: ""
     width: 0
     height: 0
     loadsync: false
     loadwidth: 0
     loadheight: 0
-    loaddisplaymode: noScale
-    loadstatus: noScale
+    loaddisplaymode: "noScale"
+    loadstatus: "noScale"
     bitmapwidth: 0
     bitmapheight: 0
     bitmapmargins: <Component: roAssociativeArray>
-    blendcolor: 0xFFFFFFFF
-    loadingbitmapuri: 
+    blendcolor: "0xFFFFFFFF"
+    loadingbitmapuri: ""
     loadingbitmapopacity: 1
-    failedbitmapuri: 
+    failedbitmapuri: ""
     failedbitmapopacity: 1
-    audioguidetext: 
+    audioguidetext: ""
 }`
             );
         });

--- a/test/brsTypes/components/Rectangle.test.js
+++ b/test/brsTypes/components/Rectangle.test.js
@@ -12,24 +12,24 @@ describe("Rectangle", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
+    id: ""
     visible: true
     opacity: 1
     translation: <Component: roArray>
     rotation: 0
     scale: <Component: roArray>
     scalerotatecenter: <Component: roArray>
-    childrenderorder: renderLast
+    childrenderorder: "renderLast"
     inheritparenttransform: true
     inheritparentopacity: true
     clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
-    rendertracking: disabled
+    rendertracking: "disabled"
     width: 0
     height: 0
-    color: 0xFFFFFFFF
+    color: "0xFFFFFFFF"
     blendingenabled: true
 }`
             );

--- a/test/brsTypes/components/RoArray.test.js
+++ b/test/brsTypes/components/RoArray.test.js
@@ -25,7 +25,7 @@ describe("RoArray", () => {
 [
     <Component: roArray>
     true
-    a string
+    "a string"
     -1
     invalid
 ]`

--- a/test/brsTypes/components/RoAssociativeArray.test.js
+++ b/test/brsTypes/components/RoAssociativeArray.test.js
@@ -40,7 +40,7 @@ describe("RoAssociativeArray", () => {
     associative-array: <Component: roAssociativeArray>
     node: <Component: roSGNode:Node>
     boolean: true
-    string: a string
+    string: "a string"
     number: -1
     invalid: invalid
 }`

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -38,12 +38,12 @@ describe("RoSGNode", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
+    id: ""
     array: <Component: roArray>
     associative-array: <Component: roAssociativeArray>
     node: <Component: roSGNode:Node>
     boolean: true
-    string: a string
+    string: "a string"
     number: -1
 }`
             );

--- a/test/brsTypes/components/Scene.test.js
+++ b/test/brsTypes/components/Scene.test.js
@@ -12,23 +12,23 @@ describe("Scene", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
+    id: ""
     visible: true
     opacity: 1
     translation: <Component: roArray>
     rotation: 0
     scale: <Component: roArray>
     scalerotatecenter: <Component: roArray>
-    childrenderorder: renderLast
+    childrenderorder: "renderLast"
     inheritparenttransform: true
     inheritparentopacity: true
     clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
-    rendertracking: disabled
-    backgrounduri: 
-    backgroundcolor: 0x000000FF
+    rendertracking: "disabled"
+    backgrounduri: ""
+    backgroundcolor: "0x000000FF"
     backexitsscene: true
     dialog: invalid
     currentdesignresolution: <Component: roAssociativeArray>

--- a/test/brsTypes/components/TextEditBox.test.js
+++ b/test/brsTypes/components/TextEditBox.test.js
@@ -12,31 +12,31 @@ describe("TextEditBox", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
+    id: ""
     visible: true
     opacity: 1
     translation: <Component: roArray>
     rotation: 0
     scale: <Component: roArray>
     scalerotatecenter: <Component: roArray>
-    childrenderorder: renderLast
+    childrenderorder: "renderLast"
     inheritparenttransform: true
     inheritparentopacity: true
     clippingrect: <Component: roArray>
     renderpass: 0
     muteaudioguide: false
     enablerendertracking: false
-    rendertracking: disabled
-    text: 
-    hinttext: 
+    rendertracking: "disabled"
+    text: ""
+    hinttext: ""
     maxtextlength: 15
     cursorposition: 0
     clearondownkey: true
     active: false
-    textcolor: OxFFFFFFFF
-    hinttextcolor: OxFFFFFFFF
+    textcolor: "OxFFFFFFFF"
+    hinttextcolor: "OxFFFFFFFF"
     width: -1
-    backgrounduri: 
+    backgrounduri: ""
 }`
             );
         });

--- a/test/brsTypes/components/Timer.test.js
+++ b/test/brsTypes/components/Timer.test.js
@@ -12,8 +12,8 @@ describe("Timer", () => {
     change: <Component: roAssociativeArray>
     focusable: false
     focusedchild: invalid
-    id: 
-    control: 
+    id: ""
+    control: ""
     repeat: false
     duration: 0
     fire: <UNINITIALIZED>

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -206,8 +206,8 @@ describe("end to end brightscript functions", () => {
                 "getAttributes() = ",
                 `<Component: roAssociativeArray> =\n` +
                     `{\n` +
-                    `    id: someId\n` +
-                    `    attr1: 0\n` +
+                    `    id: "someId"\n` +
+                    `    attr1: "0"\n` +
                     `}`,
                 'getNamedElementsCi("child1") count = ',
                 "2",

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -30,7 +30,7 @@ describe("end to end standard libary", () => {
             "false",
             "true",
             "false",
-            "<Component: roArray> =\n[\n    test_backup.txt\n]",
+            '<Component: roArray> =\n[\n    "test_backup.txt"\n]',
             "true",
         ]);
     });
@@ -102,7 +102,7 @@ describe("end to end standard libary", () => {
                 "    integer: 2147483647",
                 "    longinteger: 2147483650",
                 "    null: invalid",
-                "    string: ok",
+                '    string: "ok"',
                 "}",
             ].join("\n"),
         ]);


### PR DESCRIPTION
Fixes #416

It's my first PR here -- please be gentle with me. 😅

OK, so Roku doesn't add quotes to a string only in 1 case: if we're printing a simple string variable:

```
stringVar = "Test string"
? "String variable:"
? stringVar
```

Output:
```
String variable:
Test string
```

I all other cases, Roku adds quotes. Whether it's an array, AA, list, or field of a node:

```
arrayWithString = ["Test string"]
? "Array with string:"
? arrayWithString
?

assocArrayWithString = {
    entry: "Test string"
}
? "AA with string:"
? assocArrayWithString
?

listWithString = CreateObject("roList")
listWithString.addTail("Test string")
? "List with string:"
? listWithString
? "type("Chr(34)"Test string"Chr(34)"): "type("Test string")
? "type(listWithString[0]) (!): "type(listWithString[0])
?

nodeWithString = CreateObject("roSGNode", "Node")
nodeWithString.addFields({ stringField: "Test string" })
? "Node with string:"
? nodeWithString
```

Output:
```
Array with string:
<Component: roArray> =
[
    "Test string"
]

AA with string:
<Component: roAssociativeArray> =
{
    entry: "Test string"
}

List with string:
<Component: roList> =
(
    "Test string"
)
type("Test string"): String
type(listWithString[0]) (!): roString

Node with string:
<Component: roSGNode:Node> =
{
    change: <Component: roAssociativeArray>
    focusable: false
    focusedChild: <Component: roInvalid>
    id: ""
    stringfield: "Test string"
}
```

What this PR changes:
1. Tests have been updated with the fixed output of the strings.
2. `BrsString` `toString(...)` function output now depends on parent existence. `toString(...)` gets parent only in case this string has any kind of container (array, AA, node etc.). This perfectly correspond to Roku's behavior.

I've also made `roString` pass `parent` to its internal `BrsString`. `List` boxes strings into `roString`s, so this is needed for proper string print.