### PR TITLE
fix(rsg): Reparent does not add child to new parent

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -1472,7 +1472,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                 if (this.parent instanceof RoSGNode) {
                     this.parent.removeChildByReference(this);
                 }
-                this.setParent(newParent);
+                newParent.appendChildToParent(this);
                 return BrsBoolean.True;
             }
             return BrsBoolean.False;

--- a/test/e2e/RoSGNode.test.js
+++ b/test/e2e/RoSGNode.test.js
@@ -174,6 +174,8 @@ describe("components/roSGNode", () => {
             "4",
             "new parent id: ",
             "new node",
+            "new child count after reparent: ",
+            "1",
             //ifNodeDict tests
             "find node that does not exist: ",
             "invalid",

--- a/test/e2e/resources/components/roSGNode/roSGNode.brs
+++ b/test/e2e/resources/components/roSGNode/roSGNode.brs
@@ -100,7 +100,7 @@ sub init()
     print "parent child count: " parentNode.getChildCount()         ' => 4
     childNode3.reparent(childNode4, false)
     print "new parent id: " childNode3.getParent().id         ' => new node
-
+    print "new child count after reparent: " childNode4.getChildCount()    ' => 1
     'ifNodeDict tests
     ' no node exists
     currentNode = createObject("roSGNode", "Node")


### PR DESCRIPTION
Fixes https://github.com/sjbarag/brs/issues/644

Fixed by calling `appendChildToParent` instead of `setParent` from `reparent`'s implementation.