### PR TITLE
fix(nightly): fetch two commits to detect commits-since-last-build

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -10,12 +10,17 @@
     publish: {
       runs-on: "ubuntu-latest",
       steps: [
-        { uses: "actions/checkout@v2" },
+        {
+          uses: "actions/checkout@v2",
+          with: {
+            fetch-depth: 2
+          }
+        },
         {
           id: "commits_since_last_nightly",
           name: "Check for commits since last night's build",
           run: "test -n \"$(git log --oneline --since '25 hours ago')\"",
-          "continue-on-error": true
+          continue-on-error: true
         },
         {
           name: "Set up node 12",

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -2,8 +2,8 @@
   name: "Nightly build",
   on: {
     schedule: [
-      # build at ~00:05 UTC daily (startup delays may affect that)
-      { cron: "05 07 * * *" }
+      # build at ~00:05 PT daily (startup delays may affect that)
+      { cron: "05 17 * * *" }
     ]
   },
   jobs: {
@@ -36,11 +36,8 @@
           if: "${{ job.commits_since_last_nightly.outcome == 'success' }}"
         },
         {
-          run: "yarn publish --no-git-tag-version --new-version `node scripts/getNightlyVersion.js` --tag nightly",
+          run: "yarn prepublishOnly",
           if: "${{ job.commits_since_last_nightly.outcome == 'success' }}",
-          env: {
-            NODE_AUTH_TOKEN: "${{ secrets.NPM_PUBLISH_TOKEN }}"
-          }
         },
       ]
     }


### PR DESCRIPTION
The default behavior for GitHub's `actions/checkout@v2` only fetches the
latest commit [1], so our previous attempts to detect commits "since
last night's nightly build" always failed.  Fetch two commits to make it
possible to detect commits in `main` within the past 25 hours.

[1] https://github.com/actions/checkout/tree/25a956c84d5dd820d28caab9f86b8d183aeeff3d#checkout-v2