### PR TITLE
chore(ci): Build and test in node 16 instead of node 10

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,7 +13,7 @@
       runs-on: "ubuntu-latest",
       strategy: {
         matrix: {
-          node_version: [ 10, 12, 14 ]
+          node_version: [ 12, 14, 16 ]
         }
       },
       steps: [


### PR DESCRIPTION
Node 10.x has been end-of-life since April 30, 2021, and node 16.x will be an active LTS release on October 26, 2021.  Build and test in node 16 instead of node 10 for CI flows.