### PR TITLE
fix(stdlib): make RoSGNode#update case insensitive

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -1104,7 +1104,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
             aa.getValue().forEach((value, key) => {
                 let fieldName = new BrsString(key);
-                if (this.fields.has(key) || createFields.toBoolean()) {
+                if (this.fields.has(key.toLowerCase()) || createFields.toBoolean()) {
                     this.set(fieldName, value);
                 }
             });


### PR DESCRIPTION
# Change summary

In #629 there were a bunch of changes to `RoAssociativeArray` for case-sensitivity, namely preserving key case by default. Because `RoSGNode#update` uses an assoc array and `RoSGNode` stores all its fields lower case, we need to make it _not_ case-sensitive.