### PR TITLE
feat(extensions): Add _brs_.testData associative array

### DIFF
--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -30,3 +30,7 @@ export const _brs_ = new RoAssociativeArray([
     { name: new BrsString("triggerKeyEvent"), value: triggerKeyEvent },
     { name: new BrsString("getStackTrace"), value: GetStackTrace },
 ]);
+
+export function _resetTestData() {
+    _brs_.set(new BrsString("testData"), new RoAssociativeArray([]));
+}

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -26,6 +26,7 @@ export const _brs_ = new RoAssociativeArray([
     { name: new BrsString("runInScope"), value: RunInScope },
     { name: new BrsString("process"), value: Process },
     { name: new BrsString("global"), value: mGlobal },
+    { name: new BrsString("testData"), value: new RoAssociativeArray([]) },
     { name: new BrsString("triggerKeyEvent"), value: triggerKeyEvent },
     { name: new BrsString("getStackTrace"), value: GetStackTrace },
 ]);

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -31,6 +31,7 @@ export const _brs_ = new RoAssociativeArray([
     { name: new BrsString("getStackTrace"), value: GetStackTrace },
 ]);
 
-export function _resetTestData() {
+/** resets _brs_.testData values to `{}` in brightscript representation */
+export function resetTestData() {
     _brs_.set(new BrsString("testData"), new RoAssociativeArray([]));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
 } from "./componentprocessor";
 import { Parser } from "./parser";
 import { Interpreter, ExecutionOptions, defaultExecutionOptions } from "./interpreter";
-import { _resetTestData } from "./extensions";
+export { resetTestData } from "./extensions";
 import * as BrsError from "./Error";
 import * as LexerParser from "./LexerParser";
 import { CoverageCollector } from "./coverage";
@@ -326,9 +326,4 @@ function run(
         //options.stderr.write(e.message);
         return;
     }
-}
-
-/** resets _brs_.testData values to `{}` */
-export function resetTestData() {
-    _resetTestData();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
 } from "./componentprocessor";
 import { Parser } from "./parser";
 import { Interpreter, ExecutionOptions, defaultExecutionOptions } from "./interpreter";
-export { resetTestData } from "./extensions";
+import { resetTestData } from "./extensions";
 import * as BrsError from "./Error";
 import * as LexerParser from "./LexerParser";
 import { CoverageCollector } from "./coverage";
@@ -231,6 +231,7 @@ export async function createExecuteWithScope(
     interpreter.errors = [];
 
     return (filenames: string[], args: BrsTypes.BrsType[]) => {
+        resetTestData();
         let ast = lexParseSync(filenames, interpreter.options);
         let execErrors: BrsError.BrsError[] = [];
         let returnValue = interpreter.inSubEnv((subInterpreter) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
 } from "./componentprocessor";
 import { Parser } from "./parser";
 import { Interpreter, ExecutionOptions, defaultExecutionOptions } from "./interpreter";
+import { _resetTestData } from "./extensions";
 import * as BrsError from "./Error";
 import * as LexerParser from "./LexerParser";
 import { CoverageCollector } from "./coverage";
@@ -325,4 +326,9 @@ function run(
         //options.stderr.write(e.message);
         return;
     }
+}
+
+/** resets _brs_.testData values to `{}` */
+export function resetTestData() {
+    _resetTestData();
 }

--- a/test/extensions/testData.test.js
+++ b/test/extensions/testData.test.js
@@ -2,6 +2,7 @@ const brs = require("brs");
 const { BrsString, BrsInvalid, ValueKind } = brs.types;
 const { Interpreter } = require("../../lib/interpreter");
 const { identifier } = require("../parser/ParserTests");
+const { resetTestData } = require("../../lib/extensions");
 
 describe("_brs_.testData", () => {
     it("check testData object", () => {
@@ -19,7 +20,7 @@ describe("_brs_.testData", () => {
             .get(new BrsString("testData"));
         expect(testData.elements.size).toBe(1);
 
-        brs.resetTestData(); // will clear testData for next new Interpreter instances
+        resetTestData(); // will clear testData for next new Interpreter instances
 
         testData = new Interpreter().environment
             .get(identifier("_brs_"))

--- a/test/extensions/testData.test.js
+++ b/test/extensions/testData.test.js
@@ -1,0 +1,29 @@
+const brs = require("brs");
+const { BrsString, BrsInvalid, ValueKind } = brs.types;
+const { Interpreter } = require("../../lib/interpreter");
+const { identifier } = require("../parser/ParserTests");
+
+describe("_brs_.testData", () => {
+    it("check testData object", () => {
+        let _brs_ = new Interpreter().environment.get(identifier("_brs_"));
+        let testData = _brs_.get(new BrsString("testData"));
+
+        expect(testData.kind).toBe(ValueKind.Object);
+        expect(testData.componentName).toBe("roAssociativeArray");
+        expect(testData.elements.size).toBe(0);
+        testData.set(new BrsString("foo"), BrsInvalid.Instance);
+        expect(testData.elements.size).toBe(1);
+
+        testData = new Interpreter().environment
+            .get(identifier("_brs_"))
+            .get(new BrsString("testData"));
+        expect(testData.elements.size).toBe(1);
+
+        brs.resetTestData(); // will clear testData for next new Interpreter instances
+
+        testData = new Interpreter().environment
+            .get(identifier("_brs_"))
+            .get(new BrsString("testData"));
+        expect(testData.elements.size).toBe(0);
+    });
+});


### PR DESCRIPTION
fix for issue #623 
added `testData` to `_brs_` object
exported new method `resetTestData` for cleaning `testData` before runing test suites(test files)
linked roca PR: https://github.com/hulu/roca/pull/88