### PR TITLE
Implement clone

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -296,7 +296,7 @@ function isSubtypeCheck(currentNodeType: string, checkType: string): boolean {
 export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     readonly kind = ValueKind.Object;
     private fields = new Map<string, Field>();
-    public children: RoSGNode[] = [];
+    private children: RoSGNode[] = [];
     private parent: RoSGNode | BrsInvalid = BrsInvalid.Instance;
 
     readonly defaultFields: FieldModel[] = [
@@ -1959,14 +1959,17 @@ function cloneNode(
         // A deep clone also copies children.
         if (isDeepCopy) {
             let appendChild = copy.getMethod("appendchild");
+            let getChildren = toBeCloned.getMethod("getchildren");
 
-            if (appendChild) {
-                let children = toBeCloned.children;
+            if (getChildren && appendChild) {
+                let children = getChildren.call(interpreter, new Int32(-1), new Int32(0));
 
-                for (let child of children) {
-                    if (child instanceof RoSGNode) {
-                        let childCopy = cloneNode(interpreter, child, isDeepCopy);
-                        appendChild.call(interpreter, childCopy);
+                if (children instanceof RoArray) {
+                    for (let child of children.getElements()) {
+                        if (child instanceof RoSGNode) {
+                            let childCopy = cloneNode(interpreter, child, isDeepCopy);
+                            appendChild.call(interpreter, childCopy);
+                        }
                     }
                 }
             }

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -1696,6 +1696,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
     });
 
+    /* Returns a copy of the entire node tree or just a shallow copy. */
     private clone = new Callable("clone", {
         signature: {
             args: [new StdlibArgument("isDeepCopy", ValueKind.Boolean)],

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -1323,7 +1323,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                 let childNodesElements = child_nodes.getElements();
                 if (childNodesElements.length !== 0) {
                     childNodesElements.forEach((childNode) => {
-                        {
+                        if (childNode instanceof RoSGNode) {
                             // Remove if it exists to reappend
                             this.removeChildByReference(childNode);
                             this.appendChildToParent(childNode);

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -1323,7 +1323,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                 let childNodesElements = child_nodes.getElements();
                 if (childNodesElements.length !== 0) {
                     childNodesElements.forEach((childNode) => {
-                        if (childNode instanceof RoSGNode) {
+                        {
                             // Remove if it exists to reappend
                             this.removeChildByReference(childNode);
                             this.appendChildToParent(childNode);
@@ -1933,22 +1933,22 @@ function cloneNode(
 ): RoSGNode | BrsInvalid {
     let copy = createNodeByType(interpreter, new BrsString(toBeCloned.nodeSubtype));
 
-    let originalFields = toBeCloned.getFields();
-    let copiedFields = new RoAssociativeArray([]);
-    let addReplace = copiedFields.getMethod("addreplace");
+    if (copy instanceof RoSGNode) {
+        let originalFields = toBeCloned.getFields();
+        let copiedFields = new RoAssociativeArray([]);
+        let addReplace = copiedFields.getMethod("addreplace");
 
-    // Copy the fields.
-    for (let [key, value] of originalFields) {
-        if (addReplace) {
-            addReplace.call(
-                interpreter,
-                new BrsString(key),
-                getBrsValueFromFieldType(value.getType(), value.toString())
-            );
+        // Copy the fields.
+        for (let [key, value] of originalFields) {
+            if (addReplace) {
+                addReplace.call(
+                    interpreter,
+                    new BrsString(key),
+                    getBrsValueFromFieldType(value.getType(), value.toString())
+                );
+            }
         }
-    }
 
-    if (!(copy instanceof BrsInvalid)) {
         let update = copy.getMethod("update");
 
         if (update) {

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -296,7 +296,7 @@ function isSubtypeCheck(currentNodeType: string, checkType: string): boolean {
 export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     readonly kind = ValueKind.Object;
     private fields = new Map<string, Field>();
-    private children: RoSGNode[] = [];
+    public children: RoSGNode[] = [];
     private parent: RoSGNode | BrsInvalid = BrsInvalid.Instance;
 
     readonly defaultFields: FieldModel[] = [
@@ -1958,17 +1958,14 @@ function cloneNode(
         // A deep clone also copies children.
         if (isDeepCopy) {
             let appendChild = copy.getMethod("appendchild");
-            let getChildren = toBeCloned.getMethod("getchildren");
 
-            if (getChildren && appendChild) {
-                let children = getChildren.call(interpreter, new Int32(-1), new Int32(0));
+            if (appendChild) {
+                let children = toBeCloned.children;
 
-                if (children instanceof RoArray) {
-                    for (let child of children.getElements()) {
-                        if (child instanceof RoSGNode) {
-                            let childCopy = cloneNode(interpreter, child, isDeepCopy);
-                            appendChild.call(interpreter, childCopy);
-                        }
+                for (let child of children) {
+                    if (child instanceof RoSGNode) {
+                        let childCopy = cloneNode(interpreter, child, isDeepCopy);
+                        appendChild.call(interpreter, childCopy);
                     }
                 }
             }

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -1703,15 +1703,6 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
         impl: (interpreter: Interpreter, isDeepCopy: BrsBoolean) => {
             return cloneNode(interpreter, this, isDeepCopy.toBoolean());
-            // let cloneHelper = this.getMethod("clonehelper");
-
-            // if (cloneHelper) {
-            //     let copy = cloneHelper.call(interpreter, this, isDeepCopy);
-
-            //     return copy;
-            // }
-
-            // return BrsInvalid.Instance;
         },
     });
 

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -1929,7 +1929,6 @@ function addChildren(
                 let setField = newChild.getMethod("setfield");
                 if (setField) {
                     let nodeFields = newChild.getFields();
-
                     for (let [key, value] of Object.entries(child.fields)) {
                         let field = nodeFields.get(key.toLowerCase());
                         if (field) {

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -2528,19 +2528,22 @@ describe("RoSGNode", () => {
                     ]);
 
                     child1 = new RoSGNode([
-                        { name: new BrsString("child"), value: new BrsString("1") },
+                        { name: new BrsString("child1name"), value: new BrsString("1") },
                     ]);
                     child2 = new RoSGNode([
-                        { name: new BrsString("child"), value: new BrsString("2") },
+                        { name: new BrsString("child2name"), value: new Int32(2) },
                     ]);
                     child3 = new RoSGNode([
-                        { name: new BrsString("child"), value: new BrsString("3") },
+                        { name: new BrsString("child3name"), value: BrsBoolean.False },
                     ]);
                     grandchild1 = new RoSGNode([
-                        { name: new BrsString("grandChild"), value: new BrsString("4") },
+                        { name: new BrsString("grandchild1name"), value: new Int32(1.2) },
                     ]);
                     grandchild2 = new RoSGNode([
-                        { name: new BrsString("grandChild"), value: new BrsString("5") },
+                        {
+                            name: new BrsString("grandchild2name"),
+                            value: new BrsString("second grandchild"),
+                        },
                     ]);
 
                     let appendGrandchildren = child1.getMethod("appendchildren");
@@ -2583,7 +2586,7 @@ describe("RoSGNode", () => {
                     expect(childCount).toEqual(new Int32(0));
                 });
 
-                xit("deep copy copies children and grandchildren", () => {
+                it("deep copy copies children and grandchildren", () => {
                     let cloneMethod = originalNode.getMethod("clone");
                     let copyNode = cloneMethod.call(interpreter, new BrsBoolean(true));
 
@@ -2593,12 +2596,25 @@ describe("RoSGNode", () => {
                     expect(childCount).toEqual(new Int32(3));
 
                     getChild = copyNode.getMethod("getchild");
-                    let child1copy = getChild.call(interpreter, new Int32(1));
+                    let child1copy = getChild.call(interpreter, new Int32(0));
+
+                    expect(child1copy.get(new BrsString("child1name"))).toEqual(new BrsString("1"));
 
                     let getGrandchildCount = child1copy.getMethod("getchildcount");
                     let grandchildCount = getGrandchildCount.call(interpreter);
 
                     expect(grandchildCount).toEqual(new Int32(2));
+
+                    getChild = child1copy.getMethod("getchild");
+                    let grandchild1copy = getChild.call(interpreter, new Int32(0));
+                    let grandchild2copy = getChild.call(interpreter, new Int32(1));
+
+                    expect(grandchild1copy.get(new BrsString("grandchild1name"))).toEqual(
+                        new Int32(1.2)
+                    );
+                    expect(grandchild2copy.get(new BrsString("grandchild2name"))).toEqual(
+                        new BrsString("second grandchild")
+                    );
                 });
             });
         });

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -929,7 +929,6 @@ describe("RoSGNode", () => {
                 ]);
 
                 let addFields = node.getMethod("addfields");
-
                 let update = node.getMethod("update");
                 let getField = node.getMethod("getfield");
                 expect(update).toBeTruthy();
@@ -2502,6 +2501,7 @@ describe("RoSGNode", () => {
                 it("returns the parent subtype", () => {
                     let markupNode = new MarkupGrid();
                     let parentsubtype = markupNode.getMethod("parentsubtype");
+
                     let result = parentsubtype.call(interpreter, new BrsString("MarkUpGrid"));
                     expect(result.value).toBe("ArrayGrid");
                 });

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -2586,7 +2586,7 @@ describe("RoSGNode", () => {
                     expect(childCount).toEqual(new Int32(0));
                 });
 
-                it("deep copy copies children and grandchildren", () => {
+                it("deep clone copies children and grandchildren", () => {
                     let cloneMethod = originalNode.getMethod("clone");
                     let copyNode = cloneMethod.call(interpreter, new BrsBoolean(true));
 

--- a/test/e2e/RoSGNode.test.js
+++ b/test/e2e/RoSGNode.test.js
@@ -209,6 +209,8 @@ describe("components/roSGNode", () => {
             "invalid",
             "33",
             "37",
+            "updatedId",
+            "newValue",
             "0",
             "0",
             "0",

--- a/test/e2e/resources/components/roSGNode/roSGNode.brs
+++ b/test/e2e/resources/components/roSGNode/roSGNode.brs
@@ -214,6 +214,16 @@ sub init()
     node.ClipStart = 37
     ?node.ClipStart
 
+    ' it clones nodes
+     node = createObject("roSGNode", "ContentNode")
+     node.update({
+        id: "updatedId",
+        newField: "newValue"
+    }, true)
+    clonedNode = node.clone(true)
+    print clonedNode.id
+    print clonedNode.newField
+
     ' ifSGNodeBoundingRect
     rect = node.boundingRect()
     print rect.x          ' => 0


### PR DESCRIPTION
Implemented [`.clone(isDeepCopy as Boolean)`](https://developer.roku.com/en-gb/docs/references/brightscript/interfaces/ifsgnodedict.md) for ifSGNodeDict interface. Both shallow and deep clones copy Fields but only the deep clone copies Children.

Added associated unit and e2e tests. 