### PR TITLE
fix(interpreter): Support case insensitive names for functions in components

### DIFF
--- a/src/parser/ComponentScopeResolver.ts
+++ b/src/parser/ComponentScopeResolver.ts
@@ -45,7 +45,7 @@ export class ComponentScopeResolver {
         let statementMemo = new Set(
             statements
                 .filter((_): _ is Stmt.Function => true)
-                .map((statement) => statement.name.text)
+                .map((statement) => statement.name.text.toLowerCase())
         );
         while (statementMap.length > 0) {
             let extendedFns = statementMap.shift() || [];
@@ -53,7 +53,7 @@ export class ComponentScopeResolver {
                 extendedFns
                     .filter((_): _ is Stmt.Function => true)
                     .filter((statement) => {
-                        let statementName = statement.name.text;
+                        let statementName = statement.name.text.toLowerCase();
                         let haveFnName = statementMemo.has(statementName);
                         if (!haveFnName) {
                             statementMemo.add(statementName);

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -258,6 +258,7 @@ describe("end to end brightscript functions", () => {
             "ExtendedChild init",
             "ExtendedComponent init",
             "ExtendedComponent start",
+            "BaseComponent caseinsensitivefunction",
             "true", //m.top.isSubtype("ExtendedComponent")
             "true", //m.top.isSubtype("BaseComponent")
             "true", //m.top.isSubtype("Node")

--- a/test/e2e/Functions.test.js
+++ b/test/e2e/Functions.test.js
@@ -122,4 +122,12 @@ describe("end to end functions", () => {
             "false",
         ]);
     });
+
+    test("function/casing.brs", async () => {
+        await execute([resourceFile("function", "casing.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
+            "but I'm only interested in...",
+        ]);
+    });
 });

--- a/test/e2e/resources/components/scripts/BaseComponent.brs
+++ b/test/e2e/resources/components/scripts/BaseComponent.brs
@@ -1,8 +1,12 @@
-sub init()
+sub Init()
     print "BaseComponent init"
     start()
 end sub
 
 sub start()
     print "BaseComponent start"
+end sub
+
+sub CaseInsensitiveFunction()
+    print "BaseComponent caseinsensitivefunction"
 end sub

--- a/test/e2e/resources/components/scripts/ExtendedComponent.brs
+++ b/test/e2e/resources/components/scripts/ExtendedComponent.brs
@@ -1,6 +1,7 @@
 sub init()
     print "ExtendedComponent init"
     start()
+    caseinsensitivefunction()
 
     print m.top.isSubtype("ExtendedComponent")
     print m.top.isSubtype("BaseComponent")

--- a/test/e2e/resources/components/scripts/SupportScript.brs
+++ b/test/e2e/resources/components/scripts/SupportScript.brs
@@ -1,3 +1,3 @@
-sub start()
+sub sTarT()
     print "ExtendedComponent start"
 end sub

--- a/test/e2e/resources/function/casing.brs
+++ b/test/e2e/resources/function/casing.brs
@@ -1,0 +1,6 @@
+function callMeInsensitive()
+    print "but I'm only interested in..."
+end function
+
+callmeinsensitive()
+


### PR DESCRIPTION
In RBI functions with the same name are always overriden (despite the casing) if extending components with the only exception of the `Init` method which is a special case. With this fix, it doesn't matter what convention you use to name your function as it's going to be converted to lowerCase to fix the override issue we were having.
In addition to the fix, I added a test case to functions to verify that casing doesn't matter when naming functions.

Fixes #502