### PR TITLE
fix(extensions): reset mocks between executions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,10 @@ export async function createExecuteWithScope(
     interpreter.errors = [];
 
     return (filenames: string[], args: BrsTypes.BrsType[]) => {
+        // Reset any mocks so that subsequent executions don't interfere with each other.
+        interpreter.environment.resetMocks();
         resetTestData();
+
         let ast = lexParseSync(filenames, interpreter.options);
         let execErrors: BrsError.BrsError[] = [];
         let returnValue = interpreter.inSubEnv((subInterpreter) => {

--- a/test/e2e/createExecuteWithScope.test.js
+++ b/test/e2e/createExecuteWithScope.test.js
@@ -73,4 +73,22 @@ describe("createExecuteWithScope", () => {
             "main:onlyInScopeForMain",
         ]);
     });
+
+    test("mocks defined in earlier execution calls do not exist in subsequent executions", async () => {
+        let execute = await createExecuteWithScope([resourceFile("in-scope.brs")], outputStreams);
+
+        // mock.brs mocks the function
+        execute([resourceFile("mock.brs")], []);
+
+        // main calls the function
+        execute([resourceFile("main.brs")], [new BrsString("argz4main")]);
+
+        // the output from both files should be there
+        expect(allArgs(outputStreams.stdout.write).filter((arg) => arg !== "\n")).toEqual([
+            "mock:mocked",
+            "main:arg:argz4main",
+            "main:commonUtil",
+            "main:onlyInScopeForMain",
+        ]);
+    });
 });

--- a/test/e2e/resources/execute-with-scope/mock.brs
+++ b/test/e2e/resources/execute-with-scope/mock.brs
@@ -1,0 +1,7 @@
+sub main()
+    _brs_.mockFunction("commonUtil", function()
+        return "mocked"
+    end function)
+
+    print "mock:" + commonUtil() ' => "mocked"
+end sub


### PR DESCRIPTION
# Change summary

This resets mocks between executions that share the same base scope, to prevent them from polluting/interfering with each other. Got the idea from the implementation in #646!

Related: https://github.com/hulu/roca/issues/89