### PR TITLE
fix(interp): allow functions to be typed as objects

### DIFF
--- a/src/brsTypes/coercion.ts
+++ b/src/brsTypes/coercion.ts
@@ -25,6 +25,9 @@ export function tryCoerce(value: BrsType, target: ValueKind): BrsType | undefine
         } else if (value instanceof BrsComponent) {
             // types that are always objects should be returned unmodified
             return value;
+        } else if (value.kind === ValueKind.Callable) {
+            // functions can be given the object type
+            return value;
         }
     }
 

--- a/test/brsTypes/coercion.test.js
+++ b/test/brsTypes/coercion.test.js
@@ -1,4 +1,5 @@
 const { types } = require("../../lib");
+const { Callable } = require("../../lib/brsTypes/Callable");
 const {
     tryCoerce,
     ValueKind,
@@ -49,6 +50,7 @@ describe("type coercion", () => {
             ["string", new BrsString("lorem"), ValueKind.String],
             ["boolean", BrsBoolean.False, ValueKind.Boolean],
             ["invalid", BrsInvalid.Instance, ValueKind.Invalid],
+            ["function", new Callable("foo"), ValueKind.Object],
         ])("returns input for %s target when no coercion needed", (_type, input, target) => {
             expect(input).toBeDefined();
             expect(tryCoerce(input, target)).toBe(input);


### PR DESCRIPTION
# Changes

This fixes a bug where if you tried to do:
```brs
sub foo(arg as object) : end sub
sub bar() : end sub

foo(bar) ' runtime error
```
`brs` would throw an ugly error. RBI allows this type-casting, so we should too!

This error was actually getting thrown a bunch in the sister project, https://github.com/hulu/roca, since `brs@0.44.0`, because all the `describe` and `it` functions use the `as object` type for functions.